### PR TITLE
Add OpenAI usage guide and reference example.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 # Get key: https://etherscan.io/apis
 ETHERSCAN_API_KEY="your_etherscan_key_here"
 
-# AI Models (At least one required)
+# AI Models (At least one required for agent loops)
 GOOGLE_API_KEY="your_gemini_key_here"
 ANTHROPIC_API_KEY="sk-ant-..."
+OPENAI_API_KEY="sk-..."

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ print(response.text)
 *   **[Testing Guidelines](docs/TESTING.md)**: Instructions for validating skills and checking local coverage.
 *   **[Usage Guide: Gemini](docs/usage/gemini.md)**: Integration with Google's GenAI SDK.
 *   **[Usage Guide: Claude](docs/usage/claude.md)**: Integration with Anthropic's SDK.
+*   **[Usage Guide: OpenAI](docs/usage/openai.md)**: Integration with OpenAI Chat Completions tool calling.
 *   **[Usage Guide: Ollama](docs/usage/ollama.md)**: Native integration for local models via Ollama.
 *   **[API Keys for Skills](docs/usage/api_keys.md)**: Environment variables, cloud/CI setup, and security for skills that call external APIs.
 *   **[Skill Library](docs/skills/README.md)**: Available capabilities.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -66,7 +66,8 @@ This is Skillware's superpower. Every model (Gemini, Claude, GPT) speaks a diffe
 The `SkillLoader` acts as an adapter.
 *   `SkillLoader.to_gemini_tool(skill)` -> Transmutes the manifest into Gemini's format.
 *   `SkillLoader.to_claude_tool(skill)` -> Transmutes the manifest into Claude's format.
-*   `SkillLoader.to_ollama_tool(skill)` -> Transmutes the manifest into Ollama/OpenAI's format.
+*   `SkillLoader.to_openai_tool(skill)` -> Transmutes the manifest into OpenAI's tool format.
+*   `SkillLoader.to_ollama_prompt(skill)` -> Textual tool description for Ollama prompt-based loops.
 
 ### Step 3: Injection
 When you initialize your agent, you pass the skill's **Instructions** into the System Prompt.
@@ -95,7 +96,7 @@ Skillware is designed to be the "Standard Library" for all agents.
 | **Google Gemini** | Native `google.generativeai` support. Automatic type mapping. |
 | **Anthropic Claude** | Native `anthropic` support. XML/JSON handling. |
 | **Ollama** | Native `ollama` Python client support. Fully local JSON handling. |
-| **OpenAI GPT** | (Planned) JSON Schema adapter. |
+| **OpenAI GPT** | `to_openai_tool()`; Chat Completions tool calling. |
 | **Local LLaMA** | (Planned) GBNF Grammar generation from manifests. |
 
 ---

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -82,6 +82,10 @@ Use the skill through `SkillLoader.to_gemini_tool(...)` and pass the skill instr
 
 Use the skill through `SkillLoader.to_claude_tool(...)` and return the structured result back to Claude as a tool result. See `examples/claude_tos_evaluator.py`.
 
+## OpenAI Example
+
+Use `SkillLoader.to_openai_tool(...)` and match tool calls on the sanitized function name (for example `compliance_tos_evaluator`). See `examples/openai_tos_evaluator.py`.
+
 ## Ollama Example
 
 Use the text-based prompt adapter from `SkillLoader.to_ollama_prompt(...)` and execute the skill locally when the model emits a JSON tool block. See `examples/ollama_tos_evaluator.py`.

--- a/docs/usage/api_keys.md
+++ b/docs/usage/api_keys.md
@@ -162,4 +162,5 @@ Skills that talk only to `localhost` (for example a local Ollama instance) may n
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — declaring `env_vars` for new skills
 - [Usage: Gemini](gemini.md) — agent-side `GOOGLE_API_KEY`
 - [Usage: Claude](claude.md) — agent-side `ANTHROPIC_API_KEY`
+- [Usage: OpenAI](openai.md) — agent-side `OPENAI_API_KEY`
 - [Skill library](../skills/README.md) — per-skill environment requirements

--- a/docs/usage/openai.md
+++ b/docs/usage/openai.md
@@ -1,0 +1,140 @@
+# Integration Guide: OpenAI (ChatGPT)
+
+Skillware supports OpenAI Chat Completions tool calling via `SkillLoader.to_openai_tool()`. Use the official `openai` Python SDK.
+
+For agent credentials, set `OPENAI_API_KEY` (see [API keys for skills](api_keys.md) for local and CI setup). Skills that call external APIs during `execute()` may require additional variables documented on each skill page.
+
+---
+
+## Quick snippet
+
+```python
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+from openai import OpenAI
+
+load_env_file()
+
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+tool = SkillLoader.to_openai_tool(bundle)
+
+client = OpenAI()
+# Pass bundle["instructions"] as the system message when you start the chat.
+```
+
+---
+
+## How it works
+
+### 1. Schema adaptation
+
+`manifest.yaml` stores parameters as standard JSON Schema (`type`, `properties`, `required`). `to_openai_tool()` wraps them in OpenAI's tool shape:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "...",
+    "description": "...",
+    "parameters": { }
+  }
+}
+```
+
+No type-case conversion is required (unlike Gemini).
+
+### 2. Function name sanitization
+
+OpenAI function names must match `[a-zA-Z0-9_-]` and are limited to 64 characters. Manifest IDs with slashes are normalized automatically:
+
+| Manifest `name` | OpenAI `function.name` |
+| :--- | :--- |
+| `compliance/tos_evaluator` | `compliance_tos_evaluator` |
+| `wallet_screening` | `wallet_screening` |
+
+In your tool loop, compare `tool_call.function.name` to `tool["function"]["name"]` from `to_openai_tool()`, not necessarily the raw manifest string.
+
+### 3. System message (the Mind)
+
+Pass `bundle["instructions"]` as the `system` role content (or equivalent in your orchestration layer). That teaches the model when and how to invoke the skill, not only what parameters exist.
+
+### 4. Tool calling loop
+
+OpenAI returns `tool_calls` on the assistant message. You execute `skill.execute(...)`, append the assistant message and a `tool` role message with the result, then call `chat.completions.create` again until the model responds without tools.
+
+See `examples/openai_tos_evaluator.py` for a full loop with `compliance/tos_evaluator`.
+
+---
+
+## Complete example (manual loop)
+
+```python
+import json
+import os
+
+from openai import OpenAI
+
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+SkillClass = bundle["module"].TOSEvaluatorSkill
+skill = SkillClass()
+
+openai_tool = SkillLoader.to_openai_tool(bundle)
+tool_name = openai_tool["function"]["name"]
+
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+messages = [
+    {"role": "system", "content": bundle["instructions"]},
+    {
+        "role": "user",
+        "content": "Check whether automated crawling is allowed for https://example.com/docs.",
+    },
+]
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=messages,
+    tools=[openai_tool],
+)
+
+while response.choices[0].message.tool_calls:
+    assistant_message = response.choices[0].message
+    tool_call = assistant_message.tool_calls[0]
+
+    if tool_call.function.name != tool_name:
+        break
+
+    args = json.loads(tool_call.function.arguments)
+    result = skill.execute(args)
+
+    messages.append(assistant_message)
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": json.dumps(result),
+        }
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=messages,
+        tools=[openai_tool],
+    )
+
+print(response.choices[0].message.content)
+```
+
+---
+
+## Related documents
+
+- [API keys for skills](api_keys.md)
+- [Usage: Gemini](gemini.md)
+- [Usage: Claude](claude.md)
+- [Usage: Ollama](ollama.md) (separate prompt-based integration)
+- [Skill library](../skills/README.md)

--- a/examples/openai_tos_evaluator.py
+++ b/examples/openai_tos_evaluator.py
@@ -1,0 +1,71 @@
+import json
+import os
+
+from openai import OpenAI
+
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+print(f"Loaded Skill: {bundle['manifest']['name']}")
+
+TOSEvaluatorSkill = bundle["module"].TOSEvaluatorSkill
+tos_skill = TOSEvaluatorSkill()
+
+openai_tool = SkillLoader.to_openai_tool(bundle)
+tool_name = openai_tool["function"]["name"]
+print(f"OpenAI tool name: {tool_name}")
+
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+user_query = (
+    "Before an agent crawls https://hackernoon.com/tagged/ai for research, "
+    "check whether that appears allowed."
+)
+print(f"User: {user_query}")
+
+messages = [
+    {"role": "system", "content": bundle["instructions"]},
+    {"role": "user", "content": user_query},
+]
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=messages,
+    tools=[openai_tool],
+)
+
+while response.choices[0].message.tool_calls:
+    assistant_message = response.choices[0].message
+    tool_call = assistant_message.tool_calls[0]
+
+    if tool_call.function.name != tool_name:
+        print(f"Unexpected tool: {tool_call.function.name}")
+        break
+
+    fn_args = json.loads(tool_call.function.arguments)
+    print(f"OpenAI requested tool: {tool_call.function.name}")
+    print(f"Input: {fn_args}")
+
+    result = tos_skill.execute(fn_args)
+    print(json.dumps(result, indent=2))
+
+    messages.append(assistant_message)
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": json.dumps(result),
+        }
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=messages,
+        tools=[openai_tool],
+    )
+
+print("\nFinal Response:")
+print(response.choices[0].message.content or "")


### PR DESCRIPTION
## Description

Documents how to use Skillware with **OpenAI Chat Completions** after #1 added `to_openai_tool()`.

- **`docs/usage/openai.md`** — Load skill, adapt manifest, inject `instructions` as system context, run a manual tool loop, and match **sanitized** function names (e.g. `compliance_tos_evaluator`).
- **`examples/openai_tos_evaluator.py`** — Runnable reference for `compliance/tos_evaluator`.
- Links from **README**, **`docs/introduction.md`** (OpenAI row + correct Ollama adapter name), **`api_keys.md`**, **`tos_evaluator`** skill doc, and **`.env.example`** (`OPENAI_API_KEY`).

No changes to `skillware/core/` or registry skills.

### Type of Change

- [x] Doc Fix: Documentation Update
- [ ] Framework Feature / Skill Proposal / Bug Fix

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] `flake8` on `examples/openai_tos_evaluator.py`; docs-only otherwise.

## New or updated skill

Not applicable (`skills/` unchanged). `docs/skills/tos_evaluator.md` gains an OpenAI example link only.

## Constitution & Safety

Not applicable.

## Related Issues

Fixes #20. Depends on #1 (`to_openai_tool`).