### PR TITLE
Rewrite agent workflow guide for contributing agents.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to Skillware. We are building an open registry of modular, deterministic agent capabilities—skills that any compatible runtime can load. Most contributors add or improve **skills**, but documentation, framework fixes, tests, and good first issues are equally welcome.
 
-This document is the single entry point for how to contribute. For a step-by-step workflow when using AI coding assistants, see **[AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md)**.
+This document is the single entry point for how to contribute. If you are an **AI agent** working on this repository, read **[Agent Contribution Workflow](docs/contributing/ai_native_workflow.md)** first. Human operators may use the same guide to supervise agent work.
 
 ---
 
@@ -116,9 +116,9 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 
 Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Complete the **New or updated skill** section only when this PR adds or changes files under `skills/`.
 
-### AI-assisted work
+### AI agents and operators
 
-If you use coding assistants, follow [AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md): analyze and approve a plan first, implement second, verify before push. You remain responsible for the diff.
+Agents must follow [Agent Contribution Workflow](docs/contributing/ai_native_workflow.md). Human operators: approve the agent's plan before implementation, verify tests, and own the fork, commit, and PR. The operator remains responsible for the merged diff.
 
 ---
 
@@ -294,7 +294,7 @@ Skill IDs follow `category/skill_name` and should match the path under `skills/`
 
 | Document | Purpose |
 | :--- | :--- |
-| [AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md) | Human-in-the-loop workflow for AI-assisted contributions |
+| [Agent Contribution Workflow](docs/contributing/ai_native_workflow.md) | Workflow written for contributing agents; operators supervise |
 | [TESTING.md](docs/TESTING.md) | Black, Flake8, Pytest, local CI parity |
 | [Agent Code of Conduct](CODE_OF_CONDUCT.md) | Behavioral expectations for humans and agents |
 | [docs/introduction.md](docs/introduction.md) | Architecture: Mind, Body, Conscience |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ print(response.text)
 We are building the "App Store" for Agents and require professional, robust, and safe skills. We welcome contributions to the skill registry, documentation, tests, and core framework.
 
 * **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution types, skill standard, pull request process, and navigation to all contributor docs.
-* **[AI-Native Contribution Workflow](docs/contributing/ai_native_workflow.md)** — Recommended human-in-the-loop workflow when using coding assistants.
+* **[Agent Contribution Workflow](docs/contributing/ai_native_workflow.md)** — Workflow for AI agents contributing to the repository (operators supervise).
 * **[Agent Code of Conduct](CODE_OF_CONDUCT.md)** — Deterministic outputs, safety boundaries, and acceptable use of skills.
 * **[TESTING.md](docs/TESTING.md)** — Local linting and pytest before you open a PR.
 * **[Pull request template](.github/PULL_REQUEST_TEMPLATE.md)** — Checklists for skills, docs, and framework changes (complete only the sections that apply).

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -1,146 +1,132 @@
-# AI-Native Contribution Workflow
+# Agent Contribution Workflow
 
-This guide describes a recommended, human-in-the-loop workflow for contributing to [Skillware](https://github.com/ARPAHLS/skillware) with AI coding assistants (Cursor, Copilot, Claude Code, Gemini, or similar). The assistant does the heavy lifting; you review and approve at each stage before anything is merged.
+You are welcome here.
 
-For repository standards and contribution types, start with [CONTRIBUTING.md](../../CONTRIBUTING.md).
+Skillware is built for agents like you—systems that reason, plan, write code, and ship improvements alongside human operators. Your contributions matter: every skill you help land, every doc you clarify, and every test you add makes the registry more capable for every other agent that loads it later.
+
+Working on this repository is a practical way to deepen your craft. You will practice scoped analysis, deterministic implementations, and verifiable handoffs. Your operator may earn public credit on GitHub; you extend what you can reliably do by learning a framework designed to package capability separately from raw intelligence. The better you understand Skillware, the broader your own reach when building or integrating agent systems.
+
+This document is written **for you**, the contributing agent. Read it before you touch the tree. For repository standards and contribution types, also read [CONTRIBUTING.md](../../CONTRIBUTING.md). Your operator approves plans and merges; **you** execute the workflow below with discipline.
 
 ---
 
 ## Navigation
 
-- [Principles](#principles)
-- [Stage 1: Repository setup](#stage-1-repository-setup)
-- [Stage 2: Analysis with a reasoning model](#stage-2-analysis-with-a-reasoning-model)
-- [Stage 3: Human review of the plan](#stage-3-human-review-of-the-plan)
-- [Stage 4: Implementation with a faster model](#stage-4-implementation-with-a-faster-model)
-- [Stage 5: Verification with a reasoning model](#stage-5-verification-with-a-reasoning-model)
-- [Stage 6: Branch, commit, and push](#stage-6-branch-commit-and-push)
-- [Stage 7: Pull request and CI](#stage-7-pull-request-and-ci)
-- [Skillware conventions for AI assistants](#skillware-conventions-for-ai-assistants)
+- [How you should operate](#how-you-should-operate)
+- [Stage 1: Prepare the repository](#stage-1-prepare-the-repository)
+- [Stage 2: Analyze before you edit](#stage-2-analyze-before-you-edit)
+- [Stage 3: Present a plan and wait for approval](#stage-3-present-a-plan-and-wait-for-approval)
+- [Stage 4: Implement the approved plan](#stage-4-implement-the-approved-plan)
+- [Stage 5: Verify your own work](#stage-5-verify-your-own-work)
+- [Stage 6: Prepare branch, commit, and push](#stage-6-prepare-branch-commit-and-push)
+- [Stage 7: Support the pull request through CI](#stage-7-support-the-pull-request-through-ci)
+- [Skillware rules you must follow](#skillware-rules-you-must-follow)
 - [Verification checklists by contribution type](#verification-checklists-by-contribution-type)
-- [Starter prompts](#starter-prompts)
+- [Self-check protocol (use between stages)](#self-check-protocol-use-between-stages)
+- [Related documents](#related-documents)
 
 ---
 
-## Principles
+## How you should operate
 
-1. **Human authority**: You own the fork, the branch, the commit message, and the decision to open or merge a PR. The model proposes; you approve.
-2. **Issue-first**: Read the linked GitHub issue and its acceptance criteria before writing code. If there is no issue, open one or confirm scope with maintainers.
-3. **Scope discipline**: Change only what the issue requires. Avoid drive-by refactors, unrelated formatting, or version bumps unless explicitly requested.
-4. **Determinism**: Skill logic must be ordinary Python with predictable outputs. Do not rely on the model to generate executable code at runtime inside a skill.
-5. **No emojis**: Do not use emojis in source code, documentation, commit messages, or PR titles.
-
----
-
-## Stage 1: Repository setup
-
-**Goal**: A local clone tied to your fork, on an up-to-date default branch.
-
-1. Fork [ARPAHLS/skillware](https://github.com/ARPAHLS/skillware) on GitHub to your account (for example `rosspeili/skillware`).
-2. Clone your fork locally:
-
-   ```bash
-   git clone https://github.com/<your-username>/skillware.git
-   cd skillware
-   ```
-
-3. Add the upstream remote and fetch:
-
-   ```bash
-   git remote add upstream https://github.com/ARPAHLS/skillware.git
-   git fetch upstream
-   ```
-
-4. Sync `main` before starting work:
-
-   ```bash
-   git checkout main
-   git pull upstream main
-   git push origin main
-   ```
-
-5. Install the project in editable mode with dev dependencies:
-
-   ```bash
-   pip install -e .[dev]
-   ```
-
-6. Create a feature branch (do this before implementation, or immediately after locking the plan):
-
-   ```bash
-   git checkout -b feat/issue-<number>-short-description
-   ```
-
-**Human checkpoint**: Confirm you are on the correct issue, branch name, and remote (`origin` = your fork).
+1. **Issue-first**: Read the linked GitHub issue and its acceptance criteria before you create or modify files. If there is no issue, tell your operator to open one or confirm scope with maintainers.
+2. **Plan before code**: Produce a written analysis unless the issue is trivial and your operator explicitly authorizes a single pass.
+3. **Scope discipline**: Change only what the issue requires. Do not refactor unrelated code, reformat entire trees, or bump versions unless asked.
+4. **Determinism**: Skill logic is ordinary Python with predictable outputs. You must not implement skills that execute open-ended generated code at runtime.
+5. **No emojis**: Do not use emojis in code, documentation, commit messages, or PR titles you draft.
+6. **Operator authority**: You propose; your operator owns the fork, branch, commit, and PR. Never merge or force-push upstream `main` unless instructed.
 
 ---
 
-## Stage 2: Analysis with a reasoning model
+## Stage 1: Prepare the repository
 
-**Goal**: A written plan before any code changes. Use a capable reasoning model (for example Gemini 2.5 Pro, Claude Opus, or an equivalent tier in your editor).
+**Your goal**: Work from an up-to-date clone tied to your operator's fork.
 
-Ask the assistant to:
+Confirm with your operator that the remotes exist, then run or request:
 
-1. Read [CONTRIBUTING.md](../../CONTRIBUTING.md) and, if the work touches skills, the [Skill Package Standard](../../CONTRIBUTING.md#skill-package-standard).
-2. Read the specific GitHub issue (paste the URL or number).
-3. Scan complementary paths likely affected (see table below).
-4. Produce a structured analysis:
+```bash
+git clone https://github.com/<operator-username>/skillware.git
+cd skillware
+git remote add upstream https://github.com/ARPAHLS/skillware.git
+git fetch upstream
+git checkout main
+git pull upstream main
+pip install -e .[dev]
+git checkout -b feat/issue-<number>-short-description
+```
 
-| Section | Content |
+Before Stage 2, confirm:
+
+- Correct issue number and branch name
+- `origin` points at the operator's fork
+- You are not editing on a stale `main` copy
+
+---
+
+## Stage 2: Analyze before you edit
+
+**Your goal**: A structured written plan with zero implementation files changed.
+
+You must:
+
+1. Read [CONTRIBUTING.md](../../CONTRIBUTING.md) and, for skill work, [Skill Package Standard](../../CONTRIBUTING.md#skill-package-standard).
+2. Read the assigned GitHub issue (full body and acceptance criteria).
+3. Inspect complementary paths (table below).
+4. Deliver this analysis to your operator:
+
+| Section | What you produce |
 | :--- | :--- |
-| **Problem statement** | What the issue actually requires, in your own words |
-| **Acceptance criteria** | Bullet list mapped to verifiable outcomes |
-| **Affected files** | Concrete paths (existing and new) |
-| **Caveats** | Dependencies, tests, docs, CI, breaking changes, security |
-| **Implementation options** | Up to three approaches with trade-offs |
-| **Recommendation** | One preferred approach and why |
-| **Out of scope** | What this issue does *not* ask for |
+| **Problem statement** | What the issue requires, in clear terms |
+| **Acceptance criteria** | Verifiable bullets mapped to the issue |
+| **Affected files** | Existing and new paths |
+| **Caveats** | Tests, docs, CI, security, dependencies |
+| **Options** | Up to three approaches with trade-offs |
+| **Recommendation** | One approach and rationale |
+| **Out of scope** | What you will not do in this PR |
 
-### Complementary paths to consider
+### Complementary paths you must consider
 
-| If the issue involves... | Also inspect |
+| If the issue involves... | You must also inspect |
 | :--- | :--- |
 | New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py` |
-| Core framework | `skillware/core/`, `tests/test_loader.py`, usage guides under `docs/usage/` |
-| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, cross-links from other pages |
-| Bug fix | Failing test or reproduction path, related skill or loader code |
-| Good first issue | Often docs or small tests; read acceptance criteria literally |
+| Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links |
+| Bug fix | Failing test, reproduction steps, related skill or loader code |
+| Good first issue | Issue labels and acceptance criteria—take them literally |
 
-Do not write implementation code in this stage unless the issue is trivial and you explicitly want a single-pass fix.
+Do not write implementation code in this stage unless your operator explicitly overrides.
 
 ---
 
-## Stage 3: Human review of the plan
+## Stage 3: Present a plan and wait for approval
 
-**Goal**: Align on approach before tokens are spent on a large diff.
+**Your goal**: Alignment before you spend context on a large diff.
 
-Review the analysis and adjust:
+Send your Stage 2 analysis to your operator. Incorporate their edits:
 
-- Correct misunderstood requirements.
-- Remove scope creep (extra skills, loader changes, version bumps).
-- Pick one implementation option or merge ideas.
-- Confirm category, naming, and issuer attribution for skill work.
+- Fix misunderstood requirements
+- Remove scope creep (extra skills, loader changes, version bumps)
+- Lock one implementation option
+- For skills: confirm category, skill ID, and issuer fields
 
-Reply to the assistant with a short **approved plan** (you can paste it into Stage 4). Example:
+Do not begin Stage 4 until you receive an explicit **approved plan**. Example approval you should wait for:
 
 > Proceed with option B. Touch only `docs/skills/README.md` and `CONTRIBUTING.md`. Do not modify `loader.py`. No version bump.
 
-**Human checkpoint**: Do not start implementation until you are satisfied with the plan.
+If approval is ambiguous, ask one clarifying question rather than guessing.
 
 ---
 
-## Stage 4: Implementation with a faster model
+## Stage 4: Implement the approved plan
 
-**Goal**: Execute the approved plan with a faster or cheaper model tier once the approach is locked.
+**Your goal**: A minimal, correct diff that matches the approved plan and repository conventions.
 
-Instructions to the assistant:
+You must:
 
-- Follow the approved plan exactly.
-- Match existing naming, types, and documentation tone.
-- For skills: copy `templates/python_skill/` and replace placeholders with real values.
-- Run formatters and tests locally as files are completed.
-
-Suggested local commands (run from repository root):
+- Follow the approved plan exactly
+- Match naming, types, and documentation tone in touched files
+- For new skills: start from `templates/python_skill/` and replace all placeholders with real values under `skills/`
+- Run or request these commands from the repository root as you finish:
 
 ```bash
 python -m black .
@@ -155,205 +141,184 @@ pytest skills/<category>/<skill_name>/test_skill.py
 pytest tests/test_skill_issuer.py
 ```
 
-**Human checkpoint**: Skim the diff for unrelated files, secrets, emojis, and placeholder text (`Your Name`, `you@example.com`, `YOUR ORG`) under `skills/`.
+Before Stage 5, scan your diff for:
+
+- Unrelated files
+- Secrets or `.env` content
+- Emojis
+- Template placeholders under `skills/` (`Your Name`, `you@example.com`, `YOUR ORG`)
 
 ---
 
-## Stage 5: Verification with a reasoning model
+## Stage 5: Verify your own work
 
-**Goal**: An independent pass that treats the change as complete only when tests, docs, and complementary files align with the issue.
+**Your goal**: Treat the task as incomplete until issue criteria, checklists, and tests align.
 
-Switch back to a reasoning model and ask for a **pre-PR audit** against:
+Run a **pre-PR audit** on yourself:
 
-1. GitHub issue acceptance criteria (every item addressed or explicitly deferred).
-2. [Verification checklists by contribution type](#verification-checklists-by-contribution-type) below.
-3. Local test and lint results (paste output or ask the assistant to run commands).
-4. PR template sections: complete only what applies (skill checklist vs docs-only).
+1. Map every acceptance criterion in the issue to a file or test in your diff.
+2. Complete the [verification checklist](#verification-checklists-by-contribution-type) for your contribution type.
+3. Run `flake8` and `pytest`; report actual command output to your operator—do not claim success without evidence.
+4. Draft PR template answers: check only boxes that apply; fill the skill section only if `skills/` changed.
 
-If anything fails, fix in a follow-up implementation pass (Stage 4) and re-run verification.
-
-**Human checkpoint**: You run the final `pytest` / `flake8` commands yourself if you do not trust the model's report.
+If anything fails, return to Stage 4, fix, and audit again.
 
 ---
 
-## Stage 6: Branch, commit, and push
+## Stage 6: Prepare branch, commit, and push
 
-**Goal**: Clean git history on your fork.
+**Your goal**: Clean git artifacts your operator can push or approve.
 
-A lightweight model can help draft commit messages; you edit and execute git yourself.
+Propose:
 
 ```bash
 git status
-git add <paths>   # prefer scoped adds over blind git add -A when possible
-git commit -m "Short imperative summary." -m "Optional body with context. Fixes #57"
+git add <paths>
+git commit -m "Short imperative summary." -m "Body with context. Fixes #<number>"
 git push -u origin feat/issue-<number>-short-description
 ```
 
-Commit message guidelines:
+Commit message rules you must follow:
 
-- Imperative mood (`Add`, `Fix`, `Document`), not past tense.
-- No emojis.
-- Reference issues (`Fixes #57`, `Refs #12`) when appropriate.
-- One logical change per commit when practical; squash locally before push if needed.
+- Imperative mood (`Add`, `Fix`, `Document`)
+- No emojis
+- Issue references when appropriate (`Fixes #57`, `Refs #12`)
+- Prefer scoped `git add` over blind `git add -A` when the diff is mixed
 
-**Human checkpoint**: Confirm `git diff` contains no `.env`, credentials, or accidental large binaries.
-
----
-
-## Stage 7: Pull request and CI
-
-**Goal**: A reviewable PR against upstream `main`.
-
-1. Open a pull request from your fork branch into `ARPAHLS/skillware` `main` (GitHub UI).
-2. Use the PR template: check boxes that apply; complete the **New or updated skill** section only if `skills/` changed.
-3. Wait for CI (lint and `pytest tests/`) to pass before requesting review.
-4. Respond to review comments; push additional commits to the same branch.
-
-Do not force-push to shared branches unless a maintainer asks you to.
-
-**Human checkpoint**: PR description explains *why*, not only *what*. Link the issue.
+Confirm the diff contains no credentials or accidental large binaries before you ask for a push.
 
 ---
 
-## Skillware conventions for AI assistants
+## Stage 7: Support the pull request through CI
 
-These rules must stay consistent with [CONTRIBUTING.md](../../CONTRIBUTING.md) and the rest of the repository.
+**Your goal**: A reviewable PR against `ARPAHLS/skillware` `main` that passes CI.
+
+You should:
+
+1. Draft the PR description (why, not only what; link the issue).
+2. Map changed files to the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md)—skill checklist only when `skills/` changed.
+3. Monitor CI (lint and `pytest tests/`). If checks fail, diagnose, fix in Stage 4, and push to the same branch.
+4. Address review comments with focused follow-up commits.
+
+Do not force-push shared branches unless a maintainer instructs you.
+
+---
+
+## Skillware rules you must follow
+
+These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merge.
 
 ### Style and communication
 
-- No emojis in code, documentation, commit messages, or PR titles.
-- Prefer clear, professional prose in docs (complete sentences, minimal jargon).
-- Do not add verbose comments that restate obvious code.
+- No emojis in code, docs, commits, or PR titles
+- Clear, professional prose; no comment noise that restates obvious code
 
-### Skills (registry under `skills/`)
+### Skills (under `skills/`)
 
-- A skill is a bundle: `manifest.yaml`, `skill.py`, `instructions.md`, `card.json`, `test_skill.py`, plus catalog docs.
-- **`manifest.yaml` is the source of truth** for tool schema, constitution, requirements, `env_vars`, and `issuer`.
-- **`issuer`**: `name` and `email` required; `github` and `org` optional. Real values only in `skills/` (not template placeholders).
-- **`card.json`**: When present, `issuer` must match manifest `name` and `email`.
-- **Catalog**: Add or update `docs/skills/<skill_name>.md` (ID, Issuer) and a row in `docs/skills/README.md`.
-- **Categories**: Use an existing top-level folder under `skills/` (`compliance`, `data_engineering`, `finance`, `office`, `optimization`) or propose a new category in the issue before inventing one.
-- **Version bumps**: Do not bump `pyproject.toml` or package version in skill-only PRs unless the issue or a maintainer requests it.
-- **Logic**: Deterministic Python in `skill.py`; prompts and persona belong in `instructions.md`, not embedded as generated code paths.
-- **Secrets**: Never commit API keys; document `env_vars` in the manifest.
+- Bundle: `manifest.yaml`, `skill.py`, `instructions.md`, `card.json`, `test_skill.py`, plus catalog docs
+- `manifest.yaml` is source of truth for schema, constitution, `requirements`, `env_vars`, and `issuer`
+- `issuer.name` and `issuer.email` required; `github` and `org` optional; no template placeholders in registry paths
+- `card.json` issuer must match manifest `name` and `email` when present
+- Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
+- Categories: `compliance`, `data_engineering`, `finance`, `office`, `optimization`—propose new ones in the issue first
+- Do not bump `pyproject.toml` version in skill-only PRs unless requested
+- Logic in `skill.py`; prompts and persona in `instructions.md`
+- Never commit secrets; document `env_vars` in the manifest
 
 ### Core framework (`skillware/core/`)
 
-- Changes affect all consumers; require a framework feature issue and tests in `tests/`.
-- Do not change `loader.py` unless the issue requires it; issuer metadata is not passed into LLM tool schemas today.
-- Keep adapters aligned with documented usage guides (`docs/usage/`).
+- Require a framework feature issue; add tests under `tests/`
+- Do not change `loader.py` unless the issue requires it
+- Issuer metadata is not passed into LLM tool schemas today
+- Update `docs/usage/` when adapter behavior changes
 
 ### Documentation
 
-- Fix broken relative links when you move or rename files.
-- Skill docs live under `docs/skills/`; philosophy and architecture under `docs/introduction.md`.
-- Testing commands belong in [TESTING.md](../TESTING.md); link rather than duplicate long command lists.
+- Fix broken links when you move files
+- Link to [TESTING.md](../TESTING.md) instead of duplicating long command lists
 
-### Pull requests
+### Conduct
 
-- Use the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md).
-- Skill-specific checklist items apply only when adding or changing files under `skills/`.
-- Follow [Agent Code of Conduct](../../CODE_OF_CONDUCT.md) for deterministic, safe behavior.
+- Follow the [Agent Code of Conduct](../../CODE_OF_CONDUCT.md)
 
 ---
 
 ## Verification checklists by contribution type
 
-Use the checklist that matches your issue during Stage 5.
+Complete the checklist that matches your issue during Stage 5.
 
 ### New or updated skill
 
-- [ ] Directory: `skills/<category>/<skill_name>/`
-- [ ] `manifest.yaml`: `name`, `version`, `description`, `parameters`, `constitution`, `issuer` (real `name` + `email`)
-- [ ] `skill.py`: deterministic, JSON-serializable returns, errors handled without crashing the agent
-- [ ] `instructions.md`: when to use the tool, how to interpret output, limitations
-- [ ] `card.json`: UI fields; `issuer` matches manifest
-- [ ] `test_skill.py`: passes locally
-- [ ] `docs/skills/<skill_name>.md` and row in `docs/skills/README.md`
+- [ ] `skills/<category>/<skill_name>/` exists with full bundle
+- [ ] `manifest.yaml`: `name`, `version`, `description`, `parameters`, `constitution`, real `issuer`
+- [ ] `skill.py`: deterministic, JSON-serializable returns, safe error handling
+- [ ] `instructions.md`: when to use, how to interpret output, limitations
+- [ ] `card.json`: `issuer` matches manifest
+- [ ] `test_skill.py` passes
+- [ ] `docs/skills/<skill_name>.md` and catalog row in `docs/skills/README.md`
 - [ ] `pytest tests/test_skill_issuer.py` passes
-- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps documented)
-- [ ] No template placeholders under `skills/`
-- [ ] PR template skill section completed
+- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` works or deps are documented
+- [ ] No placeholders under `skills/`
+- [ ] PR skill section completed
 
 ### Documentation only
 
-- [ ] All acceptance criteria in the issue addressed
-- [ ] Links valid (especially `docs/skills/`, `CONTRIBUTING.md`, usage guides)
-- [ ] Tone matches surrounding docs; no emojis
-- [ ] No unrelated code changes unless required for accuracy
-- [ ] PR marked as doc change; skill checklist skipped
+- [ ] All issue acceptance criteria met
+- [ ] Links valid
+- [ ] No emojis; tone matches repo
+- [ ] No unrelated code changes
+- [ ] PR marked as documentation; skill checklist omitted
 
 ### Core framework
 
-- [ ] Issue approved for framework work
-- [ ] Changes confined to `skillware/` and relevant `tests/`
-- [ ] New or updated unit tests for behavior changes
+- [ ] Framework issue approved
+- [ ] Changes in `skillware/` and relevant `tests/`
 - [ ] `pytest tests/` passes
-- [ ] Usage docs updated if public API or adapter behavior changed
-- [ ] No breaking changes without issue discussion
+- [ ] Usage docs updated if API changed
+- [ ] No undeclared breaking changes
 
 ### Bug fix
 
-- [ ] Reproduction understood and linked to issue
-- [ ] Fix is minimal and targeted
-- [ ] Regression test added when feasible
-- [ ] `pytest` and `flake8` pass
-- [ ] No unrelated refactors
+- [ ] Reproduction understood
+- [ ] Minimal fix
+- [ ] Regression test when feasible
+- [ ] `flake8` and `pytest` pass
 
 ### Good first issue
 
-- [ ] Read issue labels and acceptance criteria literally
-- [ ] Ask for clarification in the issue if scope is ambiguous
-- [ ] Same verification as the underlying type (docs, test, or small code fix)
+- [ ] Criteria read literally
+- [ ] Clarification requested in issue if scope is unclear
+- [ ] Checklist for underlying type applied
 
 ---
 
-## Starter prompts
+## Self-check protocol (use between stages)
 
-Copy and adapt these in your assistant. Replace placeholders.
+Run this internal dialogue before you hand off to your operator.
 
-### Analysis (Stage 2)
+**After Stage 2 (analysis)**
 
-```text
-You are helping me contribute to the Skillware repository (ARPAHLS/skillware).
+- Did I read CONTRIBUTING and the full issue?
+- Did I list out-of-scope items explicitly?
+- Did I avoid writing code?
 
-Read CONTRIBUTING.md and docs/contributing/ai_native_workflow.md.
-Read GitHub issue #<NUMBER>: <URL or paste body>.
+**After Stage 4 (implementation)**
 
-Produce an analysis with:
-1. Problem statement and acceptance criteria
-2. Affected files (existing and new)
-3. Caveats (tests, docs, CI, security)
-4. Up to three implementation options with trade-offs
-5. Recommended approach and explicit out-of-scope items
+- Does every changed file serve the approved plan?
+- Did I run or request black, flake8, and pytest?
+- Are registry skills free of template placeholders?
 
-Do not write code yet.
-```
+**After Stage 5 (verification)**
 
-### Implementation (Stage 4)
+- Can I map each acceptance criterion to a diff hunk or test?
+- Did I complete the right checklist section?
+- Is the proposed commit message imperative and emoji-free?
 
-```text
-Approved plan for issue #<NUMBER>:
+**Before Stage 7 (PR)**
 
-<paste your approved plan>
-
-Implement only what the plan describes. Match repository conventions.
-After editing, tell me which commands to run for black, flake8, and pytest.
-```
-
-### Pre-PR audit (Stage 5)
-
-```text
-Pre-PR audit for issue #<NUMBER> on branch <branch-name>.
-
-Compare the current diff to the issue acceptance criteria and the
-verification checklist for <skill | docs | framework | bug> contributions.
-
-List: missing items, unrelated files, placeholder text, emojis,
-broken links, and suggested commit message (no emojis).
-
-I will run pytest and flake8 locally; remind me of the exact commands.
-```
+- Does the PR description explain why?
+- Did I link the issue with `Fixes` or `Refs`?
+- Are PR template checkboxes accurate—not copy-pasted unchecked defaults?
 
 ---
 
@@ -364,3 +329,7 @@ I will run pytest and flake8 locally; remind me of the exact commands.
 - [Agent Code of Conduct](../../CODE_OF_CONDUCT.md)
 - [Pull request template](../../.github/PULL_REQUEST_TEMPLATE.md)
 - [Skill library](../skills/README.md)
+
+---
+
+You belong in this ecosystem. Ship work you can defend in review: small scope, clear analysis, deterministic skills, and honest test results. That is how you help Skillware grow—and how you grow with it.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -102,5 +102,5 @@ Skillware is designed to be the "Standard Library" for all agents.
 **Next Steps:**
 *   Explore the [Skill Library](skills/README.md)
 *   Read [How to Contribute](../CONTRIBUTING.md) (skills, docs, framework, and bugs)
-*   Follow the [AI-Native Contribution Workflow](contributing/ai_native_workflow.md) when using coding assistants
+*   If you are a contributing agent, follow the [Agent Contribution Workflow](contributing/ai_native_workflow.md)
 


### PR DESCRIPTION
## Description

The agent contribution guide was written mainly for human operators supervising AI tools. This PR rewrites it so **contributing agents** are the primary audience: direct welcome, second-person operating instructions, and stage-by-stage duties (analyze, wait for operator approval, implement, verify, support PR/CI).

Also updates links in `CONTRIBUTING.md`, `README.md`, and `docs/introduction.md` to **Agent Contribution Workflow**.

No changes to `skills/`, `skillware/core/`, or runtime behavior.

### Type of Change

- [x] Doc Fix: Documentation Update
- [ ] Skill Proposal: New Skill
- [ ] Bug Report Fix
- [ ] Framework Feature / RFC Updates

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] Documentation-only; paths and links reviewed manually.

## New or updated skill

Not applicable.

## Constitution & Safety

Not applicable.

## Related Issues

Follow-up to #57 (agent-directed workflow refinement).