### PR TITLE
Add generic API keys guide for skills requiring external calls.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # API Keys for Skillware
-# Place this file in the root directory as .env
+# Copy to `.env` in the repository root. See docs/usage/api_keys.md for setup,
+# security, cloud/CI patterns, and how skill env names relate to your deployment.
 
 # Ethereum Interaction (Required for Wallet Screening)
 # Get key: https://etherscan.io/apis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 
 **Optional but common:**
 
-- `env_vars` — API keys and configuration (never hardcode secrets in `skill.py`)
+- `env_vars` — API keys and configuration (never hardcode secrets in `skill.py`); document the same names on the skill catalog page and link to [API keys for skills](docs/usage/api_keys.md)
 - `category`, `outputs`, `presentation` — when they clarify the skill contract
 
 **Example:**
@@ -234,6 +234,7 @@ The primary guide for the host LLM.
 - Human-readable documentation linked from the [Skill Library](docs/skills/README.md).
 - Include **ID** and **Issuer** near the top (for example linked GitHub handle and optional org).
 - Describe capabilities, prerequisites, arguments, and limitations.
+- If the skill calls external services, list its environment variables in a short table and link to [API keys for skills](docs/usage/api_keys.md). Do not duplicate the full setup guide on the skill page.
 
 ### 7. Registry index row
 
@@ -294,6 +295,7 @@ Skill IDs follow `category/skill_name` and should match the path under `skills/`
 
 | Document | Purpose |
 | :--- | :--- |
+| [API keys for skills](docs/usage/api_keys.md) | Configuring credentials for skills that call external services |
 | [Agent Contribution Workflow](docs/contributing/ai_native_workflow.md) | Workflow written for contributing agents; operators supervise |
 | [TESTING.md](docs/TESTING.md) | Black, Flake8, Pytest, local CI parity |
 | [Agent Code of Conduct](CODE_OF_CONDUCT.md) | Behavioral expectations for humans and agents |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ print(response.text)
 *   **[Usage Guide: Gemini](docs/usage/gemini.md)**: Integration with Google's GenAI SDK.
 *   **[Usage Guide: Claude](docs/usage/claude.md)**: Integration with Anthropic's SDK.
 *   **[Usage Guide: Ollama](docs/usage/ollama.md)**: Native integration for local models via Ollama.
+*   **[API Keys for Skills](docs/usage/api_keys.md)**: Environment variables, cloud/CI setup, and security for skills that call external APIs.
 *   **[Skill Library](docs/skills/README.md)**: Available capabilities.
 
 ## Contributing

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -26,6 +26,14 @@ The system prompt teaches the main Agent to:
 *   **In-Memory Caching**: The 1MB corpus is cached on the first run, delivering subsequent RAG lookups in **~1.7ms**.
 *   **Weighted Surgical Router**: Instead of a "shotgun" match, the router uses a weighted scoring system (Mentions > Keywords > collisions) and throttles retrieval to the **Top 10** most relevant Articles to prevent context window asphyxiation.
 
+## Environment
+
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `GOOGLE_API_KEY` | Yes (evaluator / Gemini paths) | Google Generative AI used by the built-in evaluator and RAG flows |
+
+Configure values per [API keys for skills](../usage/api_keys.md).
+
 ## Integration & Configuration
 
 This skill is designed for high-performance agentic loops without relying on opaque native tool APIs. 

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -30,12 +30,13 @@ The system prompt teaches the internal mapping engine to:
 
 ## 💻 Integration Guide
 
-### Environment Variables
-You must provide an Anthropic API key for the semantic mapping engine.
+### Environment
 
-```bash
-ANTHROPIC_API_KEY="sk-ant-..."
-```
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `ANTHROPIC_API_KEY` | Yes | Claude API for semantic field mapping |
+
+Configure values per [API keys for skills](../usage/api_keys.md).
 
 ### Usage (Skillware Loader)
 

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -26,14 +26,15 @@ The system instructions emphasize boundary-pushing data generation. It prohibits
 
 ## Integration Guide
 
-### Environment Variables
-Depending on the requested `model_provider`, ensure you have the necessary API key exported:
+### Environment
 
-```bash
-ANTHROPIC_API_KEY="sk-ant-..."
-GOOGLE_API_KEY="AIzaSy..."
-# Or run an Ollama server locally on default port 11434
-```
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `GOOGLE_API_KEY` | When `model_provider` is `gemini` | Google Generative AI for generation |
+| `ANTHROPIC_API_KEY` | When `model_provider` is `anthropic` | Anthropic API for generation |
+| (none) | When `model_provider` is `ollama` | Uses local Ollama on the default port |
+
+Configure values per [API keys for skills](../usage/api_keys.md).
 
 ### Usage (Skillware Loader)
 

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -43,6 +43,14 @@ A local-first compliance guardrail that checks whether an intended automated act
 * `CAUTION`: the site may allow access, but only with conditions such as API usage, permission, or strict rate limits.
 * `INSUFFICIENT_EVIDENCE`: the evaluator could not find enough trustworthy evidence to safely approve the action.
 
+## Environment
+
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `GOOGLE_API_KEY` | No | Optional LLM clause evaluator when `use_llm_evaluator` is enabled with a Gemini provider |
+
+Configure values per [API keys for skills](../usage/api_keys.md). The core policy checks do not require a cloud API key.
+
 ## Example Usage (Direct)
 
 ```python

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -44,12 +44,16 @@ Tools to keep the knowledge fresh.
 
 ## 💻 Integration Guide
 
-### Environment Variables
-You must provide an Etherscan API key.
+### Environment
 
-```bash
-ETHERSCAN_API_KEY="your_key_here"
-```
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `ETHERSCAN_API_KEY` | Yes | Etherscan API for transaction history |
+| `COINGECKO_API_KEY` | No | CoinGecko pricing (free tier if unset) |
+
+Configure values per [API keys for skills](../usage/api_keys.md). This skill reads the names declared in `skills/finance/wallet_screening/manifest.yaml`.
+
+For Gemini agent loops that invoke this skill, you also need `GOOGLE_API_KEY` in your environment (see [Gemini usage](../usage/gemini.md)).
 
 ### Usage (Gemini 2.0)
 

--- a/docs/usage/api_keys.md
+++ b/docs/usage/api_keys.md
@@ -1,0 +1,165 @@
+# API Keys for Skills
+
+Many Skillware skills call external services (block explorers, model APIs, and similar). Those skills read credentials from **environment variables** with fixed names declared in each skill's `manifest.yaml` under `env_vars`. This page explains how to configure keys safely. It does not list every skill in the registry; each [skill documentation page](../skills/README.md) states which variables that skill expects.
+
+---
+
+## Navigation
+
+- [Skill keys vs agent keys](#skill-keys-vs-agent-keys)
+- [Local development](#local-development)
+- [Cloud and CI](#cloud-and-ci)
+- [Secret managers](#secret-managers)
+- [Variable names and custom deployments](#variable-names-and-custom-deployments)
+- [Security practices](#security-practices)
+- [Illustrative examples](#illustrative-examples)
+
+---
+
+## Skill keys vs agent keys
+
+| Kind | Who consumes it | Typical variables | Where documented |
+| :--- | :--- | :--- | :--- |
+| **Skill runtime keys** | `skill.py` when you call `execute()` | Names in `manifest.yaml` `env_vars` | Skill's catalog page + manifest |
+| **Agent / LLM keys** | Your chat client (Gemini, Claude, OpenAI, and similar) | `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`, and similar | Provider usage guides under `docs/usage/` |
+
+A single workflow may need both: for example, a skill that screens wallets may require `ETHERSCAN_API_KEY`, while your Gemini agent loop separately needs `GOOGLE_API_KEY` to run the model. Configure each name the code actually reads.
+
+---
+
+## Local development
+
+### `.env` file (recommended)
+
+Copy the repository root template and fill in values:
+
+```bash
+cp .env.example .env
+```
+
+Skillware can load `.env` into the process environment before skills run:
+
+```python
+from skillware.core.env import load_env_file
+
+load_env_file()  # reads `.env` in the current working directory by default
+```
+
+Run your script from the repository root (or pass an explicit path: `load_env_file("/path/to/.env")`).
+
+Add `.env` to `.gitignore` (already ignored in this repository). Never commit real keys.
+
+### Shell export
+
+```bash
+export ETHERSCAN_API_KEY="your_key"
+python your_script.py
+```
+
+Exports apply only to the current shell session.
+
+---
+
+## Cloud and CI
+
+Inject the same variable **names** the skill expects; do not rename them unless you also provide a mapping layer (see below).
+
+**GitHub Actions (example):**
+
+```yaml
+env:
+  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+```
+
+**Docker (example):**
+
+```bash
+docker run --env-file .env your-image python examples/gemini_wallet_check.py
+```
+
+**Containers / Kubernetes:** mount secrets as environment variables with keys matching `manifest.yaml` (for example `ETHERSCAN_API_KEY`), not arbitrary secret aliases, unless your deployment template maps them.
+
+---
+
+## Secret managers
+
+Pattern: fetch the secret at startup, then set `os.environ["EXPECTED_NAME"]` before loading or executing skills.
+
+| Platform | Approach |
+| :--- | :--- |
+| **AWS Secrets Manager** | Retrieve secret in app init; `os.environ["ETHERSCAN_API_KEY"] = value` |
+| **GCP Secret Manager** | Access version payload; assign to the env name the skill documents |
+| **Azure Key Vault** | Resolve secret; export under the manifest variable name |
+
+Keep secret-fetching code in your application layer, not inside contributed skills. Skills should continue to read standard environment variable names for portability.
+
+---
+
+## Variable names and custom deployments
+
+Skills are written against **specific environment variable names** (for example `ETHERSCAN_API_KEY`). The manifest `env_vars` section documents meaning and whether each key is required.
+
+If your organization uses different secret names:
+
+1. **Preferred:** Map at deploy time so the process still exposes the name the skill expects:
+
+   ```bash
+   export ETHERSCAN_API_KEY="$(vault read -field=key secret/etherscan)"
+   ```
+
+2. **Alternative:** If the skill accepts a configuration dict (some skills read `self.config` as a fallback), pass the key there only when documented on the skill page. Do not assume all skills support custom config keys.
+
+3. **Avoid:** Renaming the variable in `.env` to `MY_ETHERSCAN_KEY` without exporting `ETHERSCAN_API_KEY`—the skill will behave as if the key is missing.
+
+When contributing a new skill, declare every external credential under `env_vars` in `manifest.yaml` and list the same names on the skill's documentation page with a link to this guide.
+
+---
+
+## Security practices
+
+- Never hardcode API keys in `skill.py`, notebooks, or documentation.
+- Never commit `.env`, key files, or CI logs containing secrets.
+- Use least-privilege keys (read-only or scoped APIs where providers allow it).
+- Rotate keys if they are exposed; revoke compromised keys at the provider.
+- Prefer secret managers or platform secret stores for production, not plaintext files on servers.
+- Do not print environment variable values in skill output or logs.
+
+Report security concerns per [SECURITY.md](../../SECURITY.md).
+
+---
+
+## Illustrative examples
+
+These patterns apply to many skills; see individual skill pages for exact variable names and requirements.
+
+### External data API (required key)
+
+A skill that fetches on-chain data may require a provider key before `execute()` returns useful results. Set the name from its manifest (illustrative):
+
+```bash
+export ETHERSCAN_API_KEY="your_etherscan_key"
+```
+
+If the key is missing, the skill should return a structured error rather than crash the host agent.
+
+### Optional provider key
+
+Some skills support a free tier when a key is absent and upgraded limits when present. The skill page and `env_vars.required` field state whether the key is optional.
+
+### Optional LLM path inside a skill
+
+Some skills optionally call a cloud model for one step (for example policy clause review). That path may require `GOOGLE_API_KEY` only when enabled via parameters such as `use_llm_evaluator: true`. The skill page lists when the key is needed.
+
+### Local-only skills
+
+Skills that talk only to `localhost` (for example a local Ollama instance) may not use API keys at all. No configuration is required beyond running the local service.
+
+---
+
+## Related documents
+
+- [.env.example](../../.env.example) — starter template at repository root
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — declaring `env_vars` for new skills
+- [Usage: Gemini](gemini.md) — agent-side `GOOGLE_API_KEY`
+- [Usage: Claude](claude.md) — agent-side `ANTHROPIC_API_KEY`
+- [Skill library](../skills/README.md) — per-skill environment requirements


### PR DESCRIPTION
## Description

Skills that call external APIs need a single place to learn how to set credentials safely. This PR adds a **generic** [API keys guide](docs/usage/api_keys.md) for local `.env`, shell, CI/Docker, and secret-manager patterns, plus security and env-name contracts (skills expect the names in `manifest.yaml`, not ad-hoc aliases).

Skill catalog pages no longer repeat full setup instructions; they use short **Environment** tables and link to the guide. `CONTRIBUTING.md`, `README.md`, and `.env.example` point to the same doc.

No changes under `skills/` or `skillware/core/`.

### Type of Change

- [x] Doc Fix: Documentation Update
- [ ] Skill Proposal / Bug Fix / Framework Feature

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] Documentation-only; markdown and links reviewed (no `flake8` / `pytest` required).

## New or updated skill

Not applicable — registry bundles unchanged. Five skill **docs** updated (`wallet_screening`, `tos_evaluator`, `pdf_form_filler`, `synthetic_generator`, `mica_module`) to replace inline key setup with env tables + link.

## Constitution & Safety

Documents secret handling (no hardcoding, `.gitignore`, rotation). No runtime behavior change.

## Related Issues

Fixes #55