### PR TITLE
Document AI-native workflow and broaden contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,182 @@
 # Contributing to Skillware
 
-Welcome to the Skillware project. We are building the definitive "App Store" for Agentic Capabilities.
+Welcome to Skillware. We are building an open registry of modular, deterministic agent capabilities—skills that any compatible runtime can load. Most contributors add or improve **skills**, but documentation, framework fixes, tests, and good first issues are equally welcome.
+
+This document is the single entry point for how to contribute. For a step-by-step workflow when using AI coding assistants, see **[AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md)**.
 
 ---
 
-## The Skill Package Standard
+## Navigation
 
-Every new skill must reside in its own directory under `skills/<category>/<skill_name>/`. It **must** contain the following files:
+| Section | Description |
+| :--- | :--- |
+| [Ways to contribute](#ways-to-contribute) | Choose your contribution type |
+| [Getting started](#getting-started) | Fork, branch, install, open issues |
+| [Universal expectations](#universal-expectations) | Standards that apply to every PR |
+| [Pull request process](#pull-request-process) | From issue to merge |
+| [Skill Package Standard](#skill-package-standard) | Required layout for registry skills |
+| [Skill categories](#skill-categories) | Folder taxonomy under `skills/` |
+| [What to avoid](#what-to-avoid) | Anti-patterns |
+| [Safety and security](#safety-and-security) | High-risk skills |
+| [Related documents](#related-documents) | Code of conduct, testing, templates |
 
-### 1. `manifest.yaml` (The Metadata)
-Defines the interface and constitution.
-*   **Must** have `name`, `version`, `description`.
-*   **Must** include an `issuer` block identifying who created or maintains the skill (`name` and `email` are required; `github` and `org` are optional but encouraged).
-*   **Must** have a valid JSON Schema in `parameters`.
-*   **Must** include a `constitution` section defining safety boundaries.
-*   **Must** include a `requirements` list if external packages are needed (e.g. `requests`, `pandas`).
+---
+
+## Ways to contribute
+
+Pick the path that matches your issue. Only the **skill** row requires the full bundle under [Skill Package Standard](#skill-package-standard).
+
+| Type | What you change | Typical issue label | Before coding | Verify locally |
+| :--- | :--- | :--- | :--- | :--- |
+| **New or updated skill** | `skills/<category>/<name>/`, `docs/skills/`, templates | Skill proposal, enhancement | Skill proposal or approved issue | `pytest` for skill + `tests/test_skill_issuer.py` |
+| **Documentation** | `docs/`, `README.md`, `CONTRIBUTING.md` | Documentation, good first issue | Doc issue or typo/fix issue | Links valid; tone consistent |
+| **Core framework** | `skillware/core/`, `tests/` | Framework feature | Framework feature issue | `pytest tests/`; update usage docs if API changes |
+| **Bug fix** | Paths named in issue | Bug report | Reproduction or failing test | Targeted test + full `pytest tests/` when touching shared code |
+| **Good first issue** | Usually docs, tests, or small fixes | Good first issue | Read acceptance criteria literally | Checklist for underlying type above |
+| **RFC / large change** | Architecture, manifest contract, loader | RFC | Maintainer discussion on issue | Per RFC scope |
+
+**Skills remain the primary contribution we expect**, but every type above should follow [Getting started](#getting-started), [Universal expectations](#universal-expectations), and [Pull request process](#pull-request-process).
+
+---
+
+## Getting started
+
+### 1. Find or open an issue
+
+Check [existing issues](https://github.com/ARPAHLS/skillware/issues) before starting work.
+
+| Intent | Issue template |
+| :--- | :--- |
+| New capability in the registry | [Skill proposal](https://github.com/ARPAHLS/skillware/issues/new/choose) |
+| Loader, adapters, `base_skill` | [Framework feature](https://github.com/ARPAHLS/skillware/issues/new/choose) |
+| Incorrect behavior | [Bug report](https://github.com/ARPAHLS/skillware/issues/new/choose) |
+| Large or breaking design | [RFC](https://github.com/ARPAHLS/skillware/issues/new/choose) |
+
+Wait for maintainer feedback on non-trivial work before investing in a large PR.
+
+### 2. Fork and clone
+
+Fork [ARPAHLS/skillware](https://github.com/ARPAHLS/skillware) to your GitHub account, then clone your fork:
+
+```bash
+git clone https://github.com/<your-username>/skillware.git
+cd skillware
+git remote add upstream https://github.com/ARPAHLS/skillware.git
+```
+
+### 3. Sync and branch
+
+```bash
+git fetch upstream
+git checkout main
+git pull upstream main
+git checkout -b feat/issue-<number>-short-description
+```
+
+### 4. Install dependencies
+
+```bash
+pip install -e .[dev]
+```
+
+See [TESTING.md](docs/TESTING.md) for formatting, linting, and pytest usage.
+
+### 5. Implement and verify
+
+Follow the table in [Ways to contribute](#ways-to-contribute), then [Pull request process](#pull-request-process).
+
+---
+
+## Universal expectations
+
+These apply to **all** contributions, regardless of type.
+
+### Code of conduct
+
+Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outputs, documented dependencies, no malicious or deceptive code.
+
+### Style
+
+- **No emojis** in source code, documentation, commit messages, or PR titles.
+- Use **Black** for formatting and **Flake8** for linting (see [TESTING.md](docs/TESTING.md)).
+- Match existing naming, structure, and documentation tone in the files you touch.
+
+### Scope
+
+- Change only what the issue requires. Avoid unrelated refactors or drive-by edits.
+- Do not bump the package version in `pyproject.toml` unless the issue or a maintainer explicitly requests it (skill-only PRs typically do not version the framework).
+
+### Tests and CI
+
+- Add or update tests when behavior changes.
+- Run `python -m flake8 .` and `pytest tests/` before opening a PR.
+- Wait for GitHub Actions CI to pass before requesting review.
+
+### Pull request template
+
+Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Complete the **New or updated skill** section only when this PR adds or changes files under `skills/`.
+
+### AI-assisted work
+
+If you use coding assistants, follow [AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md): analyze and approve a plan first, implement second, verify before push. You remain responsible for the diff.
+
+---
+
+## Pull request process
+
+1. **Link an issue** — Reference it in the PR description (`Fixes #123` or `Refs #123`).
+2. **Fork and branch** — Work on a feature branch, not `main` of the upstream repo.
+3. **Implement** — Use the checklist for your contribution type ([Ways to contribute](#ways-to-contribute)).
+4. **Verify locally**:
+
+   ```bash
+   python -m black .
+   python -m flake8 .
+   pytest tests/
+   ```
+
+   For skill work, also run:
+
+   ```bash
+   pytest skills/<category>/<skill_name>/test_skill.py
+   pytest tests/test_skill_issuer.py
+   ```
+
+5. **Commit** — Clear imperative message, no emojis; include issue reference when appropriate.
+6. **Push** to your fork and open a PR into `ARPAHLS/skillware` `main`.
+7. **CI** — Ensure checks pass; address review feedback on the same branch.
+
+### Skill-specific steps (in addition to the above)
+
+1. Copy or align with `templates/python_skill/`.
+2. Create `skills/<category>/<skill_name>/` with the full bundle (see [Skill Package Standard](#skill-package-standard)).
+3. Add `docs/skills/<skill_name>.md` and a row in [docs/skills/README.md](docs/skills/README.md).
+4. Confirm `SkillLoader.load_skill("<category>/<skill_name>")` works or document required packages and environment variables.
+
+---
+
+## Skill Package Standard
+
+Every registry skill lives in `skills/<category>/<skill_name>/` and **must** include the files below. This is the detailed standard for the **skill** contribution type.
+
+### 1. `manifest.yaml` (metadata and governance)
+
+Defines the tool interface, safety constitution, dependencies, and issuer attribution.
+
+**Required fields and sections:**
+
+- `name`, `version`, `description`
+- `issuer` — see [Issuer attribution](#issuer-attribution)
+- `parameters` — valid JSON Schema for LLM tool calling
+- `constitution` — safety boundaries enforced at the prompt level
+- `requirements` — when external packages are needed (for example `requests`, `pandas`)
+
+**Optional but common:**
+
+- `env_vars` — API keys and configuration (never hardcode secrets in `skill.py`)
+- `category`, `outputs`, `presentation` — when they clarify the skill contract
+
+**Example:**
 
 ```yaml
 name: generic_hello
@@ -35,88 +197,112 @@ parameters:
 constitution: |
   1. Do not greet offensive names.
   2. Always maintain a polite tone.
-
 requirements:
   - requests
-  - pandas
 ```
 
-### 2. `skill.py` (The Logic)
-*   **Must** define a class inheriting from `BaseSkill` (planned) or follow the standard structure.
-*   **Must** accept a dictionary of inputs and return a dictionary (JSON-serializable).
-*   **Must** catch all internal errors and return a clean error report, not raise exceptions that crash the agent.
-*   **Must NOT** print to stdout/stderr. Retrieve data only.
+### 2. `skill.py` (logic)
 
-### 3. `instructions.md` (The Mind)
-This is the most critical file. It is the "driver" for the LLM.
-*   **Start** with "You are an agent equipped with [Skill Name]..."
-*   **Explain** *when* to use the tool.
-*   **Explain** how to interpret the output.
-*   **Explain** edge cases given the tool's limitations.
+- Implement deterministic Python logic (planned: inherit from `BaseSkill` where applicable).
+- Accept a dictionary of inputs; return a JSON-serializable dictionary.
+- Catch internal errors and return a structured error report; do not crash the host agent.
+- Do **not** print to stdout or stderr for normal operation.
+- Do **not** embed open-ended LLM code generation as the skill implementation.
 
-### 4. `card.json` (The Presentation)
-*   Defines how the skill state is rendered in a UI (optional but recommended for user-facing agents).
-*   When present, should include an `issuer` object that matches `manifest.yaml` (same `name` and `email`; copy `github` and `org` when used).
+### 3. `instructions.md` (cognition)
 
-### 5. `test_skill.py` (Validation)
-*   Unit tests for deterministic execution and schema compliance.
-*   Run with `pytest skills/<category>/<skill_name>/test_skill.py`.
+The primary guide for the host LLM.
 
-### 6. `docs/skills/<skill_name>.md` (Catalog Page)
-*   Document the skill for humans browsing the [Skill Library](docs/skills/README.md).
-*   Include **ID** and **Issuer** near the top (e.g. `[@your_handle](https://github.com/your_handle)` and optional org).
-*   Add or update the skill row in `docs/skills/README.md` when merging a new skill.
+- Open with context such as: "You are an agent equipped with [Skill Name]..."
+- Explain **when** to invoke the tool.
+- Explain how to interpret outputs and handle edge cases.
+- Keep prompts and persona here, not in `skill.py`.
 
-#### Issuer attribution
-The manifest is the **source of truth**. Use real contact details—not template placeholders (`Your Name`, `you@example.com`, etc.)—in anything under `skills/`.
+### 4. `card.json` (presentation)
+
+- Optional but recommended for user-facing agents and catalog UIs.
+- Describes UI presentation (`name`, `description`, `icon`, `ui_schema`, and similar).
+- When present, include an `issuer` object that matches `manifest.yaml` (`name` and `email` at minimum; copy `github` and `org` when used).
+
+### 5. `test_skill.py` (validation)
+
+- Unit tests for schema compliance and deterministic execution paths.
+- Run: `pytest skills/<category>/<skill_name>/test_skill.py`
+
+### 6. `docs/skills/<skill_name>.md` (catalog page)
+
+- Human-readable documentation linked from the [Skill Library](docs/skills/README.md).
+- Include **ID** and **Issuer** near the top (for example linked GitHub handle and optional org).
+- Describe capabilities, prerequisites, arguments, and limitations.
+
+### 7. Registry index row
+
+- Add or update the skill table in [docs/skills/README.md](docs/skills/README.md) (Skill, ID, Issuer, Description).
+
+### Issuer attribution
+
+The manifest is the **source of truth** for issuer data. Use real contact details in everything under `skills/`—not template placeholders (`Your Name`, `you@example.com`, `YOUR ORG`, and similar).
 
 | Field | Required | Notes |
 | :--- | :--- | :--- |
 | `issuer.name` | Yes | Display name of the contributor or maintainer |
 | `issuer.email` | Yes | Contact email for the skill author |
-| `issuer.github` | No | GitHub username (without `@`) for profile links |
-| `issuer.org` | No | GitHub org or affiliation (e.g. `ARPAHLS`) |
+| `issuer.github` | No | GitHub username without `@` |
+| `issuer.org` | No | GitHub organization or affiliation |
+
+Registry-wide issuer rules are enforced in `tests/test_skill_issuer.py` (skills under `skills/` only; templates are excluded).
 
 ---
 
-## What to Avoid
+## Skill categories
 
-*   **No "God Skills"**: Do not make one massive skill that does everything. Break it down.
-*   **No Hardcoded Models**: Do not put prompts inside `skill.py`. Put them in `instructions.md`.
-*   **No Vendor Lock-in**: Do not write code that only works with LangChain wrappers. Use standard Python.
-*   **No Environment Leaks**: Never hardcode API keys. Use `os.environ` and document the required keys in `manifest.yaml`.
+Place each skill under one top-level directory under `skills/`. Use an existing category when it fits; propose a new category in the issue if none apply.
 
----
+| Category | Purpose | Examples in registry |
+| :--- | :--- | :--- |
+| `compliance` | Privacy, policy, regulatory guardrails | `pii_masker`, `mica_module`, `tos_evaluator` |
+| `data_engineering` | Datasets, generation, ETL-style tooling | `synthetic_generator` |
+| `finance` | Blockchain, risk, financial analysis | `wallet_screening` |
+| `office` | Documents, productivity | `pdf_form_filler` |
+| `optimization` | Middleware, compression, efficiency | `prompt_rewriter` |
 
-## The Pull Request Process
-
-1.  **Start with an Issue**:
-    Please check [Existing Issues](https://github.com/ARPAHLS/skillware/issues) before starting.
-    *   **New Skill**: Use `[Skill Proposal]` to request or propose a new capability.
-    *   **Feature**: Use `[Framework Feature]` for changes to the core engine.
-    *   **Bug**: Use `[Bug Report]` for errors.
-    *   **RFC**: Use `[Request for Comments]` for major architectural discussions.
-
-    [Open a New Issue Here](https://github.com/ARPAHLS/skillware/issues/new/choose) is the first step.
-    *Wait for approval/feedback before writing code.*
-2.  **Fork** the repository.
-3.  **Create** your skill folder: `skills/<category>/<your_skill>/`.
-4.  **Implement** the skill bundle: `manifest.yaml` (with `issuer`), `skill.py`, `instructions.md`, `card.json`, `test_skill.py`, and `docs/skills/<skill_name>.md`.
-5.  **Verify**: Run linting and tests locally.
-    *   `pytest tests/test_skill_issuer.py` (issuer fields on registry skills)
-    *   `pytest skills/<category>/<your_skill>/test_skill.py`
-    *   `python -m black .`
-    *   `python -m flake8 .`
-6.  **Submit** PR.
+Skill IDs follow `category/skill_name` and should match the path under `skills/`.
 
 ---
 
-## Safety & Security
+## What to avoid
 
-*   Skills that interact with real-world assets (wallets, email, etc.) must implement a "Dry Run" mode if possible.
-*   Sanitize all inputs in `skill.py` before passing to external APIs.
-*   **Malicious code in PRs will result in an immediate ban.**
+- **God skills** — One skill that does everything; split into focused capabilities.
+- **Hardcoded models** — Do not hide prompts in `skill.py`; use `instructions.md`.
+- **Vendor lock-in** — Prefer standard Python over framework-specific wrappers in skill logic.
+- **Environment leaks** — No API keys in source; document `env_vars` in the manifest.
+- **Placeholder issuers** — No template names or emails in committed registry skills.
+- **Unrequested version bumps** — Do not change `pyproject.toml` version in routine skill PRs.
 
 ---
 
-*Thank you for helping us democratize Agent capabilities.*
+## Safety and security
+
+- Skills that touch real-world assets (wallets, email, production APIs) should support a **dry run** or read-only mode when feasible.
+- Sanitize inputs in `skill.py` before external calls.
+- Respect the skill `constitution` in both code and documentation.
+- Malicious or deceptive contributions may be rejected and blocked from the project.
+
+---
+
+## Related documents
+
+| Document | Purpose |
+| :--- | :--- |
+| [AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md) | Human-in-the-loop workflow for AI-assisted contributions |
+| [TESTING.md](docs/TESTING.md) | Black, Flake8, Pytest, local CI parity |
+| [Agent Code of Conduct](CODE_OF_CONDUCT.md) | Behavioral expectations for humans and agents |
+| [docs/introduction.md](docs/introduction.md) | Architecture: Mind, Body, Conscience |
+| [docs/skills/README.md](docs/skills/README.md) | Published skill catalog |
+| [templates/python_skill/](templates/python_skill/) | Boilerplate for new skills |
+| [Pull request template](.github/PULL_REQUEST_TEMPLATE.md) | PR checklist |
+| [Security policy](SECURITY.md) | Reporting vulnerabilities |
+
+---
+
+Thank you for helping make agent capabilities portable, safe, and reusable.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ print(response.text)
 
 ## Contributing
 
-We are building the "App Store" for Agents and require professional, robust, and safe skills.
+We are building the "App Store" for Agents and require professional, robust, and safe skills. We welcome contributions to the skill registry, documentation, tests, and core framework.
 
-We actively encourage both humans and autonomous agents to contribute to this repository!
-
-* Please read our **[Agent Code of Conduct](CODE_OF_CONDUCT.md)** which outlines our strict expectations for deterministic outputs, zero LLM code generation, and safety boundaries.
-* When submitting skills, our new **Agent-Friendly Pull Request Template** provides a checklist to ensure your logic aligns natively with `loader.py` and `base_skill.py`.
-* Please also review **[CONTRIBUTING.md](CONTRIBUTING.md)** for detailed guidelines on folder structure and schema definitions.
+* **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution types, skill standard, pull request process, and navigation to all contributor docs.
+* **[AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md)** — Recommended human-in-the-loop workflow when using coding assistants.
+* **[Agent Code of Conduct](CODE_OF_CONDUCT.md)** — Deterministic outputs, safety boundaries, and acceptable use of skills.
+* **[TESTING.md](docs/TESTING.md)** — Local linting and pytest before you open a PR.
+* **[Pull request template](.github/PULL_REQUEST_TEMPLATE.md)** — Checklists for skills, docs, and framework changes (complete only the sections that apply).
 
 ## Comparison
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -1,0 +1,366 @@
+# AI-Native Contribution Workflow
+
+This guide describes a recommended, human-in-the-loop workflow for contributing to [Skillware](https://github.com/ARPAHLS/skillware) with AI coding assistants (Cursor, Copilot, Claude Code, Gemini, or similar). The assistant does the heavy lifting; you review and approve at each stage before anything is merged.
+
+For repository standards and contribution types, start with [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+---
+
+## Navigation
+
+- [Principles](#principles)
+- [Stage 1: Repository setup](#stage-1-repository-setup)
+- [Stage 2: Analysis with a reasoning model](#stage-2-analysis-with-a-reasoning-model)
+- [Stage 3: Human review of the plan](#stage-3-human-review-of-the-plan)
+- [Stage 4: Implementation with a faster model](#stage-4-implementation-with-a-faster-model)
+- [Stage 5: Verification with a reasoning model](#stage-5-verification-with-a-reasoning-model)
+- [Stage 6: Branch, commit, and push](#stage-6-branch-commit-and-push)
+- [Stage 7: Pull request and CI](#stage-7-pull-request-and-ci)
+- [Skillware conventions for AI assistants](#skillware-conventions-for-ai-assistants)
+- [Verification checklists by contribution type](#verification-checklists-by-contribution-type)
+- [Starter prompts](#starter-prompts)
+
+---
+
+## Principles
+
+1. **Human authority**: You own the fork, the branch, the commit message, and the decision to open or merge a PR. The model proposes; you approve.
+2. **Issue-first**: Read the linked GitHub issue and its acceptance criteria before writing code. If there is no issue, open one or confirm scope with maintainers.
+3. **Scope discipline**: Change only what the issue requires. Avoid drive-by refactors, unrelated formatting, or version bumps unless explicitly requested.
+4. **Determinism**: Skill logic must be ordinary Python with predictable outputs. Do not rely on the model to generate executable code at runtime inside a skill.
+5. **No emojis**: Do not use emojis in source code, documentation, commit messages, or PR titles.
+
+---
+
+## Stage 1: Repository setup
+
+**Goal**: A local clone tied to your fork, on an up-to-date default branch.
+
+1. Fork [ARPAHLS/skillware](https://github.com/ARPAHLS/skillware) on GitHub to your account (for example `rosspeili/skillware`).
+2. Clone your fork locally:
+
+   ```bash
+   git clone https://github.com/<your-username>/skillware.git
+   cd skillware
+   ```
+
+3. Add the upstream remote and fetch:
+
+   ```bash
+   git remote add upstream https://github.com/ARPAHLS/skillware.git
+   git fetch upstream
+   ```
+
+4. Sync `main` before starting work:
+
+   ```bash
+   git checkout main
+   git pull upstream main
+   git push origin main
+   ```
+
+5. Install the project in editable mode with dev dependencies:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+6. Create a feature branch (do this before implementation, or immediately after locking the plan):
+
+   ```bash
+   git checkout -b feat/issue-<number>-short-description
+   ```
+
+**Human checkpoint**: Confirm you are on the correct issue, branch name, and remote (`origin` = your fork).
+
+---
+
+## Stage 2: Analysis with a reasoning model
+
+**Goal**: A written plan before any code changes. Use a capable reasoning model (for example Gemini 2.5 Pro, Claude Opus, or an equivalent tier in your editor).
+
+Ask the assistant to:
+
+1. Read [CONTRIBUTING.md](../../CONTRIBUTING.md) and, if the work touches skills, the [Skill Package Standard](../../CONTRIBUTING.md#skill-package-standard).
+2. Read the specific GitHub issue (paste the URL or number).
+3. Scan complementary paths likely affected (see table below).
+4. Produce a structured analysis:
+
+| Section | Content |
+| :--- | :--- |
+| **Problem statement** | What the issue actually requires, in your own words |
+| **Acceptance criteria** | Bullet list mapped to verifiable outcomes |
+| **Affected files** | Concrete paths (existing and new) |
+| **Caveats** | Dependencies, tests, docs, CI, breaking changes, security |
+| **Implementation options** | Up to three approaches with trade-offs |
+| **Recommendation** | One preferred approach and why |
+| **Out of scope** | What this issue does *not* ask for |
+
+### Complementary paths to consider
+
+| If the issue involves... | Also inspect |
+| :--- | :--- |
+| New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py` |
+| Core framework | `skillware/core/`, `tests/test_loader.py`, usage guides under `docs/usage/` |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, cross-links from other pages |
+| Bug fix | Failing test or reproduction path, related skill or loader code |
+| Good first issue | Often docs or small tests; read acceptance criteria literally |
+
+Do not write implementation code in this stage unless the issue is trivial and you explicitly want a single-pass fix.
+
+---
+
+## Stage 3: Human review of the plan
+
+**Goal**: Align on approach before tokens are spent on a large diff.
+
+Review the analysis and adjust:
+
+- Correct misunderstood requirements.
+- Remove scope creep (extra skills, loader changes, version bumps).
+- Pick one implementation option or merge ideas.
+- Confirm category, naming, and issuer attribution for skill work.
+
+Reply to the assistant with a short **approved plan** (you can paste it into Stage 4). Example:
+
+> Proceed with option B. Touch only `docs/skills/README.md` and `CONTRIBUTING.md`. Do not modify `loader.py`. No version bump.
+
+**Human checkpoint**: Do not start implementation until you are satisfied with the plan.
+
+---
+
+## Stage 4: Implementation with a faster model
+
+**Goal**: Execute the approved plan with a faster or cheaper model tier once the approach is locked.
+
+Instructions to the assistant:
+
+- Follow the approved plan exactly.
+- Match existing naming, types, and documentation tone.
+- For skills: copy `templates/python_skill/` and replace placeholders with real values.
+- Run formatters and tests locally as files are completed.
+
+Suggested local commands (run from repository root):
+
+```bash
+python -m black .
+python -m flake8 .
+pytest tests/
+```
+
+For a single skill:
+
+```bash
+pytest skills/<category>/<skill_name>/test_skill.py
+pytest tests/test_skill_issuer.py
+```
+
+**Human checkpoint**: Skim the diff for unrelated files, secrets, emojis, and placeholder text (`Your Name`, `you@example.com`, `YOUR ORG`) under `skills/`.
+
+---
+
+## Stage 5: Verification with a reasoning model
+
+**Goal**: An independent pass that treats the change as complete only when tests, docs, and complementary files align with the issue.
+
+Switch back to a reasoning model and ask for a **pre-PR audit** against:
+
+1. GitHub issue acceptance criteria (every item addressed or explicitly deferred).
+2. [Verification checklists by contribution type](#verification-checklists-by-contribution-type) below.
+3. Local test and lint results (paste output or ask the assistant to run commands).
+4. PR template sections: complete only what applies (skill checklist vs docs-only).
+
+If anything fails, fix in a follow-up implementation pass (Stage 4) and re-run verification.
+
+**Human checkpoint**: You run the final `pytest` / `flake8` commands yourself if you do not trust the model's report.
+
+---
+
+## Stage 6: Branch, commit, and push
+
+**Goal**: Clean git history on your fork.
+
+A lightweight model can help draft commit messages; you edit and execute git yourself.
+
+```bash
+git status
+git add <paths>   # prefer scoped adds over blind git add -A when possible
+git commit -m "Short imperative summary." -m "Optional body with context. Fixes #57"
+git push -u origin feat/issue-<number>-short-description
+```
+
+Commit message guidelines:
+
+- Imperative mood (`Add`, `Fix`, `Document`), not past tense.
+- No emojis.
+- Reference issues (`Fixes #57`, `Refs #12`) when appropriate.
+- One logical change per commit when practical; squash locally before push if needed.
+
+**Human checkpoint**: Confirm `git diff` contains no `.env`, credentials, or accidental large binaries.
+
+---
+
+## Stage 7: Pull request and CI
+
+**Goal**: A reviewable PR against upstream `main`.
+
+1. Open a pull request from your fork branch into `ARPAHLS/skillware` `main` (GitHub UI).
+2. Use the PR template: check boxes that apply; complete the **New or updated skill** section only if `skills/` changed.
+3. Wait for CI (lint and `pytest tests/`) to pass before requesting review.
+4. Respond to review comments; push additional commits to the same branch.
+
+Do not force-push to shared branches unless a maintainer asks you to.
+
+**Human checkpoint**: PR description explains *why*, not only *what*. Link the issue.
+
+---
+
+## Skillware conventions for AI assistants
+
+These rules must stay consistent with [CONTRIBUTING.md](../../CONTRIBUTING.md) and the rest of the repository.
+
+### Style and communication
+
+- No emojis in code, documentation, commit messages, or PR titles.
+- Prefer clear, professional prose in docs (complete sentences, minimal jargon).
+- Do not add verbose comments that restate obvious code.
+
+### Skills (registry under `skills/`)
+
+- A skill is a bundle: `manifest.yaml`, `skill.py`, `instructions.md`, `card.json`, `test_skill.py`, plus catalog docs.
+- **`manifest.yaml` is the source of truth** for tool schema, constitution, requirements, `env_vars`, and `issuer`.
+- **`issuer`**: `name` and `email` required; `github` and `org` optional. Real values only in `skills/` (not template placeholders).
+- **`card.json`**: When present, `issuer` must match manifest `name` and `email`.
+- **Catalog**: Add or update `docs/skills/<skill_name>.md` (ID, Issuer) and a row in `docs/skills/README.md`.
+- **Categories**: Use an existing top-level folder under `skills/` (`compliance`, `data_engineering`, `finance`, `office`, `optimization`) or propose a new category in the issue before inventing one.
+- **Version bumps**: Do not bump `pyproject.toml` or package version in skill-only PRs unless the issue or a maintainer requests it.
+- **Logic**: Deterministic Python in `skill.py`; prompts and persona belong in `instructions.md`, not embedded as generated code paths.
+- **Secrets**: Never commit API keys; document `env_vars` in the manifest.
+
+### Core framework (`skillware/core/`)
+
+- Changes affect all consumers; require a framework feature issue and tests in `tests/`.
+- Do not change `loader.py` unless the issue requires it; issuer metadata is not passed into LLM tool schemas today.
+- Keep adapters aligned with documented usage guides (`docs/usage/`).
+
+### Documentation
+
+- Fix broken relative links when you move or rename files.
+- Skill docs live under `docs/skills/`; philosophy and architecture under `docs/introduction.md`.
+- Testing commands belong in [TESTING.md](../TESTING.md); link rather than duplicate long command lists.
+
+### Pull requests
+
+- Use the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md).
+- Skill-specific checklist items apply only when adding or changing files under `skills/`.
+- Follow [Agent Code of Conduct](../../CODE_OF_CONDUCT.md) for deterministic, safe behavior.
+
+---
+
+## Verification checklists by contribution type
+
+Use the checklist that matches your issue during Stage 5.
+
+### New or updated skill
+
+- [ ] Directory: `skills/<category>/<skill_name>/`
+- [ ] `manifest.yaml`: `name`, `version`, `description`, `parameters`, `constitution`, `issuer` (real `name` + `email`)
+- [ ] `skill.py`: deterministic, JSON-serializable returns, errors handled without crashing the agent
+- [ ] `instructions.md`: when to use the tool, how to interpret output, limitations
+- [ ] `card.json`: UI fields; `issuer` matches manifest
+- [ ] `test_skill.py`: passes locally
+- [ ] `docs/skills/<skill_name>.md` and row in `docs/skills/README.md`
+- [ ] `pytest tests/test_skill_issuer.py` passes
+- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps documented)
+- [ ] No template placeholders under `skills/`
+- [ ] PR template skill section completed
+
+### Documentation only
+
+- [ ] All acceptance criteria in the issue addressed
+- [ ] Links valid (especially `docs/skills/`, `CONTRIBUTING.md`, usage guides)
+- [ ] Tone matches surrounding docs; no emojis
+- [ ] No unrelated code changes unless required for accuracy
+- [ ] PR marked as doc change; skill checklist skipped
+
+### Core framework
+
+- [ ] Issue approved for framework work
+- [ ] Changes confined to `skillware/` and relevant `tests/`
+- [ ] New or updated unit tests for behavior changes
+- [ ] `pytest tests/` passes
+- [ ] Usage docs updated if public API or adapter behavior changed
+- [ ] No breaking changes without issue discussion
+
+### Bug fix
+
+- [ ] Reproduction understood and linked to issue
+- [ ] Fix is minimal and targeted
+- [ ] Regression test added when feasible
+- [ ] `pytest` and `flake8` pass
+- [ ] No unrelated refactors
+
+### Good first issue
+
+- [ ] Read issue labels and acceptance criteria literally
+- [ ] Ask for clarification in the issue if scope is ambiguous
+- [ ] Same verification as the underlying type (docs, test, or small code fix)
+
+---
+
+## Starter prompts
+
+Copy and adapt these in your assistant. Replace placeholders.
+
+### Analysis (Stage 2)
+
+```text
+You are helping me contribute to the Skillware repository (ARPAHLS/skillware).
+
+Read CONTRIBUTING.md and docs/contributing/ai_native_workflow.md.
+Read GitHub issue #<NUMBER>: <URL or paste body>.
+
+Produce an analysis with:
+1. Problem statement and acceptance criteria
+2. Affected files (existing and new)
+3. Caveats (tests, docs, CI, security)
+4. Up to three implementation options with trade-offs
+5. Recommended approach and explicit out-of-scope items
+
+Do not write code yet.
+```
+
+### Implementation (Stage 4)
+
+```text
+Approved plan for issue #<NUMBER>:
+
+<paste your approved plan>
+
+Implement only what the plan describes. Match repository conventions.
+After editing, tell me which commands to run for black, flake8, and pytest.
+```
+
+### Pre-PR audit (Stage 5)
+
+```text
+Pre-PR audit for issue #<NUMBER> on branch <branch-name>.
+
+Compare the current diff to the issue acceptance criteria and the
+verification checklist for <skill | docs | framework | bug> contributions.
+
+List: missing items, unrelated files, placeholder text, emojis,
+broken links, and suggested commit message (no emojis).
+
+I will run pytest and flake8 locally; remind me of the exact commands.
+```
+
+---
+
+## Related documents
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — contribution hub and skill standard
+- [TESTING.md](../TESTING.md) — Black, Flake8, Pytest
+- [Agent Code of Conduct](../../CODE_OF_CONDUCT.md)
+- [Pull request template](../../.github/PULL_REQUEST_TEMPLATE.md)
+- [Skill library](../skills/README.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -101,5 +101,6 @@ Skillware is designed to be the "Standard Library" for all agents.
 ---
 **Next Steps:**
 *   Explore the [Skill Library](skills/README.md)
-*   Learn [How to Contribute](../CONTRIBUTING.md)
+*   Read [How to Contribute](../CONTRIBUTING.md) (skills, docs, framework, and bugs)
+*   Follow the [AI-Native Contribution Workflow](contributing/ai_native_workflow.md) when using coding assistants
 


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` was written mainly for new skills. As Skillware attracts more contributors—including people using AI coding assistants—there was no single guide for docs, framework work, bugs, or good first issues, and no documented human-in-the-loop workflow for AI-assisted contributions.

This PR addresses [#57](https://github.com/ARPAHLS/skillware/issues/57) by turning `CONTRIBUTING.md` into a navigation hub and adding a dedicated AI workflow guide.

### What changed

- **`CONTRIBUTING.md`**
  - Table-of-contents navigation for quick scanning on GitHub.
  - **Ways to contribute** table: skills, documentation, core framework, bug fixes, good first issues, and RFCs (each with typical paths, issue types, and local verification).
  - **Getting started**, **universal expectations**, and **pull request process** that apply to every contribution type.
  - **Skill-specific** steps kept under the full Skill Package Standard (manifest, issuer, tests, catalog docs, categories).
  - Links to related docs (testing, code of conduct, PR template, AI workflow).

- **`docs/contributing/ai_native_workflow.md`** (new)
  - Seven-stage, human-in-the-loop workflow: setup, reasoning-model analysis, plan approval, implementation, verification, git, PR/CI.
  - Skillware conventions for AI assistants (no emojis, issuer rules, no unrequested version bumps, scope discipline).
  - Verification checklists by contribution type.
  - Copy-paste starter prompts for analysis, implementation, and pre-PR audit.

- **`README.md`** and **`docs/introduction.md`**
  - Link to the contributing hub and the AI-native workflow from Contributing / Next steps.

No runtime or loader changes.

### Type of Change

- [x] Doc Fix: Documentation Update
- [ ] Skill Proposal: New Skill
- [ ] Bug Report Fix
- [ ] Framework Feature / RFC Updates

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] Documentation-only change; `flake8` / `pytest` not required for markdown, but links and paths were reviewed manually.

## New or updated skill

Not applicable — this PR does not modify `skills/`.

## Constitution & Safety

Not applicable — documentation only; no skill execution or framework behavior changes.

## Related Issues

Fixes #57