### PR TITLE
Docs/skill docs revamp

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the official catalog of Skillware capabilities.
 
-### Office
+## Office
 Skills for document processing, email automation, and productivity.
 
 | Skill | ID | Issuer | Description |
@@ -52,3 +52,7 @@ from skillware.core.loader import SkillLoader
 # Load by registry ID (category/skill_name)
 skill = SkillLoader.load_skill("finance/wallet_screening")
 ```
+
+---
+
+See [Usage guides](../usage/README.md) for provider adapters, [Agent loops](../usage/agent_loops.md) for the shared execute pattern, and [Testing](../TESTING.md) for running skill tests before opening a PR.

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -3,6 +3,8 @@
 **ID**: `compliance/mica_module`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A highly specialized, localized RAG (Retrieval-Augmented Generation) and policy enforcement engine for the Markets in Crypto-Assets (MiCA) regulation. It ensures any agent using it can understand, query, and enforce the entirety of MiCA with granular precision, acting as a strict compliance firewall.
 
 ## Capabilities
@@ -33,6 +35,14 @@ The system prompt teaches the main Agent to:
 | `GOOGLE_API_KEY` | Yes (evaluator / Gemini paths) | Google Generative AI used by the built-in evaluator and RAG flows |
 
 Configure values per [API keys for skills](../usage/api_keys.md).
+
+## Arguments
+
+| Argument | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `user_prompt` | string | Yes | - | The user's query regarding crypto-assets, e-money licenses, or MiCA rules. |
+| `run_evaluator` | boolean | No | `false` | Triggers the built-in Gemini evaluator node to grade the RAG context and flag regulatory holes. Adds a secondary API call. |
+| `evaluator_model` | string | No | `gemini-2.5-flash-lite` | The Gemini model used by the evaluator node. Can be swapped for a faster or more capable model without changing any other part of the skill. |
 
 ## Usage Examples
 

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -3,16 +3,18 @@
 **ID**: `office/pdf_form_filler`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A productivity skill that fills AcroForm-based PDFs by mapping natural language instructions to detected form fields using semantic understanding.
 
-## 📋 Capabilities
+## Capabilities
 
 *   **Smart Field Detection**: Automatically identifies text fields, checkboxes, radio buttons, and dropdowns in standard PDFs.
 *   **Semantic Mapping**: Uses an internal LLM (Claude) to understand user instructions (e.g., "Sign me up for the newsletter") and map them to the correct field (e.g., `checkbox_subscribe_newsletter`).
 *   **Context Awareness**: Extracts nearby text labels to ensure accurate mapping, even if field names are obscure (e.g., `field_123` vs label "First Name").
 *   **Type Safety**: Automatically converts values to the correct format (booleans for checkboxes, specific options for dropdowns).
 
-## 📂 Internal Architecture
+## Internal Architecture
 
 The skill is self-contained in `skills/office/pdf_form_filler/`.
 
@@ -28,7 +30,7 @@ The system prompt teaches the internal mapping engine to:
 *   **LLM Integration**: Wraps the Anthropic SDK to perform the semantic reasoning step.
 *   **Validation**: Ensures values match the field type (e.g., selecting a valid option from a dropdown).
 
-## 💻 Integration Guide
+## Integration Guide
 
 ### Environment
 
@@ -136,7 +138,7 @@ client = OpenAI(
 
 `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "pdf_form_filler"`. See [Ollama usage](../usage/ollama.md).
 
-## 📊 Data Schema
+## Data Schema
 
 The skill returns a JSON object with the result of the operation.
 
@@ -152,7 +154,7 @@ The skill returns a JSON object with the result of the operation.
 }
 ```
 
-## ⚠️ Limitations
+## Limitations
 
 *   **AcroForms Only**: Does not support XFA forms or non-interactive "flat" PDFs.
 *   **LLM Dependency**: Requires an active internet connection and valid API key for the semantic mapping step.

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -4,6 +4,8 @@
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 **Category**: Compliance
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 High-precision, local PII (Personally Identifiable Information) detection and redaction using the `micro-f1-mask` model. This skill acts as a "Privacy Firewall" at the edge, scrubbing sensitive data before it reaches high-latency cloud models.
 
 > [!WARNING]

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -4,6 +4,8 @@
 **Skill ID:** `optimization/prompt_rewriter`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A powerful middleware skill that acts as a deterministic compression logic gate for agents. It ingests a massive, bloated prompt or conversation history and "rewrites" it to use fewer tokens while aggressively retaining 100% of the semantic meaning and instructions.
 
 This is critical for complex agents facing strict token constraints or high LLM API costs.

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -4,6 +4,8 @@
 **Skill ID:** `data_engineering/synthetic_generator`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A specialized data engineering capability that combats "model collapse" by generating high-entropy, highly structured synthetic data intentionally designed to fine-tune other models.
 
 ## Capabilities

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -4,6 +4,8 @@
 **Skill ID:** `compliance/tos_evaluator`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A local-first compliance guardrail that checks whether an intended automated action appears permissible on a target website. It evaluates `robots.txt`, discovers candidate legal pages, extracts relevant clauses, and can optionally use a low-cost LLM to interpret ambiguous policy language.
 
 ## What It Checks

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -3,9 +3,11 @@
 **ID**: `finance/wallet_screening`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
 
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
 A rigorous compliance and risk assessment tool for Ethereum wallets. This skill ports logic from professional forensic tools into the modular Skillware format.
 
-## 📋 Capabilities
+## Capabilities
 
 *   **Sanctions Check**: Screens against **880+** bundled lists (OFAC, FBI, Israel NBCTF, etc.) via dynamic dataset loading.
 *   **Malicious Contract Detection**: Identifies interactions with known bad actors (Tornado Cash, Drainers).
@@ -15,7 +17,7 @@ A rigorous compliance and risk assessment tool for Ethereum wallets. This skill 
     *   Identifies top counterparties and "most interacted" wallets.
 *   **Risk Scoring**: Flags high-risk patterns based on transaction flow analysis.
 
-## 📂 Internal Architecture
+## Internal Architecture
 
 The skill is self-contained in `skills/finance/wallet_screening/`.
 
@@ -42,7 +44,7 @@ Tools to keep the knowledge fresh.
 *   `normalization_tool.py`: Ingests raw CSVs from authorities (FBI, Israel NBCTF) and converts them to the Skillware JSON schema.
 *   `normalize_uniswap_trm.py`: Converts Uniswap's blocked address list into our risk format.
 
-## 💻 Integration Guide
+## Integration Guide
 
 ### Environment
 
@@ -149,7 +151,7 @@ client = OpenAI(
 
 Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "wallet_screening"` in the JSON block. See [Ollama usage](../usage/ollama.md) and [agent loops](../usage/agent_loops.md).
 
-## 📊 Data Schema
+## Data Schema
 
 The skill returns a rich forensic report. Agents act on this data.
 
@@ -176,6 +178,14 @@ The skill returns a rich forensic report. Agents act on this data.
   }
 }
 ```
+
+## Limitations
+
+- **Ethereum only**: The skill screens Ethereum (EVM) addresses exclusively. Bitcoin, Solana, or other chain addresses are not supported and will fail address validation.
+- **Etherscan transaction cap**: Etherscan's `txlist` endpoint returns a maximum of 10,000 transactions per address. Wallets with very high transaction volume will have their older history silently truncated, which may affect PnL and counterparty calculations.
+- **Point-in-time sanctions data**: The bundled JSON lists (`entities.ftm.json`, `malicious_scs_2025.json`, and the normalized lists) reflect the state at the time of the last `maintenance/` run. They must be refreshed periodically to stay current.
+- **No ERC-20 or internal transaction coverage**: Only standard ETH transfers from the Etherscan `txlist` action are analyzed. ERC-20 token transfers, internal transactions, and NFT transfers are not included in financial flow calculations.
+- **Not legal advice**: Risk flags are derived from open-source sanctions data and pattern heuristics. A clean result does not constitute legal clearance.
 
 ---
 


### PR DESCRIPTION
## Description

Documentation revamp for all skill pages under `docs/skills/`, addressing issue #52.

- Removed all emoji characters used as structural headers (`📋`, `📂`, `💻`, `📊`, `⚠️`) from `wallet_screening.md` and `pdf_form_filler.md`
- Added `[Skill Library](README.md) · [Testing](../TESTING.md)` breadcrumb to all 7 skill pages
- Fixed heading level inconsistency in `docs/skills/README.md` (`### Office` → `## Office`)
- Added footer links to usage guides and `TESTING.md` in the skills index
- Added `## Arguments` table to `mica_module.md` (was missing despite 3 documented parameters in `manifest.yaml`)
- Added `## Limitations` section to `wallet_screening.md` (Ethereum-only, Etherscan 10k tx cap, point-in-time sanctions data, no ERC-20/internal tx coverage)

### Type of Change

- [x] **Doc Fix**: Documentation Update

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] No skill logic was modified. `flake8` and `pytest tests/` are not applicable to this change.

## Related Issues

Closes #52
