### PR TITLE
docs: align contributor docs, CHANGELOG 0.3.2, and bump version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@ Humans: Please describe what this PR does and why it's needed.
 
 - [ ] My code follows the **Agent Code of Conduct**.
 - [ ] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
 - [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.
 
 ## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)
@@ -40,6 +41,7 @@ Skip this section for framework-only, documentation-only, or other PRs that do n
 - [ ] Skill lives at `skills/<category>/<skill_name>/` (copied from `templates/python_skill/` or equivalent).
 - [ ] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
 - [ ] `manifest.yaml` includes `issuer` with real `name` and `email` (not template placeholders).
+- [ ] Optional: `short_description` in manifest (~80 chars) for `skillware list`.
 - [ ] Optional: `issuer.github` and `issuer.org` set when applicable.
 - [ ] `requirements` and `env_vars` are documented when the skill needs them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Contributors add user-facing entries under `[Unreleased]` in the same PR. Maintainers rename that section to a version and date when cutting a PyPI release. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-27
+
 ### Added
-- **`finance/wallet_screening`**: Added FTM publicKey matching and an ETH sanctions index (#128).
+- **Changelog**: Added root `CHANGELOG.md` following Keep a Changelog, with retrospective release history from v0.2.0 and a README nav link (#108).
+- **`finance/wallet_screening`**: FTM publicKey matching and an ETH sanctions index (#128).
 
 ### Changed
-- **CLI**: Implemented a visual redesign for `skillware list`, including a new splash screen, menu loop, and table layout (#129).
+- **CLI**: Visual redesign for `skillware list`, including pastel table, `short_description` column, interactive splash, and menu (#129).
+- **CLI**: Interactive polish - splash footer links, menu re-loop, stub labels for #81 / #83, width-aware table, shared terminal context (#130, #131).
+- **Contributing**: Aligned Code of Conduct, CONTRIBUTING, agent workflow, and PR template for CHANGELOG maintenance and co-authoring rules (#124).
+- **Documentation**: README documentation table and `docs/introduction.md` link to `CHANGELOG.md`; contributor template documents optional `short_description` (#130).
 
 ## [0.3.1] - 2026-05-25
 
@@ -63,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Documentation:** Added contributor notes for PyPI packaging in `CONTRIBUTING.md` and the skill template README.
 
 ### Fixed
-- **Skill Loader:** Fixed skill resolution paths after `pip install` (#13). `SkillLoader.load_skill()` no longer restricts searches to `site-packages/skills/`. It now falls back through the following order: 
+- **Skill Loader:** Fixed skill resolution paths after `pip install` (#13). `SkillLoader.load_skill()` no longer restricts searches to `site-packages/skills/`. It now falls back through the following order:
   1. An existing path on disk (absolute or relative)
   2. Roots defined in the `SKILLWARE_SKILL_PATH` environment variable
   3. A local `skills/` folder in the current working directory (searching up to six parent directories)
@@ -104,7 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Testing:** Added central tests (`tests/skills/compliance/test_tos_evaluator.py`) and local skill tests.
 - **Documentation:** Added dedicated skill documentation (`docs/skills/tos_evaluator.md`) and updated the central skill catalog.
 - **Examples:** Added integration scripts (`examples/gemini_tos_evaluator.py`, `examples/claude_tos_evaluator.py`, `examples/ollama_tos_evaluator.py`).
-- **Dependencies:** Added `beautifulsoup4` (`bs4` in the manifest) to the project for deterministic HTML parsing 
+- **Dependencies:** Added `beautifulsoup4` (`bs4` in the manifest) to the project for deterministic HTML parsing.
 
 ## [0.2.4] - 2026-04-11
 
@@ -123,7 +131,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - **Zero-Latency PII Masker Skill:** Introduces the `compliance/pii_masker` component to act as a "Privacy Firewall", intercepting and scrubbing sensitive metadata (Names, Emails, Physical Addresses, Crypto Wallets) locally before external LLM dispatch.
 - **Ollama Edge Interoperability:** Leverages the 270M parameter `arpacorp/micro-f1-mask` structure for optimized, offline processing.
-- **Dynamic Modalities:** Added three processing modes for the masker: 
+- **Dynamic Modalities:** Added three processing modes for the masker:
   - `mask`: Preserves contextual entity tags (e.g., `[PERSON_1]`).
   - `redact`: Completely overwrites tokens with localized constants (`xxxx`).
   - `remove`: Intelligently drops strings from the payload to decrease token size.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,6 +32,12 @@ Maintainers have the right and responsibility to remove, edit, or reject comment
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual or agent is representing the project or its community. Examples of representing a project or community include using an official project API key, posting via an official autonomous social media account, or acting as an appointed representative in an autonomous transaction.
 
+## Contribution process
+
+Human contributors and operators supervising **autonomous agents** or **AI-assisted tools** (Cursor, Copilot, Claude Code, and similar) must follow [CONTRIBUTING.md](CONTRIBUTING.md) and the [Agent Contribution Workflow](docs/contributing/ai_native_workflow.md).
+
+**Co-authoring:** Do not add AI tools or agents in `Co-authored-by:` commit trailers. Reserve co-author credits for **human** collaborators only. GitHub does not infer co-authors from normal commits; `Co-authored-by:` is added deliberately (web UI or commit message). Human pair or mob work should use that mechanism. AI assistance does not.
+
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [skillware-os@arpacorp.net](mailto:skillware-os@arpacorp.net). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,8 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 
 - Change only what the issue requires. Avoid unrelated refactors or drive-by edits.
 - Do not bump the package version in `pyproject.toml` unless the issue or a maintainer explicitly requests it (skill-only PRs typically do not version the framework).
-- For user-facing changes, add entries under `[Unreleased]` in `CHANGELOG.md` in the same PR. Do not add version headers or publish releases; maintainers cut releases.
+- When a PR changes **user-visible behavior** (framework features, new or changed skills, breaking fixes, CLI or documentation users rely on), add entries under `[Unreleased]` in [CHANGELOG.md](CHANGELOG.md) in the same PR (Keep a Changelog sections: Added / Changed / Fixed / Removed). Do not add version headers or publish releases; maintainers cut releases.
+- Skill-only PRs that will not ship in the next PyPI release may omit a CHANGELOG entry; ask on the issue or use maintainer judgment.
 
 ### Tests and CI
 
@@ -143,9 +144,10 @@ Agents must follow [Agent Contribution Workflow](docs/contributing/ai_native_wor
    pytest tests/test_skill_issuer.py
    ```
 
-5. **Commit** — Clear imperative message, no emojis; include issue reference when appropriate.
-6. **Push** to your fork and open a PR into `ARPAHLS/skillware` `main`.
-7. **CI** — Ensure checks pass; address review feedback on the same branch.
+5. **Commit** — Clear imperative message, no emojis; include issue reference when appropriate. Do not add AI tools in `Co-authored-by:` trailers (see [Agent Code of Conduct](CODE_OF_CONDUCT.md#contribution-process)).
+6. **Changelog** — If the PR is user-visible, add lines under `[Unreleased]` in [CHANGELOG.md](CHANGELOG.md) before opening the PR.
+7. **Push** to your fork and open a PR into `ARPAHLS/skillware` `main`.
+8. **CI** — Ensure checks pass; address review feedback on the same branch.
 
 ### Skill-specific steps (in addition to the above)
 
@@ -168,7 +170,8 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 **Required fields and sections:**
 
 - `name`, `version`, `description`
-- `issuer` — see [Issuer attribution](#issuer-attribution)
+- `issuer` — see [Issuer attribution](#issuer-attribution); `name` and `email` required, `github` and `org` optional
+- `short_description` — optional one-line summary (~80 chars) shown in `skillware list` when present
 - `parameters` — valid JSON Schema for LLM tool calling
 - `constitution` — safety boundaries enforced at the prompt level
 - `requirements` — when external packages are needed (for example `requests`, `pandas`)
@@ -314,6 +317,7 @@ Skill IDs follow `category/skill_name` and should match the path under `skills/`
 | [docs/skills/README.md](docs/skills/README.md) | Published skill catalog |
 | [templates/python_skill/](templates/python_skill/) | Boilerplate for new skills |
 | [Pull request template](.github/PULL_REQUEST_TEMPLATE.md) | PR checklist |
+| [CHANGELOG.md](CHANGELOG.md) | Release history; contributors add under `[Unreleased]` |
 | [Security policy](SECURITY.md) | Reporting vulnerabilities |
 
 ---

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For other providers and shared integration patterns, see the [usage guides index
 | Topic | Link |
 | :--- | :--- |
 | Introduction | [docs/introduction.md](docs/introduction.md) |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Testing | [docs/TESTING.md](docs/TESTING.md) |
 | Skill library | [docs/skills/README.md](docs/skills/README.md) |
 | Usage guides | [index](docs/usage/README.md) — [Gemini](docs/usage/gemini.md) · [Claude](docs/usage/claude.md) · [OpenAI](docs/usage/openai.md) · [DeepSeek](docs/usage/deepseek.md) · [Ollama](docs/usage/ollama.md); [agent loops](docs/usage/agent_loops.md); [API keys](docs/usage/api_keys.md) |

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -91,6 +91,7 @@ You must:
 | New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed |
 | Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
 | Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/` |
+| Release / user-visible change | Root [CHANGELOG.md](../../CHANGELOG.md) under `[Unreleased]` when behavior, CLI, skills, or user-facing docs change (maintainers cut version sections) |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |
 | Good first issue | Issue labels and acceptance criteria—take them literally |
 
@@ -158,8 +159,9 @@ Run a **pre-PR audit** on yourself:
 
 1. Map every acceptance criterion in the issue to a file or test in your diff.
 2. Complete the [verification checklist](#verification-checklists-by-contribution-type) for your contribution type.
-3. Run `flake8` and `pytest`; report actual command output to your operator—do not claim success without evidence.
-4. Draft PR template answers: check only boxes that apply; fill the skill section only if `skills/` changed.
+3. If the change is user-visible, confirm [CHANGELOG.md](../../CHANGELOG.md) has entries under `[Unreleased]` (same rule as [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+4. Run `flake8` and `pytest`; report actual command output to your operator—do not claim success without evidence.
+5. Draft PR template answers: check only boxes that apply; fill the skill section only if `skills/` changed.
 
 If anything fails, return to Stage 4, fix, and audit again.
 
@@ -183,6 +185,7 @@ Commit message rules you must follow:
 - Imperative mood (`Add`, `Fix`, `Document`)
 - No emojis
 - Issue references when appropriate (`Fixes #57`, `Refs #12`)
+- Do not add AI tools or agents in `Co-authored-by:` trailers (see [Code of Conduct — Contribution process](../../CODE_OF_CONDUCT.md#contribution-process))
 - Prefer scoped `git add` over blind `git add -A` when the diff is mixed
 
 Confirm the diff contains no credentials or accidental large binaries before you ask for a push.
@@ -241,7 +244,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 
 ### Conduct
 
-- Follow the [Agent Code of Conduct](../../CODE_OF_CONDUCT.md)
+- Follow the [Agent Code of Conduct](../../CODE_OF_CONDUCT.md), including [contribution process and co-authoring rules](../../CODE_OF_CONDUCT.md#contribution-process)
 
 ---
 
@@ -265,12 +268,14 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `examples/README.md` updated if a new or changed script lives under `examples/`
 - [ ] No placeholders under `skills/`
 - [ ] PR skill section completed
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` when the skill or its user-facing docs change (unless the issue says otherwise)
 
 ### Documentation only
 
 - [ ] All issue acceptance criteria met
 - [ ] Links valid
 - [ ] `examples/README.md` row added or updated if the issue touches runnable examples
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` when the change is user-visible
 - [ ] No emojis; tone matches repo
 - [ ] No unrelated code changes
 - [ ] PR marked as documentation; skill checklist omitted unless `docs/skills/` or skill **Usage Examples** changed (then apply the Usage Examples bullet above)
@@ -282,6 +287,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `pytest tests/` passes
 - [ ] Usage docs updated if API changed
 - [ ] No undeclared breaking changes
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` when behavior changes
 
 ### Bug fix
 
@@ -289,6 +295,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] Minimal fix
 - [ ] Regression test when feasible
 - [ ] `flake8` and `pytest` pass
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` when the fix is user-visible
 
 ### Good first issue
 
@@ -325,6 +332,7 @@ Run this internal dialogue before you hand off to your operator.
 - Does the PR description explain why?
 - Did I link the issue with `Fixes` or `Refs`?
 - Are PR template checkboxes accurate—not copy-pasted unchecked defaults?
+- Is `CHANGELOG.md` updated under `[Unreleased]` when the change is user-visible?
 
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -105,6 +105,7 @@ Skillware is designed to be the "Standard Library" for all agents.
 **Next Steps:**
 *   Explore the [Skill Library](skills/README.md)
 *   Browse the [Runnable Examples Index](../examples/README.md)
+*   View the [Changelog](../CHANGELOG.md) for release history
 *   Read [How to Contribute](../CONTRIBUTING.md) (skills, docs, framework, and bugs)
 *   If you are a contributing agent, follow the [Agent Contribution Workflow](contributing/ai_native_workflow.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillware"
-version = "0.3.1"
+version = "0.3.2"
 description = "A framework for modular, self-contained AI skills."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description

Aligns contributor docs with the new CHANGELOG workflow (#91 landed in #108), adds CoC contribution-process and co-authoring rules, and batches pending release notes into `[0.3.2]` with a version bump.

**Changes:**
- `CODE_OF_CONDUCT.md` — Contribution process subsection (CONTRIBUTING + agent workflow; no AI in `Co-authored-by:`)
- `CONTRIBUTING.md` — CHANGELOG maintenance rules, PR process step, `short_description` in manifest standard, related-docs link
- `docs/contributing/ai_native_workflow.md` — Complementary-paths row, Stage 5/6/7 checks, verification checklists, CoC cross-link
- `.github/PULL_REQUEST_TEMPLATE.md` — CHANGELOG checkbox; optional `short_description` in skill section
- `CHANGELOG.md` — `[0.3.2]` release notes (includes #108, #128, #129, #130, #131, #124); empty `[Unreleased]`; trailing-space cleanup
- `README.md` / `docs/introduction.md` — Changelog links
- `pyproject.toml` — bump to `0.3.2`

### Type of Change

- [ ] **Skill Proposal**
- [ ] **Bug Report Fix**
- [x] **Doc Fix**
- [ ] **Framework Feature / RFC Updates**

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill

_Skipped: docs-only PR_

## Constitution & Safety

_Skipped: docs-only PR_

## Related Issues

Fixes #124