### PR TITLE
Add OpenAI tool adapter to SkillLoader.

### DIFF
--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -1,4 +1,5 @@
 import os
+import re
 import yaml
 import json
 import importlib.util
@@ -125,6 +126,40 @@ class SkillLoader:
         parameters = manifest.get("parameters", {})
 
         return {"name": name, "description": description, "input_schema": parameters}
+
+    @staticmethod
+    def _sanitize_openai_tool_name(name: str) -> str:
+        """
+        OpenAI function names allow letters, digits, underscores, and hyphens (max 64 chars).
+        Manifest IDs such as compliance/tos_evaluator are normalized for the tools API.
+        """
+        if not name or not str(name).strip():
+            return "unknown_tool"
+        safe = re.sub(r"[^a-zA-Z0-9_-]", "_", str(name).replace("/", "_"))
+        safe = re.sub(r"_+", "_", safe).strip("_")
+        if not safe:
+            return "unknown_tool"
+        return safe[:64]
+
+    @staticmethod
+    def to_openai_tool(skill_bundle: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Converts a skill manifest to an OpenAI Chat Completions tool definition.
+        See: https://platform.openai.com/docs/guides/function-calling
+        """
+        manifest = skill_bundle.get("manifest", {})
+        raw_name = manifest.get("name", "unknown_tool")
+        description = manifest.get("description", "")
+        parameters = manifest.get("parameters", {})
+
+        return {
+            "type": "function",
+            "function": {
+                "name": SkillLoader._sanitize_openai_tool_name(raw_name),
+                "description": description,
+                "parameters": parameters,
+            },
+        }
 
     @staticmethod
     def to_ollama_prompt(skill_bundle: Dict[str, Any]) -> str:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -61,3 +61,36 @@ def test_to_claude_tool():
     tool = SkillLoader.to_claude_tool(dummy_bundle)
     assert tool["name"] == "test_claude_skill"
     assert tool["input_schema"]["type"] == "object"
+
+
+def test_sanitize_openai_tool_name():
+    assert (
+        SkillLoader._sanitize_openai_tool_name("compliance/tos_evaluator")
+        == "compliance_tos_evaluator"
+    )
+    assert SkillLoader._sanitize_openai_tool_name("wallet_screening") == "wallet_screening"
+    assert SkillLoader._sanitize_openai_tool_name("") == "unknown_tool"
+    assert SkillLoader._sanitize_openai_tool_name("a" * 80).startswith("a")
+    assert len(SkillLoader._sanitize_openai_tool_name("a" * 80)) == 64
+
+
+def test_to_openai_tool():
+    dummy_bundle = {
+        "manifest": {
+            "name": "compliance/tos_evaluator",
+            "description": "Evaluate site policy.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "target_url": {"type": "string", "description": "URL"}
+                },
+                "required": ["target_url"],
+            },
+        }
+    }
+    tool = SkillLoader.to_openai_tool(dummy_bundle)
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "compliance_tos_evaluator"
+    assert tool["function"]["description"] == "Evaluate site policy."
+    assert tool["function"]["parameters"]["type"] == "object"
+    assert "target_url" in tool["function"]["parameters"]["properties"]


### PR DESCRIPTION
## Description

Adds native OpenAI Chat Completions support to `SkillLoader` via `to_openai_tool()`, mapping each skill manifest to the standard `{"type": "function", "function": {...}}` tool shape with JSON Schema `parameters`.

Manifest tool IDs with slashes (for example `compliance/tos_evaluator`) are normalized to OpenAI-safe function names (for example `compliance_tos_evaluator`) through `_sanitize_openai_tool_name()`. Unit tests cover adapter structure and name sanitization.

Unblocks #20 (OpenAI usage guide). DeepSeek remains a separate adapter (#66).

### Type of Change

- [x] Framework Feature / RFC Updates (`loader.py`)
- [ ] Doc Fix / Skill Proposal / Bug Fix

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] `pytest tests/test_loader.py` and `flake8` on changed files pass locally.

## New or updated skill

Not applicable.

## Constitution & Safety

Adapter-only change; no skill execution or constitution changes. Callers must match tool results using the **sanitized** function name returned by `to_openai_tool()`.

## Related Issues

Fixes #1