### PR TITLE
docs: sync examples index references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@ Humans: Please describe what this PR does and why it's needed.
 
 - [ ] My code follows the **Agent Code of Conduct**.
 - [ ] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
+- [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.
 
 ## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -90,7 +90,7 @@ You must:
 | :--- | :--- |
 | New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed |
 | Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
-| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/` |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/` |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |
 | Good first issue | Issue labels and acceptance criteria—take them literally |
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -51,11 +51,16 @@ have runnable examples. Gemini reference scripts use the `google-genai` SDK
 (`import google.genai`). All [skill catalog pages](../skills/README.md)
 include compact **Usage Examples** per provider.
 
-| Skill | Gemini | Claude | OpenAI | DeepSeek | Ollama |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| `compliance/tos_evaluator` | `gemini_tos_evaluator.py` | `claude_tos_evaluator.py` | `openai_tos_evaluator.py` | `deepseek_tos_evaluator.py` | `ollama_tos_evaluator.py` |
-| `finance/wallet_screening` | `gemini_wallet_check.py` | `claude_wallet_check.py` | (catalog page) | (catalog page) | (catalog page) |
-| `office/pdf_form_filler` | `gemini_pdf_form_filler.py` | `claude_pdf_form_filler.py` | (catalog page) | (catalog page) | (catalog page) |
-| `compliance/mica_module` | `mica_rag_flow.py` | `mica_claude_flow.py` | (catalog page) | (catalog page) | `mica_ollama_flow.py` |
-| `compliance/pii_masker` | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
-| Other skills | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
+`Local execute / mixed` means the checked-in script is not a single-provider
+agent loop. It either calls `skill.execute(...)` directly or loads multiple
+skills in one harness.
+
+| Skill | Local execute / mixed | Gemini | Claude | OpenAI | DeepSeek | Ollama |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `compliance/tos_evaluator` | - | `gemini_tos_evaluator.py` | `claude_tos_evaluator.py` | `openai_tos_evaluator.py` | `deepseek_tos_evaluator.py` | `ollama_tos_evaluator.py` |
+| `finance/wallet_screening` | - | `gemini_wallet_check.py` | `claude_wallet_check.py` | (catalog page) | (catalog page) | `ollama_skills_test.py` (multi-skill) |
+| `office/pdf_form_filler` | - | `gemini_pdf_form_filler.py` | `claude_pdf_form_filler.py` | (catalog page) | (catalog page) | `ollama_skills_test.py` (multi-skill) |
+| `compliance/mica_module` | - | `mica_rag_flow.py` | `mica_claude_flow.py` | (catalog page) | (catalog page) | `mica_ollama_flow.py` |
+| `compliance/pii_masker` | `pii_guardrail_flow.py` (local execute) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
+| `optimization/prompt_rewriter` | `prompt_compression_demo.py` (local execute) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | `ollama_skills_test.py` (multi-skill) |
+| `data_engineering/synthetic_generator` | `build_dataset_demo.py` (local execute, Gemini backend) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |


### PR DESCRIPTION
## Description

Syncs the example-script references introduced by the examples index follow-up:

- updates `docs/usage/agent_loops.md` so the quick matrix no longer contradicts `examples/README.md`
- adds a PR-template checkbox for maintaining `examples/README.md` when runnable scripts change
- updates the documentation-only workflow row to mention `examples/README.md` for runnable-script additions, renames, or removals

This PR was prepared with AI assistance under human supervision. I kept the change small and included the checks I ran below.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [ ] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
  - `python -m flake8 .` could not run because `flake8` is not installed in this local Python environment.
  - `python -m pytest tests/ -q` stopped during collection because optional dependency `anthropic` is not installed for `tests/skills/office/test_pdf_form_filler.py`.
  - Relevant focused check `python -m pytest tests/test_cli.py -q` passed.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.
  - No runnable scripts were added, renamed, or removed; the existing index was used as the source of truth.

## New or updated skill

Not applicable; this PR does not add or modify a skill bundle.

## Constitution & Safety

Documentation-only change. No skill logic, runtime behavior, secrets, dependencies, or external service calls are changed.

## Checks run

- `git diff --check` passed
- Target path sanity check for `examples/README.md`, `docs/usage/agent_loops.md`, `docs/contributing/ai_native_workflow.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/introduction.md` passed
- `python -m pytest tests/test_cli.py -q` passed: 8 passed
- `python -m pytest tests/ -q` blocked by missing optional `anthropic` dependency during collection
- `python -m flake8 .` blocked because `flake8` is not installed locally

## Related Issues

Fixes #117