### PR TITLE
docs: align skill pages with runnable examples inventory

### DIFF
--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -53,6 +53,10 @@ Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.
 
 Sample user message: *Analyse issue #56 in ARPAHLS/skillware and produce a resolution plan.*
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. Runnable example: pending — `dev_tools/issue_resolver` does not yet have a dedicated script under `examples/`, so the provider sections below remain catalog snippets until issue #118 lands.
+
 ### Direct execute
 
 ```python

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -48,6 +48,10 @@ Configure values per [API keys for skills](../usage/api_keys.md).
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The runnable scripts currently checked in for this skill are `examples/mica_rag_flow.py`, `examples/mica_claude_flow.py`, and `examples/mica_ollama_flow.py`.
+
 | Provider | Reference script |
 | :--- | :--- |
 | Gemini / RAG | `examples/mica_rag_flow.py` |

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -44,6 +44,10 @@ Configure values per [API keys for skills](../usage/api_keys.md).
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable scripts today are `examples/gemini_pdf_form_filler.py` and `examples/claude_pdf_form_filler.py`. The OpenAI, DeepSeek, and Ollama sections below are catalog snippets only unless separate runnable examples are added later.
+
 | Provider | Reference script |
 | :--- | :--- |
 | Gemini | `examples/gemini_pdf_form_filler.py` |

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -61,7 +61,9 @@ The `micro-f1-mask` model detects a variety of entities, including but not limit
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). Skill execution uses local Ollama (`arpacorp/micro-f1-mask`); no cloud agent key required for the masker itself.
 
-Reference flow: `examples/pii_guardrail_flow.py`.
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable example for this skill is `examples/pii_guardrail_flow.py`, which demonstrates the local execute path rather than a full provider loop.
 
 Sample user message: *Mask PII in: "Hello John Doe, your wallet 0xabc123 has been verified."*
 

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -28,6 +28,10 @@ Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.
 
 Sample user message: *Compress this prompt before the main model call: "Hello, could you please make sure to read this documentation..."*
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable example for this skill is `examples/prompt_compression_demo.py`; the provider sections below are catalog snippets rather than separate checked-in loop scripts.
+
 ### Direct execute
 
 ```python

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -44,6 +44,10 @@ Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.
 
 Sample user message: *Generate five high-entropy medical coding dispute samples with dual-insurance edge cases.*
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable example for this skill is `examples/build_dataset_demo.py`, which uses the skill's local execute path while configuring the internal generator with a Gemini backend.
+
 ### Direct execute
 
 ```python

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -82,6 +82,10 @@ Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.
 
 Sample user message: *Before crawling https://example.com/docs, check if automated indexing is allowed.*
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. This skill currently has dedicated runnable loops for every documented provider: `examples/gemini_tos_evaluator.py`, `examples/claude_tos_evaluator.py`, `examples/openai_tos_evaluator.py`, `examples/deepseek_tos_evaluator.py`, and `examples/ollama_tos_evaluator.py`.
+
 | Provider | Reference script |
 | :--- | :--- |
 | Gemini | `examples/gemini_tos_evaluator.py` |

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -63,10 +63,15 @@ Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.
 
 Sample user message: *Screen wallet `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` for sanctions and malicious contract interactions.*
 
+### Runnable examples
+
+See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. This page includes provider snippets, but the dedicated runnable flows today are `examples/gemini_wallet_check.py`, `examples/claude_wallet_check.py`, and the multi-skill Ollama harness `examples/ollama_skills_test.py`.
+
 | Provider | Reference script |
 | :--- | :--- |
 | Gemini | `examples/gemini_wallet_check.py` |
 | Claude | `examples/claude_wallet_check.py` |
+| Ollama (multi-skill harness) | `examples/ollama_skills_test.py` |
 
 ### Gemini
 


### PR DESCRIPTION
## Summary
- add explicit Runnable examples notes to affected skill pages
- point each page at the checked-in scripts that really exist under `examples/`
- mark catalog-only/provider-snippet sections clearly where no dedicated runnable example exists yet

## Validation
- `python3 -m flake8 docs/skills`
- `git diff --check`
- verified every referenced example path exists under `examples/`
- targeted pytest spot checks: `skills/dev_tools/issue_resolver/test_skill.py`, `tests/test_skill_issuer.py`

Closes #119