### PR TITLE
Document per-skill usage examples across providers.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,7 @@ The primary guide for the host LLM.
 - Include **ID** and **Issuer** near the top (for example linked GitHub handle and optional org).
 - Describe capabilities, prerequisites, arguments, and limitations.
 - If the skill calls external services, list its environment variables in a short table and link to [API keys for skills](docs/usage/api_keys.md). Do not duplicate the full setup guide on the skill page.
+- Add a **Usage Examples** section with runnable snippets for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). Follow [skill usage example template](docs/usage/skill_usage_template.md) and link to [usage guides](docs/usage/README.md) and [agent loops](docs/usage/agent_loops.md).
 
 ### 7. Registry index row
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ print(response.text)
 
 *   **[Core Logic & Philosophy](docs/introduction.md)**: Details on how Skillware decouples Logic, Cognition, and Governance.
 *   **[Testing Guidelines](docs/TESTING.md)**: Instructions for validating skills and checking local coverage.
+*   **[Usage guides](docs/usage/README.md)**: Provider adapters and navigation to integration docs.
+*   **[Agent loops](docs/usage/agent_loops.md)**: Shared load, tool-call, and `execute` pattern across providers.
 *   **[Usage Guide: Gemini](docs/usage/gemini.md)**: Integration with Google's GenAI SDK.
 *   **[Usage Guide: Claude](docs/usage/claude.md)**: Integration with Anthropic's SDK.
 *   **[Usage Guide: OpenAI](docs/usage/openai.md)**: Integration with OpenAI Chat Completions tool calling.

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -88,9 +88,9 @@ You must:
 
 | If the issue involves... | You must also inspect |
 | :--- | :--- |
-| New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py` |
+| New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present |
 | Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
-| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/` |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |
 | Good first issue | Issue labels and acceptance criteria—take them literally |
 
@@ -220,6 +220,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 - `issuer.name` and `issuer.email` required; `github` and `org` optional; no template placeholders in registry paths
 - `card.json` issuer must match manifest `name` and `email` when present
 - Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
+- On each catalog page, add a **Usage Examples** section (Gemini, Claude, OpenAI, DeepSeek, Ollama prompt mode) per [skill usage template](../usage/skill_usage_template.md). Keep provider mechanics in `docs/usage/`; put skill-specific paths, sample user messages, and `execute` payloads on the skill page.
 - Categories: `compliance`, `data_engineering`, `finance`, `office`, `optimization`—propose new ones in the issue first
 - Do not bump `pyproject.toml` version in skill-only PRs unless requested
 - Logic in `skill.py`; prompts and persona in `instructions.md`
@@ -236,6 +237,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 
 - Fix broken links when you move files
 - Link to [TESTING.md](../TESTING.md) instead of duplicating long command lists
+- Provider integration: [Usage guides index](../usage/README.md) and [agent loops](../usage/agent_loops.md). Per-skill copy-paste examples belong on `docs/skills/<skill_name>.md`, not repeated in full on every provider guide.
 
 ### Conduct
 
@@ -256,6 +258,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `card.json`: `issuer` matches manifest
 - [ ] `test_skill.py` passes
 - [ ] `docs/skills/<skill_name>.md` and catalog row in `docs/skills/README.md`
+- [ ] **Usage Examples** on the catalog page (all five providers per [skill usage template](../usage/skill_usage_template.md)); link to `docs/usage/` and list skill `env_vars` without duplicating [api_keys.md](../usage/api_keys.md)
 - [ ] `pytest tests/test_skill_issuer.py` passes
 - [ ] `SkillLoader.load_skill("<category>/<skill_name>")` works or deps are documented
 - [ ] No placeholders under `skills/`
@@ -267,7 +270,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] Links valid
 - [ ] No emojis; tone matches repo
 - [ ] No unrelated code changes
-- [ ] PR marked as documentation; skill checklist omitted
+- [ ] PR marked as documentation; skill checklist omitted unless `docs/skills/` or skill **Usage Examples** changed (then apply the Usage Examples bullet above)
 
 ### Core framework
 
@@ -326,6 +329,10 @@ Run this internal dialogue before you hand off to your operator.
 
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — contribution hub and skill standard
 - [TESTING.md](../TESTING.md) — Black, Flake8, Pytest
+- [Usage guides](../usage/README.md) — provider adapters (`to_gemini_tool`, `to_openai_tool`, etc.)
+- [Agent loops](../usage/agent_loops.md) — shared load / execute / tool-result pattern
+- [Skill usage example template](../usage/skill_usage_template.md) — what each skill catalog page must include
+- [API keys for skills](../usage/api_keys.md) — env setup (link from skill pages; do not duplicate)
 - [Agent Code of Conduct](../../CODE_OF_CONDUCT.md)
 - [Pull request template](../../.github/PULL_REQUEST_TEMPLATE.md)
 - [Skill library](../skills/README.md)

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -34,48 +34,106 @@ The system prompt teaches the main Agent to:
 
 Configure values per [API keys for skills](../usage/api_keys.md).
 
-## Integration & Configuration
+## Usage Examples
 
-This skill is designed for high-performance agentic loops without relying on opaque native tool APIs. 
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
-### Pure Cognitive Integration
+| Provider | Reference script |
+| :--- | :--- |
+| Gemini / RAG | `examples/mica_rag_flow.py` |
+| Claude | `examples/mica_claude_flow.py` |
+| Ollama | `examples/mica_ollama_flow.py` |
 
-This is the recommended pattern for Gemini, Claude, and Llama agents:
+Sample user message: *Can I issue a stablecoin backed by physical art under an e-money license?*
 
-1.  **Inject Manifest**: Pass the `manifest.yaml` and `instructions.md` as text into the System Prompt.
-2.  **Streaming Loop**: Enable streaming to observe the agent's "Thinking" turn as it identifies the need for RAG.
-3.  **Local Execution**: When the agent outputs the skill JSON, execute `mica_skill.execute()` locally and feed the results back to the agent.
-
-### Swapping Evaluator Models
-
-You can dynamically swap the internal evaluator model to another supported target using the `evaluator_model` parameter.
+### Direct execute
 
 ```python
 from skillware.core.loader import SkillLoader
 
-# 1. Load the Skill
-skill_bundle = SkillLoader.load_skill("compliance/mica_module")
-MiCAModuleSkill = skill_bundle['module'].MiCAModuleSkill
-
-# 2. Initialize
-validator = MiCAModuleSkill()
-
-# 3. Execute - With the Optional Evaluator Swapped Out!
-result = validator.execute({
+bundle = SkillLoader.load_skill("compliance/mica_module")
+skill = bundle["module"].MiCAModuleSkill()
+result = skill.execute({
     "user_prompt": "Can I issue a stablecoin backed by physical art under an e-money license?",
-    
-    # ---------------------------------------------
-    # Evaluator Engine Configuration Options
-    # ---------------------------------------------
-    "run_evaluator": True,                           # Enable the built-in grading loop
-    "evaluator_model": "gemini-1.5-pro-latest"       # Swap out the default flash-lite model!
+    "run_evaluator": True,
+    "evaluator_model": "gemini-2.5-flash",
 })
-
-# Access Policy Results
-print(f"Status: {result['policy_status']}")
-if result['policy_status'] == 'HIGH_RISK_DETECTED':
-    print(f"Holes: {result['gemini_evaluator_feedback']['holes_found']}")
+print(result["policy_status"])
 ```
+
+### Gemini
+
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/mica_module")
+skill = bundle["module"].MiCAModuleSkill()
+genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
+)
+# On function_call (name compliance/mica_module): skill.execute(dict(part.function_call.args))
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/mica_module")
+skill = bundle["module"].MiCAModuleSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# See examples/mica_claude_flow.py for the full loop
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/mica_module")
+skill = bundle["module"].MiCAModuleSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name (compliance_mica_module)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/mica_module")
+skill = bundle["module"].MiCAModuleSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "compliance/mica_module"`. See `examples/mica_ollama_flow.py` and [Ollama usage](../usage/ollama.md).
 
 ## Data Schema Output
 

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -38,26 +38,103 @@ The system prompt teaches the internal mapping engine to:
 
 Configure values per [API keys for skills](../usage/api_keys.md).
 
-### Usage (Skillware Loader)
+## Usage Examples
+
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
+
+| Provider | Reference script |
+| :--- | :--- |
+| Gemini | `examples/gemini_pdf_form_filler.py` |
+| Claude | `examples/claude_pdf_form_filler.py` |
+
+### Direct execute
 
 ```python
 from skillware.core.loader import SkillLoader
 
-# 1. Load the Skill
-skill_bundle = SkillLoader.load_skill("office/pdf_form_filler")
-PDFFormFillerSkill = skill_bundle['module'].PDFFormFillerSkill
-
-# 2. Initialize
-filler = PDFFormFillerSkill()
-
-# 3. Execute
+bundle = SkillLoader.load_skill("office/pdf_form_filler")
+filler = bundle["module"].PDFFormFillerSkill()
 result = filler.execute({
     "pdf_path": "/absolute/path/to/form.pdf",
-    "instructions": "Name: John Doe. Check the terms of service box."
+    "instructions": "Name: John Doe. Check the terms of service box.",
 })
-
-print(f"Filled PDF saved to: {result['output_path']}")
+print(result["output_path"])
 ```
+
+### Gemini
+
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("office/pdf_form_filler")
+skill = bundle["module"].PDFFormFillerSkill()
+genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
+)
+# User: "Fill /path/to/form.pdf — name John Doe, check the terms box."
+# On function_call (name pdf_form_filler): skill.execute(dict(part.function_call.args))
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("office/pdf_form_filler")
+skill = bundle["module"].PDFFormFillerSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# On tool_use (name pdf_form_filler): skill.execute(tool_use.input), return tool_result
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("office/pdf_form_filler")
+skill = bundle["module"].PDFFormFillerSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name to openai_tool["function"]["name"] (pdf_form_filler)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("office/pdf_form_filler")
+skill = bundle["module"].PDFFormFillerSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "pdf_form_filler"`. See [Ollama usage](../usage/ollama.md).
 
 ## 📊 Data Schema
 

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -55,14 +55,104 @@ The `micro-f1-mask` model detects a variety of entities, including but not limit
 - Crypto Wallets (`[CRYPTO_ADDRESS]`)
 - Identification Numbers (SSN, Passports, etc.)
 
-## Example Usage
+## Usage Examples
 
-Input text:
-```text
-Hello John Doe, your wallet 0xabc123 has been verified.
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). Skill execution uses local Ollama (`arpacorp/micro-f1-mask`); no cloud agent key required for the masker itself.
+
+Reference flow: `examples/pii_guardrail_flow.py`.
+
+Sample user message: *Mask PII in: "Hello John Doe, your wallet 0xabc123 has been verified."*
+
+### Direct execute
+
+```python
+from skillware.core.loader import SkillLoader
+
+bundle = SkillLoader.load_skill("compliance/pii_masker")
+skill = bundle["module"].PIIMaskerSkill()
+result = skill.execute({
+    "text": "Hello John Doe, your wallet 0xabc123 has been verified.",
+    "mode": "mask",
+})
+print(result["sanitized_text"])
 ```
 
-JSON Return (mask mode):
+### Gemini
+
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/pii_masker")
+skill = bundle["module"].PIIMaskerSkill()
+genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
+)
+# On function_call (name compliance/pii_masker): skill.execute(...) before sending user text upstream
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/pii_masker")
+skill = bundle["module"].PIIMaskerSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# On tool_use (name compliance/pii_masker): skill.execute(tool_use.input)
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/pii_masker")
+skill = bundle["module"].PIIMaskerSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name (compliance_pii_masker)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/pii_masker")
+skill = bundle["module"].PIIMaskerSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "compliance/pii_masker"`. Ensure `ollama run arpacorp/micro-f1-mask` is available. See [Ollama usage](../usage/ollama.md).
+
+### Sample output (mask mode)
+
 ```json
 {
   "sanitized_text": "Hello [PERSON_1], your wallet [CRYPTO_ADDRESS] has been verified.",

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -20,26 +20,99 @@ This is critical for complex agents facing strict token constraints or high LLM 
 *   `new_tokens` (integer): The approximate new length.
 *   `tokens_saved` (integer): The absolute number of tokens removed.
 
-## Example Usage (Skill Chaining)
+## Usage Examples
 
-The agent invokes this tool automatically when faced with an excessively long context or when instructed to compress a payload. However, you can also use it as a manual middleware step:
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). No skill-specific API keys.
+
+Sample user message: *Compress this prompt before the main model call: "Hello, could you please make sure to read this documentation..."*
+
+### Direct execute
 
 ```python
 from skillware.core.loader import SkillLoader
 
-# 1. Load the middleware
-rewriter_bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-rewriter = rewriter_bundle['module'].PromptRewriter()
-
-# 2. Compress a prompt before sending to LLM
+bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+rewriter = bundle["module"].PromptRewriter()
 result = rewriter.execute({
     "raw_text": "Hello, could you please make sure to read this documentation...",
-    "compression_aggression": "high"
+    "compression_aggression": "high",
 })
-
-print(f"Compressed: {result['compressed_text']}")
-# Output: "read documentation..."
+print(result["compressed_text"])
 ```
+
+### Gemini
+
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+skill = bundle["module"].PromptRewriter()
+genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
+)
+# On function_call (name optimization/prompt_rewriter): skill.execute(dict(part.function_call.args))
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+skill = bundle["module"].PromptRewriter()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# On tool_use (name optimization/prompt_rewriter): skill.execute(tool_use.input)
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+skill = bundle["module"].PromptRewriter()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name to openai_tool["function"]["name"] (optimization_prompt_rewriter)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+skill = bundle["module"].PromptRewriter()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "optimization/prompt_rewriter"`. See [Ollama usage](../usage/ollama.md).
 
 ## Maintenance
 

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -34,30 +34,104 @@ The system instructions emphasize boundary-pushing data generation. It prohibits
 | `ANTHROPIC_API_KEY` | When `model_provider` is `anthropic` | Anthropic API for generation |
 | (none) | When `model_provider` is `ollama` | Uses local Ollama on the default port |
 
-Configure values per [API keys for skills](../usage/api_keys.md).
+Configure values per [API keys for skills](../usage/api_keys.md). Internal generation uses `model_provider` (`gemini`, `anthropic`, or `ollama`); that is separate from which agent hosts the skill.
 
-### Usage (Skillware Loader)
+## Usage Examples
+
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
+
+Sample user message: *Generate five high-entropy medical coding dispute samples with dual-insurance edge cases.*
+
+### Direct execute
 
 ```python
 from skillware.core.loader import SkillLoader
-import json
 
-# 1. Load the Skill
-skill_bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-SyntheticGeneratorSkill = skill_bundle['module'].SyntheticGeneratorSkill()
-
-# 2. Execute
-result = SyntheticGeneratorSkill.execute({
+bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
+skill = bundle["module"].SyntheticGeneratorSkill()
+result = skill.execute({
     "domain": "medical_coding_disputes",
     "num_samples": 5,
     "entropy_temperature": 0.9,
-    "diversity_prompt": "Ensure edge-case scenarios involving dual-insurance coverage overlaps.",
-    "model_provider": "gemini"
+    "diversity_prompt": "Dual-insurance coverage overlaps.",
+    "model_provider": "gemini",
 })
-
-print(f"Generated {result['samples_generated']} samples with Entropy Score: {result['entropy_score']}")
-print(json.dumps(result['samples'], indent=2))
+print(result["entropy_score"], result["samples_generated"])
 ```
+
+### Gemini
+
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
+skill = bundle["module"].SyntheticGeneratorSkill()
+genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
+)
+# On function_call (name data_engineering/synthetic_generator): skill.execute(...)
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
+skill = bundle["module"].SyntheticGeneratorSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# On tool_use (name data_engineering/synthetic_generator): skill.execute(tool_use.input)
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
+skill = bundle["module"].SyntheticGeneratorSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name (data_engineering_synthetic_generator)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
+skill = bundle["module"].SyntheticGeneratorSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "data_engineering/synthetic_generator"`. See [Ollama usage](../usage/ollama.md).
 
 ## Data Schema
 

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -74,25 +74,101 @@ print(result["verdict"])
 print(result["reason"])
 ```
 
-## Gemini Example
+## Usage Examples
 
-Use the skill through `SkillLoader.to_gemini_tool(...)` and pass the skill instructions as the `system_instruction`. See `examples/gemini_tos_evaluator.py`.
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md) (optional `GOOGLE_API_KEY` for the LLM evaluator path).
 
-## Claude Example
+Sample user message: *Before crawling https://example.com/docs, check if automated indexing is allowed.*
 
-Use the skill through `SkillLoader.to_claude_tool(...)` and return the structured result back to Claude as a tool result. See `examples/claude_tos_evaluator.py`.
+| Provider | Reference script |
+| :--- | :--- |
+| Gemini | `examples/gemini_tos_evaluator.py` |
+| Claude | `examples/claude_tos_evaluator.py` |
+| OpenAI | `examples/openai_tos_evaluator.py` |
+| DeepSeek | `examples/deepseek_tos_evaluator.py` |
+| Ollama | `examples/ollama_tos_evaluator.py` |
 
-## OpenAI Example
+### Gemini
 
-Use `SkillLoader.to_openai_tool(...)` and match tool calls on the sanitized function name (for example `compliance_tos_evaluator`). See `examples/openai_tos_evaluator.py`.
+```python
+import os
+import google.generativeai as genai
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
 
-## DeepSeek Example
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+skill = bundle["module"].TOSEvaluatorSkill()
+tool = SkillLoader.to_gemini_tool(bundle)
+genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+model = genai.GenerativeModel(
+    "gemini-2.5-flash",
+    tools=[tool],
+    system_instruction=bundle["instructions"],
+)
+chat = model.start_chat()
+response = chat.send_message(
+    "Check whether crawling https://example.com/docs is allowed."
+)
+# On function_call: skill.execute(dict(part.function_call.args)), return function_response
+```
 
-Use `SkillLoader.to_deepseek_tool(...)` with the DeepSeek API base URL and `DEEPSEEK_API_KEY`. See `examples/deepseek_tos_evaluator.py`.
+### Claude
 
-## Ollama Example
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
 
-Use the text-based prompt adapter from `SkillLoader.to_ollama_prompt(...)` and execute the skill locally when the model emits a JSON tool block. See `examples/ollama_tos_evaluator.py`.
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+skill = bundle["module"].TOSEvaluatorSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# messages.create(..., system=bundle["instructions"], tools=tools)
+# On tool_use: skill.execute(tool_use.input), reply with tool_result
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+skill = bundle["module"].TOSEvaluatorSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# chat.completions.create(model="gpt-4o", tools=[openai_tool], ...)
+# Match tool_call.function.name to openai_tool["function"]["name"] (compliance_tos_evaluator)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+skill = bundle["module"].TOSEvaluatorSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+# chat.completions.create(model="deepseek-chat", tools=[deepseek_tool], ...)
+```
+
+### Ollama
+
+Prompt-based tool calling. Pull a model such as `gemma3` or `qwen3.5`, then see `examples/ollama_tos_evaluator.py` and [Ollama usage](../usage/ollama.md).
 
 ## Notes
 

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -53,33 +53,101 @@ Tools to keep the knowledge fresh.
 
 Configure values per [API keys for skills](../usage/api_keys.md). This skill reads the names declared in `skills/finance/wallet_screening/manifest.yaml`.
 
-For Gemini agent loops that invoke this skill, you also need `GOOGLE_API_KEY` in your environment (see [Gemini usage](../usage/gemini.md)).
+Agent loops also need a provider API key (for example `GOOGLE_API_KEY` with Gemini); see [Gemini usage](../usage/gemini.md).
 
-### Usage (Gemini 2.0)
+## Usage Examples
+
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
+
+Sample user message: *Screen wallet `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` for sanctions and malicious contract interactions.*
+
+| Provider | Reference script |
+| :--- | :--- |
+| Gemini | `examples/gemini_wallet_check.py` |
+| Claude | `examples/claude_wallet_check.py` |
+
+### Gemini
 
 ```python
 import os
 import google.generativeai as genai
+from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
-# 1. Load the Skill Bundle
-skill = SkillLoader.load_skill("finance/wallet_screening")
-
-# 2. Configure Model
+load_env_file()
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = bundle["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
 genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
 model = genai.GenerativeModel(
-    'gemini-2.0-flash-exp',
-    tools=[SkillLoader.to_gemini_tool(skill)],     # <--- Adapter
-    system_instruction=skill['instructions']        # <--- Injection
+    "gemini-2.5-flash",
+    tools=[SkillLoader.to_gemini_tool(bundle)],
+    system_instruction=bundle["instructions"],
 )
-
-# 3. Chat Loop with Feedback
-chat = model.start_chat()
-response = chat.send_message("Is wallet 0xd8dA... safe?")
-
-# 4. Handle Tool Call
-# (See examples/gemini_wallet_check.py for the full loop)
+# On function_call (name wallet_screening): skill.execute(dict(part.function_call.args))
 ```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = bundle["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+# On tool_use (name wallet_screening): skill.execute(tool_use.input), return tool_result
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = bundle["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name to openai_tool["function"]["name"] (wallet_screening)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = bundle["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+# chat.completions.create(model="deepseek-chat", tools=[deepseek_tool], ...)
+```
+
+### Ollama
+
+Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "wallet_screening"` in the JSON block. See [Ollama usage](../usage/ollama.md) and [agent loops](../usage/agent_loops.md).
 
 ## 📊 Data Schema
 

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,19 @@
+# Usage Guides
+
+How to load Skillware skills and connect them to language models. Each guide covers one provider adapter in `SkillLoader`.
+
+| Provider | Adapter | Guide | Agent API key (typical) |
+| :--- | :--- | :--- | :--- |
+| Google Gemini | `to_gemini_tool()` | [gemini.md](gemini.md) | `GOOGLE_API_KEY` |
+| Anthropic Claude | `to_claude_tool()` | [claude.md](claude.md) | `ANTHROPIC_API_KEY` |
+| OpenAI (ChatGPT) | `to_openai_tool()` | [openai.md](openai.md) | `OPENAI_API_KEY` |
+| DeepSeek | `to_deepseek_tool()` | [deepseek.md](deepseek.md) | `DEEPSEEK_API_KEY` |
+| Ollama (prompt mode) | `to_ollama_prompt()` | [ollama.md](ollama.md) | (local; no cloud key) |
+
+Skill-specific **Usage Examples** (sample prompts and execute payloads) live on each [skill catalog page](../skills/README.md).
+
+Shared patterns (load bundle, run `execute`, return tool results): [agent_loops.md](agent_loops.md).
+
+Contributors adding **Usage Examples** to skill catalog pages: [skill_usage_template.md](skill_usage_template.md).
+
+Skills that call external APIs during execution: [API keys for skills](api_keys.md).

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -1,0 +1,56 @@
+# Agent loops with Skillware
+
+Every integration follows the same execution pattern:
+
+1. `bundle = SkillLoader.load_skill("<category>/<skill_name>")`
+2. `skill = bundle["module"].<SkillClass>()`
+3. Adapt `bundle` for the model (`to_gemini_tool`, `to_claude_tool`, etc.).
+4. Pass `bundle["instructions"]` as system context.
+5. On tool call, `result = skill.execute(arguments)` and return JSON to the model.
+
+Provider guides contain full API details. Skill pages contain copy-paste examples with skill-specific paths and sample user messages.
+
+---
+
+## Tool name matching
+
+| Adapter | Match tool calls using |
+| :--- | :--- |
+| Gemini | `manifest["name"]` (may include slashes, e.g. `compliance/tos_evaluator`) |
+| Claude | `manifest["name"]` |
+| OpenAI | `to_openai_tool(bundle)["function"]["name"]` (sanitized, e.g. `compliance_tos_evaluator`) |
+| DeepSeek | `to_deepseek_tool(bundle)["function"]["name"]` (same sanitization rules) |
+| Ollama (prompt) | `"tool"` field in the JSON block the model emits |
+
+---
+
+## Minimal execute (no LLM)
+
+```python
+from skillware.core.loader import SkillLoader
+
+bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+SkillClass = bundle["module"].TOSEvaluatorSkill
+result = SkillClass().execute(
+    {
+        "target_url": "https://example.com",
+        "intended_action": "crawl documentation for research",
+    }
+)
+print(result)
+```
+
+---
+
+## Reference scripts
+
+Full runnable loops live under `examples/` where listed. All [skill catalog pages](../skills/README.md) include compact **Usage Examples** per provider.
+
+| Skill | Gemini | Claude | OpenAI | DeepSeek | Ollama |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `compliance/tos_evaluator` | `gemini_tos_evaluator.py` | `claude_tos_evaluator.py` | `openai_tos_evaluator.py` | `deepseek_tos_evaluator.py` | `ollama_tos_evaluator.py` |
+| `finance/wallet_screening` | `gemini_wallet_check.py` | `claude_wallet_check.py` | (catalog page) | (catalog page) | (catalog page) |
+| `office/pdf_form_filler` | `gemini_pdf_form_filler.py` | `claude_pdf_form_filler.py` | (catalog page) | (catalog page) | (catalog page) |
+| `compliance/mica_module` | `mica_rag_flow.py` | `mica_claude_flow.py` | (catalog page) | (catalog page) | `mica_ollama_flow.py` |
+| `compliance/pii_masker` | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
+| Other skills | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |

--- a/docs/usage/ollama.md
+++ b/docs/usage/ollama.md
@@ -5,9 +5,10 @@ Skillware natively supports [Ollama](https://ollama.com/), enabling you to run o
 ## Prerequisites
 
 1.  **Install Ollama:** Follow the instructions at [ollama.com](https://ollama.com/) to install Ollama on your machine.
-2.  **Pull a Model:** You need a model that supports tool calling. We recommend `llama3` or `llama3.1`.
+2.  **Pull a Model:** Use a model that follows instructions reliably in prompt mode (JSON tool blocks). Examples: `gemma3`, `qwen3.5`, or `llama3.1`.
     ```bash
-    ollama run llama3
+    ollama pull gemma3
+    ollama run gemma3
     ```
 3.  **Install Python Client:** Install the official Ollama Python package.
     ```bash
@@ -62,7 +63,7 @@ messages = [
 ]
 
 # 3. Call the Ollama Model
-model_name = "llama3"
+model_name = "gemma3"
 print(f"🤖 Calling Ollama model: {model_name}...")
 response = ollama.chat(
     model=model_name,

--- a/docs/usage/skill_usage_template.md
+++ b/docs/usage/skill_usage_template.md
@@ -1,0 +1,7 @@
+# Skill usage example template (contributors)
+
+When adding **Usage Examples** to `docs/skills/<skill>.md`, include subsections for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). Each block should be runnable: imports, `load_env_file()`, `load_skill`, adapter, system instructions, sample user message, and `execute` on tool call.
+
+Link to [agent_loops.md](agent_loops.md) and [README.md](README.md). List skill-specific env vars in an **Environment** table; link to [api_keys.md](api_keys.md) for setup.
+
+Do not duplicate the full API keys guide on skill pages.

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -10,7 +10,7 @@ Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from 
 4. **`instructions.md`**: Tell the agent when and how to use the tool.
 5. **`card.json`**: Mirror `issuer` from the manifest; customize UI fields.
 6. **`test_skill.py`**: Add tests; run `pytest skills/<category>/<skill_name>/test_skill.py`.
-7. **`docs/skills/<skill_name>.md`**: Add a catalog page with **ID** and **Issuer** lines.
+7. **`docs/skills/<skill_name>.md`**: Catalog page with **ID**, **Issuer**, and **Usage Examples** (all providers; see `docs/usage/skill_usage_template.md`).
 8. **`docs/skills/README.md`**: Add a row to the skill library table.
 
 Do not commit template placeholders (`Your Name`, `you@example.com`, `YOUR ORG`, etc.) under `skills/`—only real issuer details belong in the registry.


### PR DESCRIPTION
## Description

Documentation-only PR for [#58](https://github.com/ARPAHLS/skillware/issues/58). Adds a usage docs index, shared agent-loop guide, and contributor template for skill catalog pages. Every skill page now has **Usage Examples** for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). CONTRIBUTING and the agent workflow checklist match that standard. README links to the new usage docs; Ollama guidance mentions current local models (`gemma3`, `qwen3.5`, etc.).

### Type of Change

- [x] Documentation update

## Checklist

- [x] Follows Agent Code of Conduct (no emojis in docs)
- [x] `python -m pytest tests/` — 36 passed (docs-only; no code changes)

## New or updated skill

N/A — no changes under `skills/`.

## Related Issues

Fixes #58