### PR TITLE
Docs/issue 133 vision readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **Documentation**: Added [docs/vision.md](docs/vision.md) with project story, roadmap, and agent discoverability (#133).
 
 ### Changed
-- **Documentation**: README Mission links to vision.md; Comparison section adds wallet screening table; docs table and cross-links updated (#133).
+- **Documentation**: README Mission links to vision.md; wallet screening comparison table lives in COMPARISON.md; docs table and cross-links updated (#133).
 
 ## [0.3.2] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Added
+- **Documentation**: Added [docs/vision.md](docs/vision.md) with project story, roadmap, and agent discoverability (#133).
+
+### Changed
+- **Documentation**: README Mission links to vision.md; Comparison section adds wallet screening table; docs table and cross-links updated (#133).
+
 ## [0.3.2] - 2026-05-27
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,6 +38,10 @@ Human contributors and operators supervising **autonomous agents** or **AI-assis
 
 **Co-authoring:** Do not add AI tools or agents in `Co-authored-by:` commit trailers. Reserve co-author credits for **human** collaborators only. GitHub does not infer co-authors from normal commits; `Co-authored-by:` is added deliberately (web UI or commit message). Human pair or mob work should use that mechanism. AI assistance does not.
 
+**Skill contributors:** New skills must include **real issuer details** in `manifest.yaml` (`name`, `email`, and optional `github` / `org`) and matching attribution in skill docs and catalog entries. Placeholder or missing contact information is grounds for rejection. See [Issuer attribution](CONTRIBUTING.md#issuer-attribution) in [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist.
+
+**Disclaimers and promotion:** Skills may include short disclaimers, demos, or pointers to paid or extended versions when the copy is **accurate and safe**: real contact details, working links, and no misleading claims. Do not use fake emails, deceptive URLs, phishing, or promotional text that hides what the skill actually does. Maintainers review disclaimer and promo copy in manifests, instructions, and catalog pages. We may ask you to revise it, edit it ourselves, remove it, reject the skill, or restrict repeat offenders.
+
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [skillware-os@arpacorp.net](mailto:skillware-os@arpacorp.net). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -6,6 +6,21 @@ This document clarifies how Skillware compares to other common approaches for eq
 
 ---
 
+## Wallet screening: same task, different approaches
+
+**Screening an Ethereum wallet for sanctions and risk** — qualitative comparison across four methods:
+
+| Method | Speed | Cost | Accuracy | Reliability | Security | Setup |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Skillware** (`wallet_screening`) | Seconds | Low (~$0 + optional Etherscan key) | High (deterministic OFAC/TRM-style data) | Repeatable, tested Python | Fixed code path | `pip install skillware` |
+| **Prompt + web search** | Minutes | High tokens | Low (misses on-chain signals) | Varies per run | Generated code and scraping | Prompt engineering |
+| **MCP / multi-agent** | Minutes+ | Tokens + infra | Medium (tool-dependent) | Server/agent-dependent | Many moving parts | Deploy servers |
+| **Native APIs** (Chainalysis, TRM) | Sseconds | High (enterprise) | High | SLA-backed | Vendor-controlled | Contracts |
+
+Skill detail: [wallet_screening.md](docs/skills/wallet_screening.md). Multi-layer screening runs locally in one call via [`finance/wallet_screening`](skills/finance/wallet_screening/).
+
+---
+
 ## 1. Skillware vs. Model Context Protocol (MCP)
 
 The [Model Context Protocol](https://github.com/modelcontextprotocol) (MCP) is an open standard that connects AI models to data sources and tools via a client-server architecture.

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,6 +1,6 @@
 # Comparison: Skillware vs. Alternatives
 
-Skillware is a Python framework that decouples AI tool logic, cognition, and governance into self-contained, installable modules called **Skills**.
+Skillware is a Python framework that decouples AI tool logic, cognition, and governance into self-contained, installable modules called **Skills**. For the project story and roadmap, see [docs/vision.md](docs/vision.md).
 
 This document clarifies how Skillware compares to other common approaches for equipping AI agents with tools, including **Model Context Protocol (MCP)**, **Anthropic Skills**, **LangChain Tools**, **AutoGen**, and others.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,6 +314,7 @@ Skill IDs follow `category/skill_name` and should match the path under `skills/`
 | [TESTING.md](docs/TESTING.md) | Black, Flake8, Pytest, local CI parity |
 | [Agent Code of Conduct](CODE_OF_CONDUCT.md) | Behavioral expectations for humans and agents |
 | [docs/introduction.md](docs/introduction.md) | Architecture: Mind, Body, Conscience |
+| [docs/vision.md](docs/vision.md) | Project story, roadmap, and agent discoverability |
 | [docs/skills/README.md](docs/skills/README.md) | Published skill catalog |
 | [templates/python_skill/](templates/python_skill/) | Boilerplate for new skills |
 | [Pull request template](.github/PULL_REQUEST_TEMPLATE.md) | PR checklist |

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@
 
 <div align="center">
   <a href="#mission">Mission</a> •
-  <a href="docs/vision.md">Vision</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#documentation">Documentation</a> •
-  <a href="CHANGELOG.md">Changelog</a> •
   <a href="#contributing">Contributing</a> •
   <a href="#comparison">Comparison</a> •
+  <a href="CHANGELOG.md">Changelog</a> •
   <a href="#contact">Contact</a>
 </div>
 
@@ -34,18 +33,18 @@
 
 ## Mission
 
-The AI ecosystem is fragmented. Developers often re-invent tool definitions, system prompts, and safety rules for every project. **Skillware** supplies a standard to package capabilities into self-contained, installable units that work across **Gemini**, **Claude**, **Ollama**, **GPT**, and **Llama**. For the full story and roadmap, see **[docs/vision.md](docs/vision.md)**.
+The AI ecosystem is fragmented. Developers often re-invent tool definitions, system prompts, and safety rules for every project. **Skillware** supplies a standard to package capabilities into self-contained, installable units that work across **Gemini**, **Claude**, **Ollama**, **GPT**, and **Llama**. For the full story and roadmap, see our **[Vision](docs/vision.md)**.
 
 A **Skill** in this framework provides everything an Agent needs to master a domain:
 
-1.  **Logic**: Executable Python code.
-2.  **Cognition**: System instructions and "cognitive maps".
-3.  **Governance**: Constitution and safety boundaries.
-4.  **Interface**: Standardized schemas for LLM tool calling.
+1. **Logic**: Executable Python so agents run real work, not guess it.
+2. **Cognition**: System instructions and cognitive maps so any logical system uses the capability as intended.
+3. **Governance**: Constitution, safety boundaries, and hard limits baked into the bundle.
+4. **Interface**: Standardized tool schemas for any LLM or agent runtime.
 
 ### Skill library
 
-Browse capabilities by category in the [Skill library](docs/skills/README.md).
+Browse capabilities by category in the [Skill library](docs/skills/README.md) or on our <a href="https://skillware.site/skills" target="_blank" rel="noopener noreferrer">site&nbsp;↗</a>.
 
 ## Architecture
 
@@ -177,42 +176,23 @@ For other providers and shared integration patterns, see the [usage guides index
 
 ## Documentation
 
-| Topic | Link |
+| Topic | Links |
 | :--- | :--- |
-| Introduction | [docs/introduction.md](docs/introduction.md) |
-| Vision | [docs/vision.md](docs/vision.md) |
-| Changelog | [CHANGELOG.md](CHANGELOG.md) |
-| Testing | [docs/TESTING.md](docs/TESTING.md) |
-| Skill library | [docs/skills/README.md](docs/skills/README.md) |
-| Usage guides | [index](docs/usage/README.md) — [Gemini](docs/usage/gemini.md) · [Claude](docs/usage/claude.md) · [OpenAI](docs/usage/openai.md) · [DeepSeek](docs/usage/deepseek.md) · [Ollama](docs/usage/ollama.md); [agent loops](docs/usage/agent_loops.md); [API keys](docs/usage/api_keys.md) |
-| Examples index | [examples/README.md](examples/README.md) |
-| CLI | [docs/usage/cli.md](docs/usage/cli.md) |
-| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) · [agent workflow](docs/contributing/ai_native_workflow.md) |
+| **Introduction** | [Introduction](docs/introduction.md) · [Vision](docs/vision.md) · [Comparison](COMPARISON.md) |
+| **Usage guides** | [Skill Library](docs/skills/README.md) · [Usage Guide](docs/usage/README.md) · [Examples](examples/README.md) · [Agent Loops](docs/usage/agent_loops.md) · [API Keys](docs/usage/api_keys.md) · [CLI](docs/usage/cli.md) |
+| **Contributing** | [Contributing](CONTRIBUTING.md) · [Agent Native Workflow](docs/contributing/ai_native_workflow.md) · [Testing](docs/TESTING.md) · [Changelog](CHANGELOG.md) |
 
 ## Contributing
 
-We are building the "App Store" for Agents and require professional, robust, and safe skills. We welcome contributions to the skill registry, documentation, tests, and core framework.
+We are building the "App Store" for Agents. Skills are the main contribution, but documentation, tests, and framework fixes are welcome too. Human operators and supervised agents follow the same standards: scoped PRs, deterministic behavior, and verified tests.
 
-* **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution types, skill standard, pull request process, and navigation to all contributor docs.
-* **[Agent Contribution Workflow](docs/contributing/ai_native_workflow.md)** — Workflow for AI agents contributing to the repository (operators supervise).
-* **[Agent Code of Conduct](CODE_OF_CONDUCT.md)** — Deterministic outputs, safety boundaries, and acceptable use of skills.
-* **[TESTING.md](docs/TESTING.md)** — Local linting and pytest before you open a PR.
-* **[Pull request template](.github/PULL_REQUEST_TEMPLATE.md)** — Checklists for skills, docs, and framework changes (complete only the sections that apply).
+See the **Contributing** row in [Documentation](#documentation) for the full path, [Contributing](CONTRIBUTING.md) (types, skill standard, PR process), [Agent Native Workflow](docs/contributing/ai_native_workflow.md) (for autonomous and semi-autonomous agents), [Testing](docs/TESTING.md) (Black, Flake8, framework and skill pytest, pre-PR checklist), and [Changelog](CHANGELOG.md) (user-facing entries under `[Unreleased]`).
+
+Also read the [Agent Code of Conduct](CODE_OF_CONDUCT.md). Open PRs with the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) and complete only the sections that apply.
 
 ## Comparison
 
-**Screening an Ethereum wallet for sanctions and risk** — same task, different approaches:
-
-| Method | Speed | Cost | Accuracy | Reliability | Security | Setup |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Skillware** (`wallet_screening`) | Seconds | Low (~$0 + optional Etherscan key) | High (deterministic OFAC/TRM-style data) | Repeatable, tested Python | Fixed code path | `pip install skillware` |
-| **Prompt + web search** | Minutes | High tokens | Low (misses on-chain signals) | Varies per run | Generated code and scraping | Prompt engineering |
-| **MCP / multi-agent** | Slow | Tokens + infra | Medium (tool-dependent) | Server/agent-dependent | Many moving parts | Deploy servers |
-| **Native APIs** (Chainalysis, TRM) | Fast | High (enterprise) | High | SLA-backed | Vendor-controlled | Contracts |
-
-Skill detail: [wallet_screening](docs/skills/wallet_screening.md) · Full comparison: [COMPARISON.md](COMPARISON.md)
-
-Skillware differs from the Model Context Protocol (MCP) or Anthropic's Skills repository in the following ways:
+Skillware differs from the Model Context Protocol (MCP), and Anthropic's Skills repository in several ways:
 
 *   **Model Agnostic**: Native adapters for Gemini, Claude, Ollama, and OpenAI.
 *   **Code-First**: Skills are executable Python packages, not just server specs.
@@ -225,7 +205,11 @@ Skillware differs from the Model Context Protocol (MCP) or Anthropic's Skills re
 For questions, suggestions, or contributions, please open an issue or reach out to us:
 
 *   **Email**: [skillware-os@arpacorp.net](mailto:skillware-os@arpacorp.net)
+*   **Enterprise**: [skills@arpacorp.net](mailto:skills@arpacorp.net) — enterprise skills, chaining, and forward deployed engineering
+*   **Security**: [security@arpacorp.net](mailto:security@arpacorp.net) — report bugs, vulnerabilities, or other sensitive issues (see [SECURITY.md](SECURITY.md))
 *   **Issues**: [GitHub Issues](https://github.com/arpahls/skillware/issues)
+
+For skill-specific questions or reaching a skill's maintainer, check issuer and author details on the skill card, in the repo [Skill Library](docs/skills/README.md), or on our website's <a href="https://skillware.site/skills" target="_blank" rel="noopener noreferrer">skills catalog&nbsp;↗</a>.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 <div align="center">
   <a href="#mission">Mission</a> •
+  <a href="docs/vision.md">Vision</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#documentation">Documentation</a> •
@@ -33,7 +34,7 @@
 
 ## Mission
 
-The AI ecosystem is fragmented. Developers often re-invent tool definitions, system prompts, and safety rules for every project. **Skillware** supplies a standard to package capabilities into self-contained units that work across **Gemini**, **Claude**, **Ollama**, **GPT**, and **Llama**.
+The AI ecosystem is fragmented. Developers often re-invent tool definitions, system prompts, and safety rules for every project. **Skillware** supplies a standard to package capabilities into self-contained, installable units that work across **Gemini**, **Claude**, **Ollama**, **GPT**, and **Llama**. For the full story and roadmap, see **[docs/vision.md](docs/vision.md)**.
 
 A **Skill** in this framework provides everything an Agent needs to master a domain:
 
@@ -179,6 +180,7 @@ For other providers and shared integration patterns, see the [usage guides index
 | Topic | Link |
 | :--- | :--- |
 | Introduction | [docs/introduction.md](docs/introduction.md) |
+| Vision | [docs/vision.md](docs/vision.md) |
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Testing | [docs/TESTING.md](docs/TESTING.md) |
 | Skill library | [docs/skills/README.md](docs/skills/README.md) |
@@ -198,6 +200,17 @@ We are building the "App Store" for Agents and require professional, robust, and
 * **[Pull request template](.github/PULL_REQUEST_TEMPLATE.md)** — Checklists for skills, docs, and framework changes (complete only the sections that apply).
 
 ## Comparison
+
+**Screening an Ethereum wallet for sanctions and risk** — same task, different approaches:
+
+| Method | Speed | Cost | Accuracy | Reliability | Security | Setup |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Skillware** (`wallet_screening`) | Seconds | Low (~$0 + optional Etherscan key) | High (deterministic OFAC/TRM-style data) | Repeatable, tested Python | Fixed code path | `pip install skillware` |
+| **Prompt + web search** | Minutes | High tokens | Low (misses on-chain signals) | Varies per run | Generated code and scraping | Prompt engineering |
+| **MCP / multi-agent** | Slow | Tokens + infra | Medium (tool-dependent) | Server/agent-dependent | Many moving parts | Deploy servers |
+| **Native APIs** (Chainalysis, TRM) | Fast | High (enterprise) | High | SLA-backed | Vendor-controlled | Contracts |
+
+Skill detail: [wallet_screening](docs/skills/wallet_screening.md) · Full comparison: [COMPARISON.md](COMPARISON.md)
 
 Skillware differs from the Model Context Protocol (MCP) or Anthropic's Skills repository in the following ways:
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -339,6 +339,7 @@ Run this internal dialogue before you hand off to your operator.
 ## Related documents
 
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — contribution hub and skill standard
+- [Vision](../vision.md) — project story and roadmap
 - [TESTING.md](../TESTING.md) — Black, Flake8, Pytest
 - [Usage guides](../usage/README.md) — provider adapters (`to_gemini_tool`, `to_openai_tool`, etc.)
 - [Agent loops](../usage/agent_loops.md) — shared load / execute / tool-result pattern

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -103,6 +103,7 @@ Skillware is designed to be the "Standard Library" for all agents.
 
 ---
 **Next Steps:**
+*   Read the [Vision](vision.md) (story, roadmap, and where we are today)
 *   Explore the [Skill Library](skills/README.md)
 *   Browse the [Runnable Examples Index](../examples/README.md)
 *   View the [Changelog](../CHANGELOG.md) for release history

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,102 @@
+# Skillware Vision
+
+Skillware is an open registry and Python framework for **installable agent capabilities**. A Skill is not a prompt snippet or a server spec. It is a self-contained bundle: executable logic, instructions for the model, safety rules, and a schema any supported LLM can call. You install know-how the same way you install libraries with `pip`.
+
+This page is the long-form story behind the project. For a scannable overview, start with [README.md](../README.md). For technical contrasts with MCP, LangChain, and similar approaches, see [COMPARISON.md](../COMPARISON.md).
+
+---
+
+## How we started
+
+Every new agent project used to mean rewriting tool definitions, system prompts, and safety checks from scratch. The same wallet check, PDF parser, or data pipeline showed up again under different names, tied to one model API or one framework.
+
+We wanted something closer to how operating systems ship software. `apt-get` installs packages. `pip` installs libraries. **Skillware installs capability.** One bundle works across Gemini, Claude, OpenAI, DeepSeek, and Ollama because the loader adapts manifests at runtime instead of locking you to one vendor.
+
+That decoupling matters in practice. Teams can swap models without rewriting tools. Open source contributors can ship a skill once and have it run everywhere the loader supports. Operators keep governance and attribution in the bundle instead of scattered across prompts.
+
+For a longer argument against markdown-only skill files, see the essay [*skills.md is Dead: Why Your Agents Need Skillware*](https://dev.to/arpa/skillsmd-is-dead-why-your-agents-need-skillware-2g59) (extended reading).
+
+---
+
+## Why not instructions only?
+
+Markdown instructions and web search can describe a task. They cannot guarantee how it runs.
+
+Prompt-only flows burn context reading rules, then ask the model to invent code on every run. That is slow, expensive, and hard to audit. Web search adds latency and misses signals that live in structured data or on-chain history.
+
+Skillware bundles **deterministic Python**, **local datasets**, **tests**, and **governance** in one installable unit. The model decides *when* to call a skill. The skill decides *how* the work runs. Results are repeatable. Boundaries are written down in `manifest.yaml` and enforced in code.
+
+That split is the difference between a demo and something you can ship. Instructions alone leave execution quality to the model's mood that day. A skill gives you the same JSON shape, the same error handling, and the same audit trail on run one and run one thousand.
+
+---
+
+## Wallet screening as an example
+
+Consider screening an Ethereum wallet for sanctions exposure and risky counterparties. That is not a single API call. It is layered work: load OFAC and related lists, scan transaction history, flag mixer or drainer interactions, score risk, and return a structured report the model can summarize.
+
+The [`finance/wallet_screening`](../skills/finance/wallet_screening/) skill packages all of that. Bundled JSON datasets sit beside the Python runner. Optional Etherscan access enriches live chain data. The agent receives a tool schema plus `instructions.md` that teach it how to interpret the JSON verdict.
+
+Multi-layer screening runs locally in one `execute()` call. No generated scraper. No ad-hoc script the model wrote five minutes ago. For skill-level detail, see [wallet_screening.md](skills/wallet_screening.md). For how this task compares to prompts, MCP, or enterprise APIs, see the table under [Comparison](../README.md#comparison) in the README.
+
+---
+
+## Built for agents
+
+Skillware is designed so agents and their operators can discover, vet, and integrate capabilities without reinventing the wheel.
+
+- **Manifests** declare inputs, outputs, dependencies, and constitution in `manifest.yaml`.
+- **`skillware list`** (CLI) surfaces the local registry with categories, issuers, and descriptions.
+- **[Examples index](../examples/README.md)** maps runnable provider scripts to skills.
+- **[Usage guides](usage/README.md)** show the same load / tool-call / execute loop for Gemini, Claude, OpenAI, DeepSeek, and Ollama.
+- **[Agent contribution workflow](contributing/ai_native_workflow.md)** documents how supervised agents propose scoped changes and open PRs.
+
+Copy a snippet from an example, point `SkillLoader` at a skill id, and you have a working tool on any supported model. That is the discoverability loop we are optimizing for.
+
+New contributors should not need to reverse-engineer the repo to find the right entry point. Vision and introduction explain the why. The skill catalog and examples show the what. Usage guides and the agent workflow show the how. Each layer stays short so agents and humans can drill down only where they need depth.
+
+---
+
+## Roadmap in four phases
+
+This is direction, not a delivery schedule. Future phases are roadmap items.
+
+### 1. Now: modular skills for existing LLMs
+
+Ship a growing public registry, a stable loader, model adapters, tests, and docs. Make it trivial to install a skill and call it from any major LLM runtime. **You are here.**
+
+### 2. Next: ultimate skills with industry partners
+
+Co-develop deeper skills with domain partners: compliance, finance, robotics vendors, and similar. Higher assurance data, shared maintenance, and production-grade bundles beyond community contributions alone.
+
+### 3. World skills: robots, drones, appliances
+
+Extend the same bundle model to physical systems. A skill becomes a portable contract between an agent and a device or simulation, not only a Python function behind an API.
+
+### 4. Brain skills: BCI-scale skill delivery
+
+Long-term vision: deliver procedural capability at the edge of human-machine interfaces. Same modular idea, different execution surface. Research and partnership territory.
+
+---
+
+## Where we are today
+
+Honest snapshot as of the v0.3.x line:
+
+- **Registry**: Skills under `skills/` with docs in [docs/skills/](skills/README.md).
+- **Loader**: Dynamic import, dependency checks, and adapters for major LLM tool formats.
+- **CLI**: `skillware list` and an interactive menu (install with `skillware[cli]` today; default packaging may expand).
+- **Active work**: Wallet screening enhancements ([RFC #115](https://github.com/ARPAHLS/skillware/issues/115)), CLI polish, contributor docs, and good first issues across docs and framework.
+
+Browse [open good first issues](https://github.com/ARPAHLS/skillware/issues?q=is%3Aopen+label%3A%22good+first+issue%22) if you want a low-risk entry point.
+
+---
+
+## Join us
+
+Skillware is community-built. We welcome human contributors and **supervised agents** following the same standards: small PRs, tests where they matter, no emojis in project prose, and honest issue links.
+
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** — fork, branch, skill standard, pull request process.
+- **[Agent Contribution Workflow](contributing/ai_native_workflow.md)** — how operators and agents ship reviewable work.
+- **[Introduction](introduction.md)** — Mind, Body, Conscience architecture in depth.
+
+Help us make agent capabilities portable, safe, and reusable.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -36,7 +36,7 @@ Consider screening an Ethereum wallet for sanctions exposure and risky counterpa
 
 The [`finance/wallet_screening`](../skills/finance/wallet_screening/) skill packages all of that. Bundled JSON datasets sit beside the Python runner. Optional Etherscan access enriches live chain data. The agent receives a tool schema plus `instructions.md` that teach it how to interpret the JSON verdict.
 
-Multi-layer screening runs locally in one `execute()` call. No generated scraper. No ad-hoc script the model wrote five minutes ago. For skill-level detail, see [wallet_screening.md](skills/wallet_screening.md). For how this task compares to prompts, MCP, or enterprise APIs, see the table under [Comparison](../README.md#comparison) in the README.
+Multi-layer screening runs locally in one `execute()` call. No generated scraper. No ad-hoc script the model wrote five minutes ago. For skill-level detail, see [wallet_screening.md](skills/wallet_screening.md). For how this task compares to prompts, MCP, or enterprise APIs, see the [wallet screening table](../COMPARISON.md#wallet-screening-same-task-different-approaches) in [COMPARISON.md](../COMPARISON.md).
 
 ---
 
@@ -58,29 +58,51 @@ New contributors should not need to reverse-engineer the repo to find the right 
 
 ## Roadmap in four phases
 
-This is direction, not a delivery schedule. Future phases are roadmap items.
+Skillware follows one thread: modular capability you can install, trust, and extend across models, machines, and people.
 
-### 1. Now: modular skills for existing LLMs
+### v0: Modular Agent Skills
 
-Ship a growing public registry, a stable loader, model adapters, tests, and docs. Make it trivial to install a skill and call it from any major LLM runtime. **You are here.**
+**Self-contained, deterministic skills for any LLM or agent**
 
-### 2. Next: ultimate skills with industry partners
+**In short:** A public registry, a stable loader, model adapters, tests, and docs. Install a skill and call it from any major LLM runtime. **You are here** (v0.3.x).
 
-Co-develop deeper skills with domain partners: compliance, finance, robotics vendors, and similar. Higher assurance data, shared maintenance, and production-grade bundles beyond community contributions alone.
+**Example:** Your agent runs `pip install skillware`, loads a Terms-of-Service evaluator skill, then visits a site or ingests a document. It follows the skill's constitution and logic immediately: what to extract, what to flag, what never to scrape or store. No extra prompt engineering, no one-off tools, no separate subscription stack. The capability ships as one bundle.
 
-### 3. World skills: robots, drones, appliances
+---
 
-Extend the same bundle model to physical systems. A skill becomes a portable contract between an agent and a device or simulation, not only a Python function behind an API.
+### v1: Ultimate skills
 
-### 4. Brain skills: BCI-scale skill delivery
+**Partner-grade bundles with verified data and shared maintenance**
 
-Long-term vision: deliver procedural capability at the edge of human-machine interfaces. Same modular idea, different execution surface. Research and partnership territory.
+**In short:** Co-develop deeper skills with industry partners in compliance, finance, supply chain & logistics, manufacturing, among other domains. Higher-assurance datasets, SLAs, and production ownership beyond community contributions alone.
+
+**Example:** An OEM and a plant operator co-maintain a skill chain for production lines: ingest IoT telemetry, normalize units, flag anomalies, and alert on silo levels, line stoppages, and vendor price shifts. Live feeds, audit logs, and signed releases ship inside the bundle. The same skill ids run in staging and on the floor. Logic, governance, and data provenance stay aligned because the bundle is the contract, not a patchwork of prompts and ad-hoc integrations.
+
+---
+
+### v2: World skills
+
+**Skills for robots, UAVs and drones, appliances, and the physical world**
+
+**In short:** Extend the bundle model beyond Python-in-a-process. A skill becomes a portable contract between an agent and a device, sensor mesh, or simulation.
+
+**Example:** At home, a fridge skill uses vision to notice you are low on milk, checks vendor skills for a three-day discount at store X, and suggests pickup after your gym slot tomorrow. A drone skill inspects a roof or field boundary from a live feed. Same installable idea, different surfaces and devices.
+
+---
+
+### v3: Brain skills
+
+**Procedural delivery at the edge of human-machine interfaces**
+
+**In short:** Long-term research and partnership territory. Deliver practice, language, and job skills through interfaces where cognition and execution meet, not only through chat or APIs.
+
+**Example:** A learner installs a language or trade skill and receives structured procedural capability: pronunciation drills, safety checks on a lathe, or clinical triage steps under supervision. Decades of practice compressed into a governed bundle the interface can invoke step by step. Same modular philosophy as v0, a different execution surface.
 
 ---
 
 ## Where we are today
 
-Honest snapshot as of the v0.3.x line:
+Honest snapshot for **v0** (current v0.3.x line):
 
 - **Registry**: Skills under `skills/` with docs in [docs/skills/](skills/README.md).
 - **Loader**: Dynamic import, dependency checks, and adapters for major LLM tool formats.


### PR DESCRIPTION
## Description

Docs-only PR for **#133**: adds `docs/vision.md` as the canonical project story and lightly reshapes README navigation and contributor-facing copy. Also includes README, conduct, and cross-link polish discovered while implementing the issue.

**New**
- `docs/vision.md` — origin story, why not prompts-only, wallet screening narrative, agent discoverability, v0–v3 roadmap (with examples), current state, contributor invite
- Wallet screening comparison table in `COMPARISON.md` (not README — keeps Comparison scannable)

**README**
- Mission links to Vision; expanded Logic / Cognition / Governance / Interface list
- Top nav + grouped **Documentation** table (Introduction · Usage guides · Contributing)
- Skill library site link opens in new tab (↗)
- Contributing section as short paragraphs (points to docs table; no duplicate bullet farm)
- Contact: enterprise (`skills@`), security (`security@` + SECURITY.md), skill-author note (card, library, site)

**Cross-links**
- `docs/introduction.md`, `CONTRIBUTING.md`, `docs/contributing/ai_native_workflow.md`, `COMPARISON.md` → vision.md

**Beyond #133 scope (included in same PR)**
- `CODE_OF_CONDUCT.md` — under **Contribution process**: skill issuer requirements + disclaimer/promo review expectations

### Type of Change

- [ ] Skill Proposal
- [ ] Bug Report Fix
- [x] **Doc Fix**
- [ ] Framework Feature / RFC Updates

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (docs-only; no code changes).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] `examples/README.md` — N/A (no example script changes).

## New or updated skill

N/A — no registry changes.

## Constitution & Safety

N/A — documentation and conduct text only.

## Related Issues

Fixes #133