### PR TITLE
feat: migrate from google-generativeai to google-genai SDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report.yml
@@ -68,4 +68,4 @@ body:
       placeholder: |
         Windows 11
         Python 3.12
-        google-generativeai 0.8.3
+        google-genai 1.0.0

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -16,7 +16,7 @@ To list all locally available skills from the terminal, see the [CLI reference](
 
 | Provider | Adapter | Guide | Agent API key (typical) |
 | :--- | :--- | :--- | :--- |
-| Google Gemini | `to_gemini_tool()` | [gemini.md](gemini.md) | `GOOGLE_API_KEY` |
+| Google Gemini | `to_gemini_tool()` | [gemini.md](gemini.md) | `GOOGLE_API_KEY` (install `skillware[gemini]` for `google-genai`) |
 | Anthropic Claude | `to_claude_tool()` | [claude.md](claude.md) | `ANTHROPIC_API_KEY` |
 | OpenAI (ChatGPT) | `to_openai_tool()` | [openai.md](openai.md) | `OPENAI_API_KEY` |
 | DeepSeek | `to_deepseek_tool()` | [deepseek.md](deepseek.md) | `DEEPSEEK_API_KEY` |

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -44,7 +44,7 @@ print(result)
 
 ## Reference scripts
 
-Full runnable loops live under `examples/` where listed. All [skill catalog pages](../skills/README.md) include compact **Usage Examples** per provider.
+Full runnable loops live under `examples/` where listed. Gemini reference scripts use the `google-genai` SDK (`import google.genai`). All [skill catalog pages](../skills/README.md) include compact **Usage Examples** per provider.
 
 | Skill | Gemini | Claude | OpenAI | DeepSeek | Ollama |
 | :--- | :--- | :--- | :--- | :--- | :--- |

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -2,6 +2,14 @@
 
 Skillware provides first-class support for Google's Gemini models via the `google-genai` SDK.
 
+## Install
+
+```bash
+pip install "skillware[gemini]"
+```
+
+This installs the [`google-genai`](https://pypi.org/project/google-genai/) package. Set `GOOGLE_API_KEY` in your environment or `.env` file before running Gemini examples.
+
 ## ⚡ Quick Snippet
 
 ```python

--- a/examples/gemini_pdf_form_filler.py
+++ b/examples/gemini_pdf_form_filler.py
@@ -1,54 +1,42 @@
 import os
 import sys
 
-# Add repo root to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import google.generativeai as genai  # noqa: E402
+import google.genai as genai  # noqa: E402
+from google.genai import types  # noqa: E402
 from skillware.core.loader import SkillLoader  # noqa: E402
 from skillware.core.env import load_env_file  # noqa: E402
 
-# Load Env (Requires GOOGLE_API_KEY for the Agent, and ANTHROPIC_API_KEY for the Skill's internal logic)
 load_env_file()
 
-# 1. Load the Skill
 skill_bundle = SkillLoader.load_skill("office/pdf_form_filler")
 print(f"Loaded Skill: {skill_bundle['manifest']['name']}")
 
-# 2. Instantiate the Skill
-# The skill needs ANTHROPIC_API_KEY in env to perform semantic mapping
 PDFFormFillerSkill = skill_bundle["module"].PDFFormFillerSkill
 pdf_skill = PDFFormFillerSkill()
 
-# 3. Setup Gemini Agent
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
+tool = SkillLoader.to_gemini_tool(skill_bundle)
+system_instruction = skill_bundle["instructions"]
 
-# Define tool for Gemini
-tools = [SkillLoader.to_gemini_tool(skill_bundle)]
-
-model = genai.GenerativeModel(
-    "gemini-2.0-flash-exp",
-    tools=tools,
-    system_instruction=skill_bundle["instructions"],  # Inject skill's cognitive map
-)
-
-chat = model.start_chat(enable_automatic_function_calling=True)
-
-# 4. Run the Agent Loop
-# Note: You need a real PDF file for this to work.
 pdf_path = os.path.abspath("test_form.pdf")
-user_query = f"Fill out the form at {pdf_path}. Set the name to 'Jane Doe' and check the 'Subscribe' box."
+user_query = (
+    f"Fill out the form at {pdf_path}. Set the name to 'Jane Doe' and check the "
+    "'Subscribe' box."
+)
 
 print(f"User: {user_query}")
 
-# Create a function map for manual execution if needed (Python SDK handles this automatically usually)
-# But for completeness:
-function_map = {"pdf_form_filler": pdf_skill.execute}
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents=user_query,
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=system_instruction,
+    ),
+)
 
-response = chat.send_message(user_query)
-
-# Simple manual tool execution loop (if auto-calling isn't fully handled or we want to inspect)
-# Note: Recent genai SDKs handle this better, but explicit loops are safer for demos.
 while response.candidates and response.candidates[0].content.parts:
     part = response.candidates[0].content.parts[0]
 
@@ -56,37 +44,41 @@ while response.candidates and response.candidates[0].content.parts:
         fn_name = part.function_call.name
         fn_args = dict(part.function_call.args)
 
-        print(f"🤖 Agent wants to call: {fn_name}")
+        print(f"Agent wants to call: {fn_name}")
         print(f"   Args: {fn_args}")
 
         if fn_name == "pdf_form_filler":
             try:
-                # Check if file exists before running
                 if not os.path.exists(fn_args.get("pdf_path", "")):
-                    print(f"⚠️ Error: PDF file not found at {fn_args.get('pdf_path')}")
+                    print(f"Error: PDF file not found at {fn_args.get('pdf_path')}")
                     result = {"error": "PDF file not found."}
                 else:
-                    print("⚙️ Executing skill...")
+                    print("Executing skill...")
                     result = pdf_skill.execute(fn_args)
-                    print(f"✅ Result: {result}")
-            except Exception as e:
-                result = {"error": str(e)}
+                    print(f"Result: {result}")
+            except Exception as exc:
+                result = {"error": str(exc)}
 
-            # Send result back
-            response = chat.send_message(
-                [
+            response = client.models.generate_content(
+                model="gemini-2.5-flash",
+                contents=[
+                    "Use this tool result to answer the original request.",
                     {
                         "function_response": {
                             "name": fn_name,
                             "response": {"result": result},
                         }
-                    }
-                ]
+                    },
+                ],
+                config=types.GenerateContentConfig(
+                    tools=[tool],
+                    system_instruction=system_instruction,
+                ),
             )
         else:
             break
     else:
         break
 
-print("\n💬 Agent Final Response:")
+print("\nAgent Final Response:")
 print(response.text)

--- a/examples/gemini_tos_evaluator.py
+++ b/examples/gemini_tos_evaluator.py
@@ -1,7 +1,7 @@
 import json
-import os
 
-import google.generativeai as genai
+import google.genai as genai
+from google.genai import types
 
 from skillware.core.env import load_env_file
 from skillware.core.loader import SkillLoader
@@ -14,23 +14,25 @@ print(f"Loaded Skill: {bundle['manifest']['name']}")
 TOSEvaluatorSkill = bundle["module"].TOSEvaluatorSkill
 tos_skill = TOSEvaluatorSkill()
 
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
-tools = [SkillLoader.to_gemini_tool(bundle)]
+client = genai.Client()
+tool = SkillLoader.to_gemini_tool(bundle)
+system_instruction = bundle["instructions"]
 
-model = genai.GenerativeModel(
-    "gemini-2.5-flash-lite",
-    tools=tools,
-    system_instruction=bundle["instructions"],
-)
-
-chat = model.start_chat(enable_automatic_function_calling=True)
 user_query = (
     "Before scraping Hackernoon tagged AI pages, check whether automated crawling "
     "appears allowed for https://hackernoon.com/tagged/ai."
 )
 print(f"User: {user_query}")
 
-response = chat.send_message(user_query)
+response = client.models.generate_content(
+    model="gemini-2.5-flash-lite",
+    contents=user_query,
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=system_instruction,
+    ),
+)
+
 while response.candidates and response.candidates[0].content.parts:
     part = response.candidates[0].content.parts[0]
     if not part.function_call:
@@ -44,15 +46,21 @@ while response.candidates and response.candidates[0].content.parts:
     if fn_name == "compliance/tos_evaluator":
         result = tos_skill.execute(fn_args)
         print(json.dumps(result, indent=2))
-        response = chat.send_message(
-            [
+        response = client.models.generate_content(
+            model="gemini-2.5-flash-lite",
+            contents=[
+                "Use this tool result to answer the original request.",
                 {
                     "function_response": {
                         "name": fn_name,
                         "response": {"result": result},
                     }
-                }
-            ]
+                },
+            ],
+            config=types.GenerateContentConfig(
+                tools=[tool],
+                system_instruction=system_instruction,
+            ),
         )
     else:
         break

--- a/examples/gemini_wallet_check.py
+++ b/examples/gemini_wallet_check.py
@@ -1,90 +1,76 @@
 import os
-import google.generativeai as genai
+
+import google.genai as genai
+from google.genai import types
+
 from skillware.core.loader import SkillLoader
 from skillware.core.env import load_env_file
 
-# Load Global Env (User should create a .env file with ETHERSCAN_API_KEY and GOOGLE_API_KEY)
 load_env_file()
 
-# 1. Load the Skill dynamically
-# Adjust path to where the skill is located relative to this script
 SKILL_PATH = "finance/wallet_screening"
 skill_bundle = SkillLoader.load_skill(SKILL_PATH)
 
 print(f"Loaded Skill: {skill_bundle['manifest']['name']}")
 
-# 2. Instantiate the Skill
 WalletScreeningSkill = skill_bundle["module"].WalletScreeningSkill
 wallet_skill = WalletScreeningSkill(
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 
-# 3. Setup Gemini
-genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+client = genai.Client()
+tool = SkillLoader.to_gemini_tool(skill_bundle)
+system_instruction = skill_bundle["instructions"]
 
-# Define the tool for Gemini using the manifest
-tools_listing = [SkillLoader.to_gemini_tool(skill_bundle)]
-
-# Create the model with the tool
-model = genai.GenerativeModel(
-    "gemini-2.5-flash",
-    tools=tools_listing,
-    system_instruction=skill_bundle["instructions"],  # Inject the skill's cognitive map
-)
-
-chat = model.start_chat(enable_automatic_function_calling=True)
-
-# 4. Run the Agent Loop
 user_query = (
     "Can you screen this wallet for me? 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 )
 print(f"User: {user_query}")
 
-# Create a function map for manual execution if automatic calling wasn't enabled
-# (though the library handles it, describing it here for clarity)
-function_map = {"wallet_screening": wallet_skill.execute}
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents=user_query,
+    config=types.GenerateContentConfig(
+        tools=[tool],
+        system_instruction=system_instruction,
+    ),
+)
 
-# In a real loop, you would handle the tool call response.
-# Here we simulate the key steps or let the library's auto-function calling work if supported by the client lib version.
-# Note: Python client support for auto-execution might vary, so we define a simple runner.
-
-# Send initial message
-response = chat.send_message(user_query)
-
-# Simple loop to handle tool calls (depth 1 for demo, but loop is better)
 while response.candidates and response.candidates[0].content.parts:
     part = response.candidates[0].content.parts[0]
 
-    # Check if the model wants to call a function
     if part.function_call:
         fn_name = part.function_call.name
         fn_args = dict(part.function_call.args)
 
-        print(f"🤖 Agent wants to call: {fn_name}")
+        print(f"Agent wants to call: {fn_name}")
 
         if fn_name == "wallet_screening":
-            # Execute the skill logic
-            print("⚙️ Executing skill locally...")
+            print("Executing skill locally...")
             api_result = wallet_skill.execute(fn_args)
 
-            # Send the result back to the model
-            print("📤 Sending result back to Agent...")
-            response = chat.send_message(
-                [
+            print("Sending result back to Agent...")
+            response = client.models.generate_content(
+                model="gemini-2.5-flash",
+                contents=[
+                    "Use this tool result to answer the original request.",
                     {
                         "function_response": {
                             "name": fn_name,
                             "response": {"result": api_result},
                         }
-                    }
-                ]
+                    },
+                ],
+                config=types.GenerateContentConfig(
+                    tools=[tool],
+                    system_instruction=system_instruction,
+                ),
             )
         else:
             print(f"Unknown function: {fn_name}")
             break
     else:
-        # No function call, just text
         break
 
-print("\n💬 Agent Final Response:")
+print("\nAgent Final Response:")
 print(response.text)

--- a/examples/mica_rag_flow.py
+++ b/examples/mica_rag_flow.py
@@ -1,24 +1,20 @@
-import os
 import json
 import re
-import google.generativeai as genai
+
+import google.genai as genai
 from skillware.core.loader import SkillLoader
 from skillware.core.env import load_env_file
 
 
 def main():
-    # 1. Setup
     load_env_file()
-    genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+    client = genai.Client()
 
     print("[System] Loading MiCA Module (Cognitive/Surgical Mode)...")
     skill_bundle = SkillLoader.load_skill("compliance/mica_module")
-    # Instantiate the logic
     MiCA_Module = skill_bundle["module"].MiCAModuleSkill
     mica_skill = MiCA_Module()
 
-    # 2. Build the "Cognitive Map" (System Instructions + Manifest)
-    # We use the un-altered manifest name here (slashes are fine in text prompts!)
     tool_text = SkillLoader.to_ollama_prompt(skill_bundle)
 
     system_instruction = f"""{skill_bundle.get('instructions', '')}
@@ -37,38 +33,35 @@ If you need regulatory context, output a JSON block like this:
 Wait for the response before making your final compliant determination.
 """
 
-    model = genai.GenerativeModel("gemini-2.5-flash-lite")
-
-    user_query = "How do I get an authorization to be a crypto-asset service provider (CASP) in the EU?"
+    user_query = (
+        "How do I get an authorization to be a crypto-asset service provider (CASP) in the EU?"
+    )
 
     print(f"\n[User]: {user_query}")
     print("-" * 50)
 
-    chat = model.start_chat()
     result_msg = ""
 
     print("Agent (Gemini) is thinking...", flush=True)
 
-    # turn limit for safety
     for turn in range(3):
         try:
-            # First turn uses the prompt, subsequent turns use the skill result
             prompt = (
                 system_instruction + "\n\nUSER QUERY: " + user_query
                 if turn == 0
                 else result_msg
             )
 
-            # Use streaming for visual feedback
-            response = chat.send_message(prompt, stream=True)
-
             full_content = ""
             print("\n[Agent]: ", end="", flush=True)
-            for chunk in response:
-                print(chunk.text, end="", flush=True)
-                full_content += chunk.text
+            for chunk in client.models.generate_content_stream(
+                model="gemini-2.5-flash-lite",
+                contents=prompt,
+            ):
+                if chunk.text:
+                    print(chunk.text, end="", flush=True)
+                    full_content += chunk.text
 
-            # Extract Tool Call
             match = re.search(r"```json\s*({.*?})\s*```", full_content, re.DOTALL)
             if match:
                 call_data = json.loads(match.group(1))
@@ -85,18 +78,17 @@ Wait for the response before making your final compliant determination.
                 sections = result.get("retrieved_sections", [])
                 print(f" > Articles found: {', '.join(sections)}")
 
-                # Feedback loop
                 result_msg = (
-                    f"SYSTEM RESPONSE (Source Articles):\n{result.get('final_context_for_agent', '')}\n\n"
+                    f"SYSTEM RESPONSE (Source Articles):\n"
+                    f"{result.get('final_context_for_agent', '')}\n\n"
                     "Please generate your final authorized response."
                 )
             else:
-                # No more tool calls, done
                 print("\n\n(Scenario Complete)")
                 break
 
-        except Exception as e:
-            print(f"\n[Error]: {e}")
+        except Exception as exc:
+            print(f"\n[Error]: {exc}")
             break
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ cli = [
     "rich>=13.0",
 ]
 gemini = [
-    "google-generativeai",
+    "google-genai",
 ]
 claude = [
     "anthropic",
@@ -52,7 +52,7 @@ office = [
 ]
 all = [
     "rich>=13.0",
-    "google-generativeai",
+    "google-genai",
     "anthropic",
     "openai",
     "pymupdf",

--- a/skills/compliance/mica_module/manifest.yaml
+++ b/skills/compliance/mica_module/manifest.yaml
@@ -21,7 +21,7 @@ parameters:
   required:
     - user_prompt
 requirements:
-  - google.generativeai
+  - google-genai
 constitution: |
   1. COMPLIANCE: Do not invent or hallucinate financial regulations. Base all enforcement strictly on the provided MiCA corpus blocks.
   2. FOCUS: Act exclusively as a compliance firewall and RAG engine; retrieve relevant chunks incrementally.

--- a/skills/compliance/mica_module/skill.py
+++ b/skills/compliance/mica_module/skill.py
@@ -1,7 +1,7 @@
 import json
 import os
 from typing import Any, Dict, List
-import google.generativeai as genai
+
 from skillware.core.base_skill import BaseSkill
 
 
@@ -207,11 +207,43 @@ class MiCAModuleSkill(BaseSkill):
         """
 
         try:
-            model = genai.GenerativeModel(model_name)
-            resp = model.generate_content(
-                prompt_payload,
-                generation_config=genai.GenerationConfig(
-                    response_mime_type="application/json", temperature=0.0
+            import google.genai as genai
+            from google.genai import types
+        except ImportError:
+            return {
+                "policy_status": "CAUTION",
+                "gemini_evaluator_feedback": {
+                    "grade": "N/A",
+                    "holes_found": "google-genai is not installed.",
+                    "suggestion": "Proceed manually integrating the extracted logic.",
+                },
+                "final_context_for_agent": (
+                    f"Output your final answer seamlessly integrating and adhering to these MiCA rules:\n{context}"
+                ),
+            }
+
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            return {
+                "policy_status": "CAUTION",
+                "gemini_evaluator_feedback": {
+                    "grade": "N/A",
+                    "holes_found": "GOOGLE_API_KEY is not configured.",
+                    "suggestion": "Proceed manually integrating the extracted logic.",
+                },
+                "final_context_for_agent": (
+                    f"Output your final answer seamlessly integrating and adhering to these MiCA rules:\n{context}"
+                ),
+            }
+
+        try:
+            client = genai.Client(api_key=api_key)
+            resp = client.models.generate_content(
+                model=model_name,
+                contents=prompt_payload,
+                config=types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    temperature=0.0,
                 ),
             )
             return json.loads(resp.text)

--- a/skills/compliance/tos_evaluator/skill.py
+++ b/skills/compliance/tos_evaluator/skill.py
@@ -11,9 +11,11 @@ from bs4 import BeautifulSoup
 from skillware.core.base_skill import BaseSkill
 
 try:
-    import google.generativeai as genai
+    import google.genai as genai
+    from google.genai import types
 except ImportError:  # pragma: no cover - dependency is optional at runtime
     genai = None
+    types = None
 
 
 class TOSEvaluatorSkill(BaseSkill):
@@ -458,14 +460,13 @@ class TOSEvaluatorSkill(BaseSkill):
                 "status": "skipped",
                 "reason": f"Unsupported llm_provider '{normalized['llm_provider']}'.",
             }
-        if genai is None:
-            return {"status": "skipped", "reason": "google-generativeai is not installed."}
+        if genai is None or types is None:
+            return {"status": "skipped", "reason": "google-genai is not installed."}
 
         api_key = os.environ.get("GOOGLE_API_KEY")
         if not api_key:
             return {"status": "skipped", "reason": "GOOGLE_API_KEY is not configured."}
 
-        genai.configure(api_key=api_key)
         prompt = {
             "target_url": normalized["target_url"],
             "intended_action": normalized["intended_action"],
@@ -479,11 +480,13 @@ class TOSEvaluatorSkill(BaseSkill):
         }
 
         try:
-            model = genai.GenerativeModel(normalized["llm_model"])
-            response = model.generate_content(
-                json.dumps(prompt, ensure_ascii=True),
-                generation_config=genai.GenerationConfig(
-                    response_mime_type="application/json", temperature=0.0
+            client = genai.Client(api_key=api_key)
+            response = client.models.generate_content(
+                model=normalized["llm_model"],
+                contents=json.dumps(prompt, ensure_ascii=True),
+                config=types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    temperature=0.0,
                 ),
             )
             parsed = json.loads(response.text)

--- a/skills/data_engineering/synthetic_generator/skill.py
+++ b/skills/data_engineering/synthetic_generator/skill.py
@@ -38,19 +38,18 @@ class SyntheticGeneratorSkill(BaseSkill):
     def _call_gemini(
         self, prompt: str, temperature: float, model_name: str
     ) -> str:
-        import google.generativeai as genai
+        import google.genai as genai
+        from google.genai import types
+
         api_key = (
             self.config.get("GOOGLE_API_KEY")
             or os.environ.get("GOOGLE_API_KEY")
         )
-        if api_key:
-            genai.configure(api_key=api_key)
-        model = genai.GenerativeModel(model_name)
-        response = model.generate_content(
-            prompt,
-            generation_config=genai.types.GenerationConfig(
-                temperature=temperature
-            )
+        client = genai.Client(api_key=api_key)
+        response = client.models.generate_content(
+            model=model_name,
+            contents=prompt,
+            config=types.GenerateContentConfig(temperature=temperature),
         )
         return response.text
 

--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -9,12 +9,26 @@ from typing import Dict, Any, List, Optional
 SKILLWARE_SKILL_PATH_ENV = "SKILLWARE_SKILL_PATH"
 _MAX_PARENT_WALK = 6
 
+# PyPI distribution names that differ from their import paths.
+_REQUIREMENT_IMPORT_ALIASES = {
+    "google-genai": "google.genai",
+    "google-generativeai": "google.generativeai",
+    "pymupdf": "fitz",
+    "beautifulsoup4": "bs4",
+    "pyyaml": "yaml",
+}
+
 
 class SkillLoader:
     """
     Utility to load skills dynamically or by path, bundling their
     manifests, instructions, and logic for LLM usage.
     """
+
+    @staticmethod
+    def _requirement_import_name(requirement: str) -> str:
+        pkg_name = requirement.split(">")[0].split("<")[0].split("=")[0].strip()
+        return _REQUIREMENT_IMPORT_ALIASES.get(pkg_name, pkg_name)
 
     @staticmethod
     def _is_skill_dir(path: Path) -> bool:
@@ -117,11 +131,8 @@ class SkillLoader:
         if "requirements" in manifest:
             missing = []
             for req in manifest["requirements"]:
-                # Simple check for package name. Complex version parsing (>=1.0)
-                # requires packaging.utils or similar, but keeping it deps-free for now.
-                # We strip version specifiers for the import check.
-                pkg_name = req.split(">")[0].split("<")[0].split("=")[0].strip()
-                if not importlib.util.find_spec(pkg_name):
+                import_name = SkillLoader._requirement_import_name(req)
+                if not importlib.util.find_spec(import_name):
                     missing.append(req)
 
             if missing:

--- a/tests/skills/compliance/test_tos_evaluator.py
+++ b/tests/skills/compliance/test_tos_evaluator.py
@@ -175,17 +175,20 @@ def test_tos_evaluator_llm_fallback_is_mockable(mock_get):
 
     bundle = SkillLoader.load_skill("compliance/tos_evaluator")
     mock_genai = MagicMock()
-    mock_model = MagicMock()
-    mock_model.generate_content.return_value.text = json.dumps(
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(
         {
             "verdict": "CAUTION",
             "confidence_score": 0.81,
             "rationale": "The clause conditions automation on prior written consent.",
         }
     )
-    mock_genai.GenerativeModel.return_value = mock_model
-    mock_genai.GenerationConfig.return_value = object()
+    mock_client.models.generate_content.return_value = mock_response
+    mock_genai.Client.return_value = mock_client
+    mock_types = MagicMock()
     bundle["module"].genai = mock_genai
+    bundle["module"].types = mock_types
     skill = bundle["module"].TOSEvaluatorSkill()
     with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}):
         result = skill.execute(


### PR DESCRIPTION
Replace deprecated `google-generativeai` usage with the supported `google-genai` SDK across optional dependencies, skill runtime code, reference examples, and usage docs. Add PyPI-to-import aliases in `SkillLoader` so manifest requirements such as `google-genai` resolve correctly at load time.

Fixes #80

## Description

Migrates Skillware off the deprecated Gemini SDK:

- **`pyproject.toml`**: `[gemini]` and `[all]` extras now install `google-genai`
- **`skillware/core/loader.py`**: map PyPI package names to import paths (`google-genai` → `google.genai`, etc.)
- **Skills**: update Gemini calls in `tos_evaluator`, `mica_module`, and `synthetic_generator`
- **Examples**: migrate `gemini_*.py` and `mica_rag_flow.py` to `google.genai.Client()` + `GenerateContentConfig` patterns
- **Docs**: install note in `docs/usage/gemini.md`, usage README and `agent_loops.md` alignment
- **Tests**: update `test_tos_evaluator` mocks for the new client API

Verified locally with **Python 3.13**: `pytest tests/` (50 passed), `flake8` on changed files.

Also addresses the remaining scope of #96 (examples + complementary usage docs). Recommend closing #96 after merge.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).

## New or updated skill

Skipped — no new registry skill. Existing skills were updated as part of the SDK migration only.

## Constitution & Safety

No change to skill constitutions. Migration preserves existing behavior: optional Gemini calls remain behind env keys and graceful skip paths when `google-genai` or `GOOGLE_API_KEY` is unavailable.

## Related Issues

Fixes #80  
Also completes the remaining scope of #96