### PR TITLE
docs: update Gemini snippets to google-genai

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ GOOGLE_API_KEY="your_key"
 ### 3. Usage Example (Gemini)
 
 ```python
+import os
 import google.genai as genai
 from google.genai import types
 from skillware.core.loader import SkillLoader
@@ -108,7 +109,10 @@ load_env_file()
 
 # 1. Load the Skill from the Registry
 # The loader reads the code, manifest, and instructions automatically
-skill_bundle = SkillLoader.load_skill("category/skill_name")  # see docs/usage/README.md for path search order
+skill_bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = skill_bundle["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
 
 # 2. Client & Tool Setup
 client = genai.Client()
@@ -116,17 +120,37 @@ tool = SkillLoader.to_gemini_tool(skill_bundle)       # The "Adapter"
 system_instruction = skill_bundle['instructions']     # The "Mind"
 
 # 3. Agent Loop
-# Pass tool and system_instruction through google-genai's GenerateContentConfig,
-# then execute any returned function calls with skill_bundle["module"].execute(...).
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model="gemini-2.5-flash",
     contents="Screen wallet 0xd8dA... for risks.",
     config=types.GenerateContentConfig(
         tools=[tool],
         system_instruction=system_instruction,
     ),
 )
-print(response.text)
+
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=system_instruction,
+            ),
+        )
+        print(follow_up.text)
+    else:
+        print(part.text)
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ GOOGLE_API_KEY="your_key"
 
 ```python
 import google.genai as genai
+from google.genai import types
 from skillware.core.loader import SkillLoader
 from skillware.core.env import load_env_file
 
@@ -120,6 +121,10 @@ system_instruction = skill_bundle['instructions']     # The "Mind"
 response = client.models.generate_content(
     model='gemini-2.5-flash',
     contents="Screen wallet 0xd8dA... for risks.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=system_instruction,
+    ),
 )
 print(response.text)
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ GOOGLE_API_KEY="your_key"
 ### 3. Usage Example (Gemini)
 
 ```python
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.loader import SkillLoader
 from skillware.core.env import load_env_file
 
@@ -109,17 +109,18 @@ load_env_file()
 # The loader reads the code, manifest, and instructions automatically
 skill_bundle = SkillLoader.load_skill("category/skill_name")  # see docs/usage/README.md for path search order
 
-# 2. Model & Chat Setup
-model = genai.GenerativeModel(
-    'gemini-2.5-flash',
-    tools=[SkillLoader.to_gemini_tool(skill_bundle)], # The "Adapter"
-    system_instruction=skill_bundle['instructions']   # The "Mind"
-)
-chat = model.start_chat(enable_automatic_function_calling=True)
+# 2. Client & Tool Setup
+client = genai.Client()
+tool = SkillLoader.to_gemini_tool(skill_bundle)       # The "Adapter"
+system_instruction = skill_bundle['instructions']     # The "Mind"
 
 # 3. Agent Loop
-# The SDK handles the loop: model -> tool call -> execution -> result -> model reply.
-response = chat.send_message("Screen wallet 0xd8dA... for risks.")
+# Pass tool and system_instruction through google-genai's GenerateContentConfig,
+# then execute any returned function calls with skill_bundle["module"].execute(...).
+response = client.models.generate_content(
+    model='gemini-2.5-flash',
+    contents="Screen wallet 0xd8dA... for risks.",
+)
 print(response.text)
 ```
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -94,7 +94,7 @@ Skillware is designed to be the "Standard Library" for all agents.
 
 | Platform | Integration Strategy |
 | :--- | :--- |
-| **Google Gemini** | Native `google.generativeai` support. Automatic type mapping. |
+| **Google Gemini** | Native `google-genai` support. Automatic type mapping. |
 | **Anthropic Claude** | Native `anthropic` support. XML/JSON handling. |
 | **Ollama** | Native `ollama` Python client support. Fully local JSON handling. |
 | **OpenAI GPT** | `to_openai_tool()`; Chat Completions tool calling. |

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -75,6 +75,7 @@ print(result["repository"]["readme_url"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -82,9 +83,18 @@ load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
 skill = bundle["module"].IssueResolverSkill()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name dev_tools/issue_resolver): skill.execute(function_call.args)
-# Feed result back to the model; it then fetches the issue and produces the plan.
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Analyze https://github.com/owner/repo/issues/123 and propose a fix plan.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -74,24 +74,16 @@ print(result["repository"]["readme_url"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
 skill = bundle["module"].IssueResolverSkill()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-chat = model.start_chat()
-response = chat.send_message(
-    "Analyse https://github.com/owner/repo/issues/42 and give me a resolution plan."
-)
-# On function_call (name dev_tools/issue_resolver): skill.execute(function_call.args)
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name dev_tools/issue_resolver): skill.execute(function_call.args)
 # Feed result back to the model; it then fetches the issue and produces the plan.
 ```
 

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -82,7 +82,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
 skill = bundle["module"].IssueResolverSkill()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -95,6 +95,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -83,7 +83,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
 skill = bundle["module"].MiCAModuleSkill()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -96,6 +96,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -76,6 +76,7 @@ print(result["policy_status"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -83,8 +84,18 @@ load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
 skill = bundle["module"].MiCAModuleSkill()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name compliance/mica_module): skill.execute(dict(part.function_call.args))
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Check whether this stablecoin disclosure aligns with MiCA expectations.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -75,20 +75,16 @@ print(result["policy_status"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
 skill = bundle["module"].MiCAModuleSkill()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-# On function_call (name compliance/mica_module): skill.execute(dict(part.function_call.args))
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name compliance/mica_module): skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -75,7 +75,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 # User: "Fill /path/to/form.pdf — name John Doe, check the terms box."
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -89,6 +89,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -67,21 +67,17 @@ print(result["output_path"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
 # User: "Fill /path/to/form.pdf — name John Doe, check the terms box."
-# On function_call (name pdf_form_filler): skill.execute(dict(part.function_call.args))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name pdf_form_filler): skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -68,6 +68,7 @@ print(result["output_path"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -76,8 +77,18 @@ bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
 # User: "Fill /path/to/form.pdf — name John Doe, check the terms box."
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name pdf_form_filler): skill.execute(dict(part.function_call.args))
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Fill /path/to/form.pdf — name John Doe, check the terms box.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -91,7 +91,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
 skill = bundle["module"].PIIMaskerSkill()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -104,6 +104,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -84,6 +84,7 @@ print(result["sanitized_text"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -91,8 +92,18 @@ load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
 skill = bundle["module"].PIIMaskerSkill()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name compliance/pii_masker): skill.execute(...) before sending user text upstream
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Mask PII before summarizing: Jane Doe, jane@example.com, +1-555-0100.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -83,20 +83,16 @@ print(result["sanitized_text"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
 skill = bundle["module"].PIIMaskerSkill()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-# On function_call (name compliance/pii_masker): skill.execute(...) before sending user text upstream
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name compliance/pii_masker): skill.execute(...) before sending user text upstream
 ```
 
 ### Claude

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -54,7 +54,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
 skill = bundle["module"].PromptRewriter()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -67,6 +67,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -46,20 +46,16 @@ print(result["compressed_text"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
 skill = bundle["module"].PromptRewriter()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-# On function_call (name optimization/prompt_rewriter): skill.execute(dict(part.function_call.args))
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name optimization/prompt_rewriter): skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -47,6 +47,7 @@ print(result["compressed_text"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -54,8 +55,18 @@ load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
 skill = bundle["module"].PromptRewriter()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name optimization/prompt_rewriter): skill.execute(dict(part.function_call.args))
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Rewrite this support prompt for a concise, policy-safe assistant.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -73,7 +73,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
 skill = bundle["module"].SyntheticGeneratorSkill()
-client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -86,6 +86,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -65,20 +65,16 @@ print(result["entropy_score"], result["samples_generated"])
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
 skill = bundle["module"].SyntheticGeneratorSkill()
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-# On function_call (name data_engineering/synthetic_generator): skill.execute(...)
+client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name data_engineering/synthetic_generator): skill.execute(...)
 ```
 
 ### Claude

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -66,6 +66,7 @@ print(result["entropy_score"], result["samples_generated"])
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -73,8 +74,18 @@ load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
 skill = bundle["module"].SyntheticGeneratorSkill()
 client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name data_engineering/synthetic_generator): skill.execute(...)
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Generate 25 synthetic customer support rows with no real PII.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -95,6 +95,7 @@ Sample user message: *Before crawling https://example.com/docs, check if automat
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -106,9 +107,14 @@ client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
 response = client.models.generate_content(
     model="gemini-2.5-flash",
     contents="Check whether crawling https://example.com/docs is allowed.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
 )
-# Pass tool in GenerateContentConfig.tools, then on function_call:
-# skill.execute(dict(part.function_call.args)), return function_response
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -103,7 +103,7 @@ load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
 skill = bundle["module"].TOSEvaluatorSkill()
 tool = SkillLoader.to_gemini_tool(bundle)
-client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+client = genai.Client()
 response = client.models.generate_content(
     model="gemini-2.5-flash",
     contents="Check whether crawling https://example.com/docs is allowed.",
@@ -115,6 +115,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -94,7 +94,7 @@ Sample user message: *Before crawling https://example.com/docs, check if automat
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -102,17 +102,13 @@ load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
 skill = bundle["module"].TOSEvaluatorSkill()
 tool = SkillLoader.to_gemini_tool(bundle)
-genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[tool],
-    system_instruction=bundle["instructions"],
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Check whether crawling https://example.com/docs is allowed.",
 )
-chat = model.start_chat()
-response = chat.send_message(
-    "Check whether crawling https://example.com/docs is allowed."
-)
-# On function_call: skill.execute(dict(part.function_call.args)), return function_response
+# Pass tool in GenerateContentConfig.tools, then on function_call:
+# skill.execute(dict(part.function_call.args)), return function_response
 ```
 
 ### Claude

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -72,7 +72,7 @@ Sample user message: *Screen wallet `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
 ```python
 import os
-import google.generativeai as genai
+import google.genai as genai
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -81,13 +81,9 @@ bundle = SkillLoader.load_skill("finance/wallet_screening")
 skill = bundle["module"].WalletScreeningSkill(
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
-genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=[SkillLoader.to_gemini_tool(bundle)],
-    system_instruction=bundle["instructions"],
-)
-# On function_call (name wallet_screening): skill.execute(dict(part.function_call.args))
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
+# client.models.generate_content(...), then on function_call (name wallet_screening): skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -82,7 +82,7 @@ bundle = SkillLoader.load_skill("finance/wallet_screening")
 skill = bundle["module"].WalletScreeningSkill(
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
-client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
     model="gemini-2.5-flash",
@@ -95,6 +95,23 @@ response = client.models.generate_content(
 for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=bundle["instructions"],
+            ),
+        )
+        print(follow_up.text)
 ```
 
 ### Claude

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -73,6 +73,7 @@ Sample user message: *Screen wallet `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 ```python
 import os
 import google.genai as genai
+from google.genai import types
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
 
@@ -82,8 +83,18 @@ skill = bundle["module"].WalletScreeningSkill(
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
-# Pass SkillLoader.to_gemini_tool(bundle) in GenerateContentConfig.tools when calling
-# client.models.generate_content(...), then on function_call (name wallet_screening): skill.execute(dict(part.function_call.args))
+tool = SkillLoader.to_gemini_tool(bundle)
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Screen wallet 0xd8dA... for sanctions and malicious contract interactions.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
 ```
 
 ### Claude

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -52,9 +52,16 @@ Gemini supports `enable_automatic_function_calling=True`.
 If you need granular control (e.g., to sanitize inputs or show progress bars), use the manual loop:
 
 ```python
-response = chat.send_message("Scan wallet...")
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Scan wallet 0xd8dA... for risks.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=skill["instructions"],
+    ),
+)
 
-for part in response.parts:
+for part in response.candidates[0].content.parts:
     if fn := part.function_call:
         print(f"Model wants to call {fn.name} with {fn.args}")
 
@@ -62,16 +69,18 @@ for part in response.parts:
         result = my_skill.execute(dict(fn.args))
 
         # 2. Send Result
-        chat.send_message(
-            genai.prototypes.Part(
-                function_response=genai.prototypes.FunctionResponse(
-                    name=fn.name,
-                    response={'result': result}
-                )
-            )
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {"function_response": {"name": fn.name, "response": {"result": result}}},
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=skill["instructions"],
+            ),
         )
 ```
-*(Note: As of Gemini SDK v0.8+, the exact import for `FunctionResponse` may vary. Using a dictionary structure is often more robust.)*
 
 ## 🔗 Skill Chaining (Middleware)
 
@@ -92,7 +101,7 @@ response = client.models.generate_content(
     model='gemini-2.5-flash',
     contents="Summarize the optimized context.",
     config=types.GenerateContentConfig(
-        system_instruction=sys_prompt,
+        system_instruction=optimized_ctx_result["compressed_text"],
     ),
 )
 ```

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -1,23 +1,22 @@
 # Integration Guide: Google Gemini
 
-Skillware provides first-class support for Google's Gemini models via the `google-generativeai` SDK.
+Skillware provides first-class support for Google's Gemini models via the `google-genai` SDK.
 
 ## ⚡ Quick Snippet
 
 ```python
 from skillware.core.loader import SkillLoader
-import google.generativeai as genai
+import google.genai as genai
 
 # Load & Convert
 skill = SkillLoader.load_skill("finance/wallet_screening")
 tool = SkillLoader.to_gemini_tool(skill)
 
-# Initialize
-model = genai.GenerativeModel(
-    'gemini-2.0-flash-exp',
-    tools=[tool],
-    system_instruction=skill['instructions']
-)
+# Initialize the google-genai client
+client = genai.Client()
+
+# Pass tool and skill['instructions'] through GenerateContentConfig when calling
+# client.models.generate_content(...).
 ```
 
 ## 🔍 How It Works
@@ -82,8 +81,8 @@ optimized_ctx_result = rewriter['module'].PromptRewriter().execute({
     "compression_aggression": "high"
 })
 
-model = genai.GenerativeModel(
-    'gemini-2.5-flash',
-    system_instruction=optimized_ctx_result["compressed_text"]
+response = client.models.generate_content(
+    model='gemini-2.5-flash',
+    contents="Summarize the optimized context.",
 )
 ```

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -5,12 +5,16 @@ Skillware provides first-class support for Google's Gemini models via the `googl
 ## ⚡ Quick Snippet
 
 ```python
+import os
 from skillware.core.loader import SkillLoader
 import google.genai as genai
 from google.genai import types
 
 # Load & Convert
 skill = SkillLoader.load_skill("finance/wallet_screening")
+skill_instance = skill["module"].WalletScreeningSkill(
+    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
+)
 tool = SkillLoader.to_gemini_tool(skill)
 
 # Initialize the google-genai client
@@ -24,6 +28,28 @@ response = client.models.generate_content(
         system_instruction=skill["instructions"],
     ),
 )
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill_instance.execute(dict(part.function_call.args))
+        follow_up = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                "Use this tool result to answer the original request.",
+                {
+                    "function_response": {
+                        "name": part.function_call.name,
+                        "response": {"result": result},
+                    }
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=skill["instructions"],
+            ),
+        )
+        print(follow_up.text)
+    else:
+        print(part.text)
 ```
 
 ## 🔍 How It Works
@@ -42,10 +68,9 @@ Gemini 1.5+ supports `system_instruction`. Skillware leverages this to inject th
 This is crucial. Without `system_instruction`, the model knows it *has* a tool, but it doesn't know the nuanced strategy of *when* to use it. By injecting the instructions, you effectively fine-tune the model's behavior for that specific capability during the session.
 
 ### 3. Function Calling Loop
-Gemini supports `enable_automatic_function_calling=True`.
-
-*   **Automatic**: The SDK handles the loop. It calls your python function and sends the result back.
-*   **Manual**: You receive a `Part` with `function_call`. You must execute the logic and send back a `FunctionResponse`.
+The `google-genai` SDK returns model parts that can include `function_call` requests.
+In a manual Skillware loop, execute the matching local skill with `skill.execute(dict(part.function_call.args))`, then send a `function_response` back to Gemini so the model can produce the final answer.
+If you use an automatic-calling helper in your own app, keep the same boundary: Skillware executes locally, and the tool result is returned to the model before you show a final response.
 
 ## 🛠️ Advanced: Manual Execution Loop
 
@@ -66,7 +91,7 @@ for part in response.candidates[0].content.parts:
         print(f"Model wants to call {fn.name} with {fn.args}")
 
         # 1. Execute Logic
-        result = my_skill.execute(dict(fn.args))
+        result = skill_instance.execute(dict(fn.args))
 
         # 2. Send Result
         follow_up = client.models.generate_content(

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -7,6 +7,7 @@ Skillware provides first-class support for Google's Gemini models via the `googl
 ```python
 from skillware.core.loader import SkillLoader
 import google.genai as genai
+from google.genai import types
 
 # Load & Convert
 skill = SkillLoader.load_skill("finance/wallet_screening")
@@ -15,8 +16,14 @@ tool = SkillLoader.to_gemini_tool(skill)
 # Initialize the google-genai client
 client = genai.Client()
 
-# Pass tool and skill['instructions'] through GenerateContentConfig when calling
-# client.models.generate_content(...).
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Screen wallet 0xd8dA... for risks.",
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=skill["instructions"],
+    ),
+)
 ```
 
 ## 🔍 How It Works
@@ -84,5 +91,8 @@ optimized_ctx_result = rewriter['module'].PromptRewriter().execute({
 response = client.models.generate_content(
     model='gemini-2.5-flash',
     contents="Summarize the optimized context.",
+    config=types.GenerateContentConfig(
+        system_instruction=sys_prompt,
+    ),
 )
 ```


### PR DESCRIPTION
## Summary
- replace deprecated google-generativeai import references with google-genai docs wording
- update README, Gemini usage guide, and skill docs to use google.genai imports and Client setup
- leave framework and skill Python code unchanged, per issue scope

Closes #88

## Checks
- git diff --check
- rg google-generativeai|google\.generativeai|genai\.configure|GenerativeModel README.md docs returned no matches