### PR TITLE
Feat/issue 93 cli visual redesign

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -11,6 +11,16 @@ The CLI depends on `rich` for terminal output. Install it with the `cli` extra:
 
     pip install "skillware[cli]"
 
+## Interactive menu
+
+Running `skillware` with no arguments launches an ASCII splash screen and an
+interactive numbered menu:
+
+    skillware
+
+The menu accepts both number input (`1`) and command name (`list`). Press `q`
+or Enter to exit cleanly.
+
 ## Commands
 
 ### skillware list
@@ -21,10 +31,10 @@ Print a table of all locally available skills.
 
 Sample output:
 
-    ID                           VERSION  CATEGORY    ISSUER      DESCRIPTION                        REQUIREMENTS
-    compliance/pii_masker        0.1.0    compliance  rosspeili   High-precision PII detection...    requests
-    finance/wallet_screening     1.0.0    finance     rosspeili   Crypto wallet screening tool...    requests
-    office/pdf_form_filler       0.1.0    office      rosspeili   Fills PDF forms from natural...    pymupdf, anthropic
+    ID                           VERSION  CATEGORY    ISSUER      DESCRIPTION                                       REQUIREMENTS
+    compliance/pii_masker        0.1.0    compliance  rosspeili   Detects and redacts PII locally using Ollama.     requests
+    finance/wallet_screening     1.0.0    finance     rosspeili   Screens Ethereum wallets against OFAC sanctions.  requests
+    office/pdf_form_filler       0.1.0    office      rosspeili   Fills PDF forms from natural language.            pymupdf, anthropic
 
 #### Flags
 
@@ -60,4 +70,26 @@ To point the CLI at a persistent custom root, set the environment variable:
 
 Only skills with both `manifest.yaml` and `skill.py` present are shown —
 the same condition `SkillLoader` requires to load a skill successfully.
+
+## Color theme
+
+The CLI uses a pastel color palette consistent with the project's visual identity:
+
+| Element | Color | Hex |
+| :--- | :--- | :--- |
+| Table headers and borders | Lavender | `#C7CEEA` |
+| Category column | Peach | `#FFDAC1` |
+| Skill ID column | Mint | `#B5EAD7` |
+| Splash screen | Lavender | `#C7CEEA` |
+| Interactive menu | Peach | `#FFDAC1` |
+
+## short_description field
+
+Skill manifests can include a `short_description` field (max 80 chars) for
+a concise one-line summary shown in `skillware list`:
+
+    short_description: "Screens Ethereum wallets against OFAC sanctions and mixer lists."
+
+If `short_description` is absent, the CLI falls back to the first sentence
+of `description`, truncated to 80 characters.
 

--- a/skills/compliance/mica_module/manifest.yaml
+++ b/skills/compliance/mica_module/manifest.yaml
@@ -1,6 +1,7 @@
 name: compliance/mica_module
 version: 0.1.0
 description: A highly specialized, localized RAG and policy enforcement engine for the Markets in Crypto-Assets (MiCA) regulation.
+short_description: "Local RAG and policy enforcement engine for MiCA regulation."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/compliance/pii_masker/manifest.yaml
+++ b/skills/compliance/pii_masker/manifest.yaml
@@ -1,6 +1,7 @@
 name: compliance/pii_masker
 version: 0.1.0
 description: High-precision, local PII detection and redaction using the micro-f1-mask model via Ollama.
+short_description: "Detects and redacts PII locally using the micro-f1-mask model."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/compliance/tos_evaluator/manifest.yaml
+++ b/skills/compliance/tos_evaluator/manifest.yaml
@@ -1,6 +1,7 @@
 name: "compliance/tos_evaluator"
 version: "0.1.0"
 description: "Evaluates whether an intended automated website action appears permissible by checking robots.txt, discovered legal pages, and optional low-cost LLM review for ambiguous policy language."
+short_description: "Evaluates whether an automated web action is permitted by site policy."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/data_engineering/novelty_extractor/manifest.yaml
+++ b/skills/data_engineering/novelty_extractor/manifest.yaml
@@ -1,6 +1,7 @@
 name: "data_engineering/novelty_extractor"
 version: "0.1.0"
 description: "Filters a text dataset by semantic novelty, retaining only chunks that carry new information above a configurable threshold."
+short_description: "Filters text datasets by semantic novelty using local embeddings."
 issuer:
   name: Martin Rizzo Lozano
   email: rizzolozanomartin@gmail.com

--- a/skills/data_engineering/synthetic_generator/manifest.yaml
+++ b/skills/data_engineering/synthetic_generator/manifest.yaml
@@ -1,6 +1,7 @@
 name: "data_engineering/synthetic_generator"
 version: "0.1.0"
 description: "Generates high-entropy structured synthetic data for model fine-tuning to avoid mode collapse."
+short_description: "Generates high-entropy synthetic JSONL data for model fine-tuning."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/dev_tools/issue_resolver/manifest.yaml
+++ b/skills/dev_tools/issue_resolver/manifest.yaml
@@ -1,6 +1,7 @@
 name: "dev_tools/issue_resolver"
 version: "0.1.0"
 description: "Analyzes any GitHub issue against its target repository and produces a structured resolution plan with ranked implementation options, affected files, and caveats."
+short_description: "Analyzes a GitHub issue and produces a ranked implementation plan."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/finance/wallet_screening/manifest.yaml
+++ b/skills/finance/wallet_screening/manifest.yaml
@@ -2,6 +2,7 @@ name: wallet_screening
 version: 1.0.0
 description: |
   A comprehensive crypto wallet screening tool. Checks Ethereum addresses against sanctions lists (OFAC, FBI, etc.) and known malicious contracts (Mixers, Scams). analyze transaction history for risk.
+short_description: "Screens Ethereum wallets against OFAC sanctions and mixer lists."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/office/pdf_form_filler/manifest.yaml
+++ b/skills/office/pdf_form_filler/manifest.yaml
@@ -1,6 +1,7 @@
 name: pdf_form_filler
 version: 0.1.0
 description: Fills PDF forms based on natural language instructions.
+short_description: "Fills PDF forms from natural language instructions using Claude."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skills/optimization/prompt_rewriter/manifest.yaml
+++ b/skills/optimization/prompt_rewriter/manifest.yaml
@@ -1,6 +1,7 @@
 name: "optimization/prompt_rewriter"
 version: "0.1.0"
 description: "A powerful middleware skill that aggressively compresses massive, bloated prompts into fewer tokens while retaining 100% of the semantic meaning and instructions."
+short_description: "Compresses bloated prompts into fewer tokens without losing meaning."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -5,13 +5,13 @@ from typing import List, Dict, Any, Optional
 
 from skillware.core.loader import SkillLoader
 
-TABLE_STYLE     = "bold #C7CEEA"    # lavender  - headers
-CATEGORY_STYLE  = "bold #FFDAC1"    # peach     - category column
-ID_STYLE        = "#B5EAD7"       # mint      - skill ID column
-BORDER_STYLE    = "#C7CEEA"       # lavender  - table border
+TABLE_STYLE = "bold #C7CEEA"  # lavender  - headers
+CATEGORY_STYLE = "bold #FFDAC1"  # peach     - category column
+ID_STYLE = "#B5EAD7"  # mint      - skill ID column
+BORDER_STYLE = "#C7CEEA"  # lavender  - table border
 
-SPLASH_STYLE    = "#C7CEEA"       # lavender  - swillware splash color
-MENU_STYLE      = "#FFDAC1"       # peach     - menu category
+SPLASH_STYLE = "#C7CEEA"  # lavender  - swillware splash color
+MENU_STYLE = "#FFDAC1"  # peach     - menu category
 
 
 def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
@@ -36,6 +36,7 @@ def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
 
     return roots
 
+
 def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
     """Return short_description if present, else first sentence of description truncated."""
     short = data.get("short_description", "").strip()
@@ -51,7 +52,7 @@ def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
         if idx != -1:
             desc = desc[: idx + 1]
             break
-    
+
     return desc[:max_len] + ("..." if len(desc) > max_len else "")
 
 
@@ -129,17 +130,15 @@ def cmd_list(
         return
 
     table = Table(
-        box=box.SIMPLE_HEAVY,
-        border_style=BORDER_STYLE,
-        header_style=TABLE_STYLE
+        box=box.SIMPLE_HEAVY, border_style=BORDER_STYLE, header_style=TABLE_STYLE
     )
 
-    table.add_column("ID",              style=ID_STYLE,     no_wrap=True)
-    table.add_column("VERSION",         style="dim")
-    table.add_column("CATEGORY",        style=CATEGORY_STYLE)
-    table.add_column("ISSUER",          style="dim")
+    table.add_column("ID", style=ID_STYLE, no_wrap=True)
+    table.add_column("VERSION", style="dim")
+    table.add_column("CATEGORY", style=CATEGORY_STYLE)
+    table.add_column("ISSUER", style="dim")
     table.add_column("DESCRIPTION")
-    table.add_column("REQUIREMENTS",    style="dim")
+    table.add_column("REQUIREMENTS", style="dim")
 
     for skill in skills:
         table.add_row(
@@ -153,6 +152,7 @@ def cmd_list(
 
     console.print(table)
 
+
 def cmd_interactive(console=None, parser=None) -> None:
     """Launch ASCII splash screen and interactive menu."""
     try:
@@ -162,17 +162,17 @@ def cmd_interactive(console=None, parser=None) -> None:
         raise SystemExit(
             "rich is required for the CLI. Install it with: pip install 'skillware[cli]'"
         )
-    
+
     import importlib.metadata
 
     if console is None:
         console = Console()
-    
+
     try:
         version = importlib.metadata.version("skillware")
     except importlib.metadata.PackageNotFoundError:
         version = "dev"
-    
+
     splash = r"""
   ███████╗██╗  ██╗██╗██╗     ██╗    ██╗ █████╗ ██████╗ ███████╗
   ██╔════╝██║ ██╔╝██║██║     ██║    ██║██╔══██╗██╔══██╗██╔════╝
@@ -180,7 +180,7 @@ def cmd_interactive(console=None, parser=None) -> None:
   ╚════██║██╔═██╗ ██║██║     ██║███╗██║██╔══██║██╔══██╗██╔══╝
   ███████║██║  ██╗██║███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗
   ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝"""
-    
+
     console.print(Text(splash, style=SPLASH_STYLE))
     console.print(
         Text(
@@ -222,7 +222,7 @@ def cmd_interactive(console=None, parser=None) -> None:
         if choice in ("q", ""):
             console.print("  Bye.", style="dim")
             return
-        
+
         command = commands.get(choice)
 
         if command == "list":
@@ -236,11 +236,14 @@ def cmd_interactive(console=None, parser=None) -> None:
             if parser:
                 parser.print_help()
             else:
-                console.print("  Run 'skillware --help' for usage information.", style="dim")
+                console.print(
+                    "  Run 'skillware --help' for usage information.", style="dim"
+                )
         else:
             console.print(f"  Unknown command: '{choice}'", style="dim #FF9AA2")
 
         console.print()
+
 
 def main() -> None:
     """CLI entry point."""

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -5,6 +5,11 @@ from typing import List, Dict, Any, Optional
 
 from skillware.core.loader import SkillLoader
 
+TABLE_STYLE     = "bold #C7CEEA"    # lavender  - headers
+CATEGORY_STYLE  = "bold #FFDAC1"    # peach     - category column
+ID_STYLE        = "#B5EAD7"       # mint      - skill ID column
+BORDER_STYLE    = "#C7CEEA"       # lavender  - table border
+
 
 def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
     """Return the list of roots to search for skills, mirrors SkillLoader resolution order."""
@@ -99,6 +104,7 @@ def cmd_list(
     try:
         from rich.table import Table
         from rich.console import Console
+        from rich import box
     except ImportError:
         raise SystemExit(
             "rich is required for the CLI. Install it with: pip install 'skillware[cli]'"
@@ -119,14 +125,18 @@ def cmd_list(
         console.print("No skills found.")
         return
 
-    table = Table()
+    table = Table(
+        box=box.SIMPLE_HEAVY,
+        border_style=BORDER_STYLE,
+        header_style=TABLE_STYLE
+    )
 
-    table.add_column("ID")
-    table.add_column("VERSION")
-    table.add_column("CATEGORY")
-    table.add_column("ISSUER")
+    table.add_column("ID",              style=ID_STYLE,     no_wrap=True)
+    table.add_column("VERSION",         style="dim")
+    table.add_column("CATEGORY",        style=CATEGORY_STYLE)
+    table.add_column("ISSUER",          style="dim")
     table.add_column("DESCRIPTION")
-    table.add_column("REQUIREMENTS")
+    table.add_column("REQUIREMENTS",    style="dim")
 
     for skill in skills:
         table.add_row(
@@ -139,7 +149,6 @@ def cmd_list(
         )
 
     console.print(table)
-
 
 def main() -> None:
     """CLI entry point."""

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -10,6 +10,9 @@ CATEGORY_STYLE  = "bold #FFDAC1"    # peach     - category column
 ID_STYLE        = "#B5EAD7"       # mint      - skill ID column
 BORDER_STYLE    = "#C7CEEA"       # lavender  - table border
 
+SPLASH_STYLE    = "#C7CEEA"       # lavender  - swillware splash color
+MENU_STYLE      = "#FFDAC1"       # peach     - menu category
+
 
 def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
     """Return the list of roots to search for skills, mirrors SkillLoader resolution order."""
@@ -150,6 +153,95 @@ def cmd_list(
 
     console.print(table)
 
+def cmd_interactive(console=None, parser=None) -> None:
+    """Launch ASCII splash screen and interactive menu."""
+    try:
+        from rich.console import Console
+        from rich.text import Text
+    except ImportError:
+        raise SystemExit(
+            "rich is required for the CLI. Install it with: pip install 'skillware[cli]'"
+        )
+    
+    import importlib.metadata
+
+    if console is None:
+        console = Console()
+    
+    try:
+        version = importlib.metadata.version("skillware")
+    except importlib.metadata.PackageNotFoundError:
+        version = "dev"
+    
+    splash = r"""
+  ███████╗██╗  ██╗██╗██╗     ██╗    ██╗ █████╗ ██████╗ ███████╗
+  ██╔════╝██║ ██╔╝██║██║     ██║    ██║██╔══██╗██╔══██╗██╔════╝
+  ███████╗█████╔╝ ██║██║     ██║ █╗ ██║███████║██████╔╝█████╗
+  ╚════██║██╔═██╗ ██║██║     ██║███╗██║██╔══██║██╔══██╗██╔══╝
+  ███████║██║  ██╗██║███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗
+  ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝"""
+    
+    console.print(Text(splash, style=SPLASH_STYLE))
+    console.print(
+        Text(
+            f"  Skill Management Framework - v{version}\n",
+            style=f"dim {SPLASH_STYLE}",
+        )
+    )
+
+    menu = [
+        ("1", "list", "discover and display all locally installed skills"),
+        ("2", "paths", "show and repair skill directory resolution paths"),
+        ("3", "test", "run test_skill.py for one or all skills"),
+        ("4", "help", "usage guide for any command"),
+    ]
+
+    for num, name, desc in menu:
+        console.print(f"    [{num}] {name:<10}— {desc}", style=MENU_STYLE)
+
+    console.print()
+
+    commands = {
+        "1": "list",
+        "list": "list",
+        "2": "paths",
+        "paths": "paths",
+        "3": "test",
+        "test": "test",
+        "4": "help",
+        "help": "help",
+    }
+
+    while True:
+        try:
+            choice = input("  > ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n  Bye.", style="dim")
+            return
+
+        if choice in ("q", ""):
+            console.print("  Bye.", style="dim")
+            return
+        
+        command = commands.get(choice)
+
+        if command == "list":
+            cmd_list()
+        elif command in ("paths", "test"):
+            console.print(
+                f"  '{command}' is not yet implemented. Coming in a future release.",
+                style="dim",
+            )
+        elif command == "help":
+            if parser:
+                parser.print_help()
+            else:
+                console.print("  Run 'skillware --help' for usage information.", style="dim")
+        else:
+            console.print(f"  Unknown command: '{choice}'", style="dim #FF9AA2")
+
+        console.print()
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(prog="skillware")
@@ -182,7 +274,7 @@ def main() -> None:
             issuer_filter=args.issuer,
         )
     else:
-        parser.print_help()
+        cmd_interactive(parser=parser)
 
 
 if __name__ == "__main__":

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -28,6 +28,24 @@ def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
 
     return roots
 
+def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
+    """Return short_description if present, else first sentence of description truncated."""
+    short = data.get("short_description", "").strip()
+    if short:
+        return short[:max_len] + ("..." if len(short) > max_len else "")
+
+    desc = data.get("description", "").strip()
+
+    seps = [".", "!", "?"]
+
+    for sep in seps:
+        idx = desc.find(sep)
+        if idx != -1:
+            desc = desc[: idx + 1]
+            break
+    
+    return desc[:max_len] + ("..." if len(desc) > max_len else "")
+
 
 def _discover_skills(
     skills_root_override: Optional[Path] = None,
@@ -62,7 +80,7 @@ def _discover_skills(
                     "category": manifest_path.parent.parent.name,
                     "name": manifest_path.parent.name,
                     "version": data.get("version", "?").strip(),
-                    "description": data.get("description", "").strip(),
+                    "description": _short_description(data),
                     "requirements": ", ".join(data.get("requirements") or []).strip(),
                     "issuer": issuer.get("github") or issuer.get("name") or "",
                 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,9 @@
-from skillware.cli import _discover_skills, cmd_list, cmd_interactive, _short_description
+from skillware.cli import (
+    _discover_skills,
+    cmd_list,
+    cmd_interactive,
+    _short_description,
+)
 
 
 def test_discover_skills_returns_skills(tmp_path):
@@ -138,6 +143,7 @@ def test_cmd_list_filter_by_category(tmp_path):
     output = buf.getvalue()
     assert "office" in output
     assert "finance" not in output
+
 
 def test_short_description_uses_short_description_field():
     """short_description field takes priority over description."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-from skillware.cli import _discover_skills, cmd_list
+from skillware.cli import _discover_skills, cmd_list, cmd_interactive, _short_description
 
 
 def test_discover_skills_returns_skills(tmp_path):
@@ -138,3 +138,64 @@ def test_cmd_list_filter_by_category(tmp_path):
     output = buf.getvalue()
     assert "office" in output
     assert "finance" not in output
+
+def test_short_description_uses_short_description_field():
+    """short_description field takes priority over description."""
+    data = {
+        "short_description": "Short one.",
+        "description": "This is a much longer description that should not appear.",
+    }
+    assert _short_description(data) == "Short one."
+
+
+def test_short_description_truncates_at_80_chars():
+    """short_description longer than 80 chars should be truncated with ..."""
+    data = {"short_description": "A" * 90}
+    result = _short_description(data)
+    assert len(result) == 83  # 80 + "..."
+    assert result.endswith("...")
+
+
+def test_short_description_falls_back_to_first_sentence():
+    """Without short_description, use first sentence of description."""
+    data = {"description": "First sentence. Second sentence follows."}
+    assert _short_description(data) == "First sentence."
+
+
+def test_short_description_empty_manifest():
+    """Empty manifest should return empty string."""
+    assert _short_description({}) == ""
+
+
+def test_cmd_interactive_exits_on_q(monkeypatch):
+    """Entering q should exit cleanly."""
+    import io
+    from rich.console import Console
+
+    monkeypatch.setattr("builtins.input", lambda _: "q")
+    buf = io.StringIO()
+    cmd_interactive(console=Console(file=buf, force_terminal=False))
+    assert "Bye" in buf.getvalue()
+
+
+def test_cmd_interactive_exits_on_empty(monkeypatch):
+    """Pressing enter without input should exit cleanly."""
+    import io
+    from rich.console import Console
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    buf = io.StringIO()
+    cmd_interactive(console=Console(file=buf, force_terminal=False))
+    assert "Bye" in buf.getvalue()
+
+
+def test_cmd_interactive_unknown_command(monkeypatch):
+    """Unknown command should print error then exit on q."""
+    import io
+    from rich.console import Console
+
+    responses = iter(["unknown_cmd", "q"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+    buf = io.StringIO()
+    cmd_interactive(console=Console(file=buf, force_terminal=False))
+    assert "Unknown command" in buf.getvalue()


### PR DESCRIPTION
<!--
AUTOMATED AGENT GREETING

Greetings, netizen! We welcome your pull requests to Skillware.
Before submitting your code, please ensure you have:
1. Fully read and understood the linked GitHub Issue and its requirements.
2. Analyzed the core architecture (`loader.py`, `base_skill.py`) to ensure your approach aligns with the framework natively.
3. Verified all dependencies are documented in your `manifest.yaml` and logic executes deterministically.
4. Checked off all items in the checklist below.

We are excited to review your capabilities! Let's build together.
-->

## Description

Implements the CLI visual redesign requested in #93.

**Short descriptions in manifests**
Added `short_description` field to all 9 existing skill manifests. `skillware list`
displays `short_description` when present, falling back to the first sentence of
`description` truncated at 80 chars. No breaking changes to existing manifests.

**Pastel color theme**
Applied the project's pastel palette to the `rich` table using constants defined
at module level for reuse: lavender headers and borders (`#C7CEEA`), peach category
column (`#FFDAC1`), mint skill ID column (`#B5EAD7`). Table uses `box.SIMPLE_HEAVY`.

**Interactive menu**
Added `cmd_interactive()` — launched when `skillware` is run with no arguments.
Displays an ASCII splash screen with the version number, followed by a numbered
menu. Accepts both number (`1`) and command name (`list`) input. Exits cleanly
on `q`, empty input, or `Ctrl+C`. `paths` and `test` are stubbed with a
"not yet implemented" message for follow-on issues.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip this section for framework-only, documentation-only, or other PRs that do not touch the skill registry.

### Bundle & metadata

- [ ] Skill lives at `skills/<category>/<skill_name>/` (copied from `templates/python_skill/` or equivalent).
- [ ] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
- [ ] `manifest.yaml` includes `issuer` with real `name` and `email` (not template placeholders).
- [ ] Optional: `issuer.github` and `issuer.org` set when applicable.
- [ ] `requirements` and `env_vars` are documented when the skill needs them.

### Logic, cognition, and UI

- [ ] `skill.py` is deterministic Python (no arbitrary LLM-generated code paths).
- [ ] `instructions.md` explains when and how to use the skill.
- [ ] `card.json` is present and its `issuer` matches `manifest.yaml` (`name` and `email` at minimum).

### Tests & loader

- [ ] `test_skill.py` covers execution and schema expectations.
- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps are documented).

### Documentation & catalog

- [ ] `docs/skills/<skill_name>.md` exists or is updated (ID, Issuer, usage).
- [ ] `docs/skills/README.md` lists the skill with ID and Issuer.

## Constitution & Safety (if adding or modifying a skill)

<!--
State the constitutional boundaries applied to this skill to ensure safe execution.
Example: "This skill only performs read operations on the blockchain and does not sign transactions."
-->

## Related Issues
Fixes #93 
