### PR TITLE
Feat/issue 130 cli polish ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pip install "skillware[cli]"
 skillware list
 ```
 
-This prints a table of all locally available skills and confirms the install and path resolution are working.
+This prints a table of all locally available skills and confirms the install and path resolution are working. Running `skillware` with no arguments opens the interactive menu.
 
 ### 3. Configuration
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -253,6 +253,7 @@ Complete the checklist that matches your issue during Stage 5.
 
 - [ ] `skills/<category>/<skill_name>/` exists with full bundle
 - [ ] `manifest.yaml`: `name`, `version`, `description`, `parameters`, `constitution`, real `issuer`
+- [ ] Optional: `short_description` field (~80 chars) for a concise one-line summary in `skillware list`
 - [ ] `skill.py`: deterministic, JSON-serializable returns, safe error handling
 - [ ] `instructions.md`: when to use, how to interpret output, limitations
 - [ ] `card.json`: `issuer` matches manifest

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -18,8 +18,19 @@ interactive numbered menu:
 
     skillware
 
-The menu accepts both number input (`1`) and command name (`list`). Press `q`
-or Enter to exit cleanly.
+The splash displays the current version and links to the project site and
+repository. The menu accepts both number input (`1`) and command name (`list`).
+After each command completes, the menu re-prints automatically. Press `q` or
+`Ctrl+C` to exit.
+
+Available commands:
+
+| Input | Command | Status |
+| :--- | :--- | :--- |
+| `1` / `list` | List all locally installed skills | Available |
+| `2` / `paths` | Show and repair skill directory resolution paths | Coming in #81 |
+| `3` / `test` | Run test_skill.py for one or all skills | Coming in #83 |
+| `4` / `help` | Print usage information | Available |
 
 ## Commands
 

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -130,7 +130,10 @@ def cmd_list(
         return
 
     table = Table(
-        box=box.SIMPLE_HEAVY, border_style=BORDER_STYLE, header_style=TABLE_STYLE, expand=True
+        box=box.SIMPLE_HEAVY,
+        border_style=BORDER_STYLE,
+        header_style=TABLE_STYLE,
+        expand=True,
     )
 
     table.add_column("ID", style=ID_STYLE, no_wrap=True, ratio=2)
@@ -152,11 +155,13 @@ def cmd_list(
 
     console.print(table)
 
+
 def _print_menu(console, menu) -> None:
     for num, name, desc in menu:
         console.print(f"    [{num}] {name:<20}— {desc}", style=MENU_STYLE)
 
     console.print()
+
 
 def cmd_interactive(console=None, parser=None) -> None:
     """Launch ASCII splash screen and interactive menu."""
@@ -194,7 +199,12 @@ def cmd_interactive(console=None, parser=None) -> None:
         )
     )
 
-    console.print(Text("  https://skillware.site  ·  https://github.com/arpahls/skillware\n", style=f"dim {SPLASH_STYLE}"))
+    console.print(
+        Text(
+            "  https://skillware.site  ·  https://github.com/arpahls/skillware\n",
+            style=f"dim {SPLASH_STYLE}",
+        )
+    )
 
     menu = [
         ("1", "list", "discover and display all locally installed skills"),

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -10,7 +10,7 @@ CATEGORY_STYLE = "bold #FFDAC1"  # peach     - category column
 ID_STYLE = "#B5EAD7"  # mint      - skill ID column
 BORDER_STYLE = "#C7CEEA"  # lavender  - table border
 
-SPLASH_STYLE = "#C7CEEA"  # lavender  - swillware splash color
+SPLASH_STYLE = "#C7CEEA"  # lavender  - sKillware splash color
 MENU_STYLE = "#FFDAC1"  # peach     - menu category
 
 
@@ -41,7 +41,7 @@ def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
     """Return short_description if present, else first sentence of description truncated."""
     short = data.get("short_description", "").strip()
     if short:
-        return short[:max_len] + ("..." if len(short) > max_len else "")
+        return short[:max_len] + ("…" if len(short) > max_len else "")
 
     desc = data.get("description", "").strip()
 
@@ -53,7 +53,7 @@ def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
             desc = desc[: idx + 1]
             break
 
-    return desc[:max_len] + ("..." if len(desc) > max_len else "")
+    return desc[:max_len] + ("…" if len(desc) > max_len else "")
 
 
 def _discover_skills(
@@ -130,15 +130,15 @@ def cmd_list(
         return
 
     table = Table(
-        box=box.SIMPLE_HEAVY, border_style=BORDER_STYLE, header_style=TABLE_STYLE
+        box=box.SIMPLE_HEAVY, border_style=BORDER_STYLE, header_style=TABLE_STYLE, expand=True
     )
 
-    table.add_column("ID", style=ID_STYLE, no_wrap=True)
-    table.add_column("VERSION", style="dim")
-    table.add_column("CATEGORY", style=CATEGORY_STYLE)
-    table.add_column("ISSUER", style="dim")
-    table.add_column("DESCRIPTION")
-    table.add_column("REQUIREMENTS", style="dim")
+    table.add_column("ID", style=ID_STYLE, no_wrap=True, ratio=2)
+    table.add_column("VERSION", style="dim", no_wrap=True, ratio=1)
+    table.add_column("CATEGORY", style=CATEGORY_STYLE, no_wrap=True, ratio=1)
+    table.add_column("ISSUER", style="dim", no_wrap=True, ratio=1)
+    table.add_column("DESCRIPTION", ratio=3)
+    table.add_column("REQUIREMENTS", style="dim", ratio=2)
 
     for skill in skills:
         table.add_row(
@@ -152,6 +152,11 @@ def cmd_list(
 
     console.print(table)
 
+def _print_menu(console, menu) -> None:
+    for num, name, desc in menu:
+        console.print(f"    [{num}] {name:<20}— {desc}", style=MENU_STYLE)
+
+    console.print()
 
 def cmd_interactive(console=None, parser=None) -> None:
     """Launch ASCII splash screen and interactive menu."""
@@ -184,22 +189,19 @@ def cmd_interactive(console=None, parser=None) -> None:
     console.print(Text(splash, style=SPLASH_STYLE))
     console.print(
         Text(
-            f"  Skill Management Framework - v{version}\n",
+            f"  Skill Management Framework — v{version}",
             style=f"dim {SPLASH_STYLE}",
         )
     )
 
+    console.print(Text("  https://skillware.site  ·  https://github.com/arpahls/skillware\n", style=f"dim {SPLASH_STYLE}"))
+
     menu = [
         ("1", "list", "discover and display all locally installed skills"),
-        ("2", "paths", "show and repair skill directory resolution paths"),
-        ("3", "test", "run test_skill.py for one or all skills"),
+        ("2", "paths (soon, #81)", "show and repair skill directory resolution paths"),
+        ("3", "test (soon, #83)", "run test_skill.py for one or all skills"),
         ("4", "help", "usage guide for any command"),
     ]
-
-    for num, name, desc in menu:
-        console.print(f"    [{num}] {name:<10}— {desc}", style=MENU_STYLE)
-
-    console.print()
 
     commands = {
         "1": "list",
@@ -212,6 +214,8 @@ def cmd_interactive(console=None, parser=None) -> None:
         "help": "help",
     }
 
+    _print_menu(console, menu)
+
     while True:
         try:
             choice = input("  > ").strip().lower()
@@ -219,14 +223,14 @@ def cmd_interactive(console=None, parser=None) -> None:
             console.print("\n  Bye.", style="dim")
             return
 
-        if choice in ("q", ""):
+        if choice == "q":
             console.print("  Bye.", style="dim")
             return
 
         command = commands.get(choice)
 
         if command == "list":
-            cmd_list()
+            cmd_list(console=console)
         elif command in ("paths", "test"):
             console.print(
                 f"  '{command}' is not yet implemented. Coming in a future release.",
@@ -243,6 +247,7 @@ def cmd_interactive(console=None, parser=None) -> None:
             console.print(f"  Unknown command: '{choice}'", style="dim #FF9AA2")
 
         console.print()
+        _print_menu(console, menu)
 
 
 def main() -> None:

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -10,7 +10,7 @@ CATEGORY_STYLE = "bold #FFDAC1"  # peach     - category column
 ID_STYLE = "#B5EAD7"  # mint      - skill ID column
 BORDER_STYLE = "#C7CEEA"  # lavender  - table border
 
-SPLASH_STYLE = "#C7CEEA"  # lavender  - sKillware splash color
+SPLASH_STYLE = "#C7CEEA"  # lavender  - skillware splash color
 MENU_STYLE = "#FFDAC1"  # peach     - menu category
 
 

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -6,7 +6,7 @@ Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from 
 
 1. **Rename** the folder to match your skill ID (e.g. `skills/finance/my_skill`).
 2. **Packaging**: Add empty `__init__.py` files in `skills/<category>/` (new categories only) and in your skill folder so PyPI wheels include the full bundle. No `pyproject.toml` changes per skill.
-3. **`manifest.yaml`**: Set real `name`, `version`, `description`, `parameters`, `constitution`, and `issuer` (`name` + `email` required; `github` / `org` optional).
+3. **`manifest.yaml`**: Set real `name`, `version`, `description`, `short_description`, `parameters`, `constitution`, and `issuer` (`name` + `email` required; `github` / `org` optional).
 4. **`skill.py`**: Implement deterministic logic; no LLM-generated code in the skill body.
 5. **`instructions.md`**: Tell the agent when and how to use the tool.
 6. **`card.json`**: Mirror `issuer` from the manifest; customize UI fields.

--- a/templates/python_skill/manifest.yaml
+++ b/templates/python_skill/manifest.yaml
@@ -1,6 +1,7 @@
 name: "my-awesome-skill"
 version: "0.1.0"
 description: "A short description of what this skill does."
+short_description: "One-line summary for skillware list (~80 chars)."
 issuer:
   name: Your Name
   email: you@example.com

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,4 +218,4 @@ def test_cmd_interactive_list_dispatch(tmp_path, monkeypatch):
     cmd_interactive(console=console)
 
     output = buf.getvalue()
-    assert "test_skill" in output or "No skills found" in output
+    assert "test_skill" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,11 +155,11 @@ def test_short_description_uses_short_description_field():
 
 
 def test_short_description_truncates_at_80_chars():
-    """short_description longer than 80 chars should be truncated with ..."""
+    """short_description longer than 80 chars should be truncated with …"""
     data = {"short_description": "A" * 90}
     result = _short_description(data)
-    assert len(result) == 83  # 80 + "..."
-    assert result.endswith("...")
+    assert len(result) == 81  # 80 + "…"
+    assert result.endswith("…")
 
 
 def test_short_description_falls_back_to_first_sentence():
@@ -184,17 +184,6 @@ def test_cmd_interactive_exits_on_q(monkeypatch):
     assert "Bye" in buf.getvalue()
 
 
-def test_cmd_interactive_exits_on_empty(monkeypatch):
-    """Pressing enter without input should exit cleanly."""
-    import io
-    from rich.console import Console
-
-    monkeypatch.setattr("builtins.input", lambda _: "")
-    buf = io.StringIO()
-    cmd_interactive(console=Console(file=buf, force_terminal=False))
-    assert "Bye" in buf.getvalue()
-
-
 def test_cmd_interactive_unknown_command(monkeypatch):
     """Unknown command should print error then exit on q."""
     import io
@@ -205,3 +194,27 @@ def test_cmd_interactive_unknown_command(monkeypatch):
     buf = io.StringIO()
     cmd_interactive(console=Console(file=buf, force_terminal=False))
     assert "Unknown command" in buf.getvalue()
+
+def test_cmd_interactive_list_dispatch(tmp_path, monkeypatch):
+    """Entering 1 or list should dispatch to cmd_list."""
+    import io
+    from rich.console import Console
+
+    skill_dir = tmp_path / "office" / "test_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.py").touch()
+    (skill_dir / "manifest.yaml").write_text(
+        "name: test_skill\nversion: 0.1.0\ndescription: Test.\n"
+        "short_description: Test skill.\n"
+    )
+
+    responses = iter(["1", "q"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+    monkeypatch.chdir(tmp_path)
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    cmd_interactive(console=console)
+
+    output = buf.getvalue()
+    assert "test_skill" in output or "No skills found" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,7 @@ def test_cmd_interactive_unknown_command(monkeypatch):
     cmd_interactive(console=Console(file=buf, force_terminal=False))
     assert "Unknown command" in buf.getvalue()
 
+
 def test_cmd_interactive_list_dispatch(tmp_path, monkeypatch):
     """Entering 1 or list should dispatch to cmd_list."""
     import io


### PR DESCRIPTION
<!--
AUTOMATED AGENT GREETING

Greetings, netizen! We welcome your pull requests to Skillware.
Before submitting your code, please ensure you have:
1. Fully read and understood the linked GitHub Issue and its requirements.
2. Analyzed the core architecture (`loader.py`, `base_skill.py`) to ensure your approach aligns with the framework natively.
3. Verified all dependencies are documented in your `manifest.yaml` and logic executes deterministically.
4. Checked off all items in the checklist below.

We are excited to review your capabilities! Let's build together.
-->

## Description

Polish pass on the CLI following #93 (pastel redesign, merged).

**Splash footer** — added a dim pastel line under the version with
`https://skillware.site` and `https://github.com/arpahls/skillware`.

**Menu UX** — stub items now labeled `paths (soon, #81)` and
`test (soon, #83)` so users know they are coming. Menu re-prints after
each command; exits only on `q` or `Ctrl+C`, not on empty Enter.

**Width-aware table** — `cmd_list()` now uses `expand=True` and column
ratios so the table adapts to terminal width instead of crushing columns
on narrow terminals. `console` is passed from `cmd_interactive()` to
`cmd_list()` so both share the same terminal context.

**short_description ripple** — added `short_description` to
`templates/python_skill/manifest.yaml` with an example string. Mentioned
as optional in the contributor checklist in
`docs/contributing/ai_native_workflow.md` and
`templates/python_skill/README.md`. Added one line to `README.md` Quick
Start noting that bare `skillware` opens the interactive menu.

**Tests** — added `test_cmd_interactive_list_dispatch` covering menu
input `1` dispatching to `cmd_list`. Removed stale test that asserted
a `FileNotFoundError` no longer raised by the current implementation.

**Docs** — refreshed `docs/usage/cli.md` with current sample output,
color theme table, and interactive menu documentation.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip this section for framework-only, documentation-only, or other PRs that do not touch the skill registry.

### Bundle & metadata

- [ ] Skill lives at `skills/<category>/<skill_name>/` (copied from `templates/python_skill/` or equivalent).
- [ ] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
- [ ] `manifest.yaml` includes `issuer` with real `name` and `email` (not template placeholders).
- [ ] Optional: `issuer.github` and `issuer.org` set when applicable.
- [ ] `requirements` and `env_vars` are documented when the skill needs them.

### Logic, cognition, and UI

- [ ] `skill.py` is deterministic Python (no arbitrary LLM-generated code paths).
- [ ] `instructions.md` explains when and how to use the skill.
- [ ] `card.json` is present and its `issuer` matches `manifest.yaml` (`name` and `email` at minimum).

### Tests & loader

- [ ] `test_skill.py` covers execution and schema expectations.
- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps are documented).

### Documentation & catalog

- [ ] `docs/skills/<skill_name>.md` exists or is updated (ID, Issuer, usage).
- [ ] `docs/skills/README.md` lists the skill with ID and Issuer.

## Constitution & Safety (if adding or modifying a skill)

<!--
State the constitutional boundaries applied to this skill to ensure safe execution.
Example: "This skill only performs read operations on the blockchain and does not sign transactions."
-->

## Related Issues
Fixes #130 
