### PR TITLE
feat: version support policy and CLI advisory for unsupported install…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ## [Unreleased]
 
 ### Added
+- **Version policy**: `skillware/version_policy.py` with supported-version thresholds; CLI prints one dim stderr advisory only for installs below `0.2.6` (#132).
+- **Tests**: `tests/test_version_policy.py` for advisory thresholds, opt-out, and CLI hook (#132).
 - **Documentation**: Added [docs/vision.md](docs/vision.md) with project story, roadmap, and agent discoverability (#133).
 
 ### Changed
+- **SECURITY.md**: Supported-version table aligned with `>= 0.3.1` security support and unsupported `< 0.2.6` band (#132).
+- **CLI**: Calls version advisory once at `main()` startup, not on menu re-loops (#132).
+- **Dependencies**: Added `packaging` for semver comparisons (#132).
 - **Documentation**: README Mission links to vision.md; wallet screening comparison table lives in COMPARISON.md; docs table and cross-links updated (#133).
 
 ## [0.3.2] - 2026-05-27

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,17 @@
 
 ## Supported Versions
 
-Use the latest version of Skillware to ensure you have the latest security patches.
+Use a current Skillware release to receive security fixes. We patch vulnerabilities only for supported versions.
 
-| Version | Supported |
-| ------- | --------- |
-| 0.2.x   | Yes       |
-| < 0.1.0   | No        |
+| Installed version | Security support | CLI advisory |
+| :--- | :--- | :--- |
+| **>= 0.3.1** | Supported. Security reports accepted and patched here. | Silent |
+| **0.2.6 – 0.3.0** | No security fixes. Upgrade recommended. | Silent (no upgrade spam) |
+| **< 0.2.6** (e.g. 0.2.5) | Unsupported. | One dim stderr message at CLI startup (in releases that ship this check) |
+
+Thresholds are defined in `skillware/version_policy.py` (`MIN_SECURITY_SUPPORTED`, `MIN_UNSUPPORTED`) and bumped by maintainers when support windows change.
+
+**Note:** PyPI releases are immutable. Users on very old wheels will not see the CLI advisory until they upgrade to a release that includes this logic at least once. That is expected for OSS packaging.
 
 ## Reporting a Vulnerability
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -11,6 +11,21 @@ The CLI depends on `rich` for terminal output. Install it with the `cli` extra:
 
     pip install "skillware[cli]"
 
+## Version advisory
+
+On CLI startup, Skillware checks the installed package version **once per process**.
+If you are on an **unsupported** release (below `0.2.6`, for example `0.2.5`), a single
+dim message is printed to stderr suggesting an upgrade to `>= 0.3.1`. Current and
+recent installs (`0.2.6` and above) stay silent so normal use is not spammed.
+
+Library use (`import skillware`, `SkillLoader`) never prints this message.
+
+To disable the check in CI or automation:
+
+    export SKILLWARE_NO_VERSION_CHECK=1
+
+See [SECURITY.md](../../SECURITY.md) for the full supported-version policy.
+
 ## Interactive menu
 
 Running `skillware` with no arguments launches an ASCII splash screen and an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyyaml",
     "python-dotenv",
     "beautifulsoup4",
+    "packaging",
 ]
 requires-python = ">=3.10"
 

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 
 from skillware.core.loader import SkillLoader
+from skillware.version_policy import emit_upgrade_advisory
 
 TABLE_STYLE = "bold #C7CEEA"  # lavender  - headers
 CATEGORY_STYLE = "bold #FFDAC1"  # peach     - category column
@@ -262,6 +263,8 @@ def cmd_interactive(console=None, parser=None) -> None:
 
 def main() -> None:
     """CLI entry point."""
+    emit_upgrade_advisory()
+
     parser = argparse.ArgumentParser(prog="skillware")
     subparsers = parser.add_subparsers(dest="command")
 

--- a/skillware/version_policy.py
+++ b/skillware/version_policy.py
@@ -1,0 +1,63 @@
+"""Supported-version policy and CLI upgrade advisory."""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib import metadata
+from typing import Optional
+
+from packaging.version import Version
+
+PACKAGE_NAME = "skillware"
+MIN_SECURITY_SUPPORTED = Version("0.3.1")
+MIN_UNSUPPORTED = Version("0.2.6")
+UPGRADE_TARGET = "0.3.1"
+
+
+def is_version_check_disabled() -> bool:
+    return os.environ.get("SKILLWARE_NO_VERSION_CHECK", "").strip() == "1"
+
+
+def get_installed_version() -> Optional[Version]:
+    """Return the installed package version, or None for dev/editable/unparseable."""
+    try:
+        raw = metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+    if not raw or raw == "dev":
+        return None
+    try:
+        return Version(raw)
+    except Exception:
+        return None
+
+
+def should_emit_unsupported_advisory(installed: Version) -> bool:
+    """True only for installs below MIN_UNSUPPORTED (e.g. 0.2.5 and earlier)."""
+    return installed < MIN_UNSUPPORTED
+
+
+def format_unsupported_message(installed: Version) -> str:
+    return (
+        f"Skillware {installed} is unsupported. "
+        f'Upgrade to >={UPGRADE_TARGET}: pip install -U "skillware[cli]"'
+    )
+
+
+def emit_upgrade_advisory() -> None:
+    """Print one dim stderr advisory for unsupported CLI installs; otherwise silent."""
+    if is_version_check_disabled():
+        return
+
+    installed = get_installed_version()
+    if installed is None or not should_emit_unsupported_advisory(installed):
+        return
+
+    message = format_unsupported_message(installed)
+    try:
+        from rich.console import Console
+
+        Console(stderr=True).print(message, style="dim")
+    except ImportError:
+        print(message, file=sys.stderr)

--- a/tests/test_version_policy.py
+++ b/tests/test_version_policy.py
@@ -1,0 +1,96 @@
+import pytest
+from packaging.version import Version
+
+from skillware import version_policy
+
+
+@pytest.fixture(autouse=True)
+def clear_version_check_env(monkeypatch):
+    monkeypatch.delenv("SKILLWARE_NO_VERSION_CHECK", raising=False)
+
+
+def test_get_installed_version_parses_release(monkeypatch):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.3.2",
+    )
+    assert version_policy.get_installed_version() == Version("0.3.2")
+
+
+def test_get_installed_version_dev_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "dev",
+    )
+    assert version_policy.get_installed_version() is None
+
+
+def test_should_emit_only_below_min_unsupported():
+    assert version_policy.should_emit_unsupported_advisory(Version("0.2.5")) is True
+    assert version_policy.should_emit_unsupported_advisory(Version("0.2.6")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.3.0")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.3.1")) is False
+
+
+def test_emit_advisory_silent_for_current_release(monkeypatch, capsys):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.3.1",
+    )
+    version_policy.emit_upgrade_advisory()
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_advisory_silent_for_outdated_but_supported_band(monkeypatch, capsys):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.3.0",
+    )
+    version_policy.emit_upgrade_advisory()
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_advisory_warns_for_unsupported(monkeypatch, capsys):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.2.5",
+    )
+    version_policy.emit_upgrade_advisory()
+    err = capsys.readouterr().err
+    assert "0.2.5" in err
+    assert "unsupported" in err.lower()
+    assert ">=0.3.1" in err
+
+
+def test_emit_advisory_respects_opt_out(monkeypatch, capsys):
+    monkeypatch.setenv("SKILLWARE_NO_VERSION_CHECK", "1")
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.2.5",
+    )
+    version_policy.emit_upgrade_advisory()
+    assert capsys.readouterr().err == ""
+
+
+def test_cli_main_calls_advisory_once(monkeypatch):
+    import sys
+
+    calls = []
+    from skillware import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "emit_upgrade_advisory",
+        lambda: calls.append(True),
+    )
+    monkeypatch.setattr(cli_module, "cmd_list", lambda **kwargs: None)
+    monkeypatch.setattr(sys, "argv", ["skillware", "list"])
+
+    cli_module.main()
+    assert len(calls) == 1


### PR DESCRIPTION
## Description

Fixes **#132**: stale supported-version policy and a targeted CLI nudge for very old installs.

**Problem:** `SECURITY.md` still listed `0.2.x` as supported while current releases are `0.3.x`. Users on ancient PyPI pins had no in-tool guidance to upgrade, but we did not want to spam everyone on recent installs.

**Solution:**
- Add `skillware/version_policy.py` with centralized thresholds (`MIN_SECURITY_SUPPORTED`, `MIN_UNSUPPORTED`).
- Call `emit_upgrade_advisory()` **once** at the start of `skillware.cli:main()` — not on menu re-loops, not on `import skillware`.
- Update `SECURITY.md`, `docs/usage/cli.md`, and `CHANGELOG.md`.
- Add `packaging` for semver comparison; tests in `tests/test_version_policy.py`.

**Policy**

| Installed | Security support | CLI |
|---|---|---|
| **≥ 0.3.1** | Supported (patches accepted) | Silent |
| **0.2.6 – 0.3.0** | No security fixes; upgrade recommended | Silent (no nag) |
| **< 0.2.6** (e.g. 0.2.5) | Unsupported | One dim stderr line per process |

**CLI message** (Rich `stderr`, dim style when available; plain stderr fallback):

`Skillware 0.2.5 is unsupported. Upgrade to >=0.3.1: pip install -U "skillware[cli]"`

**Opt-out:** `SKILLWARE_NO_VERSION_CHECK=1` (documented in `docs/usage/cli.md`).

**Note vs issue draft:** #132 originally proposed advisories for all installs below `0.3.1`. This PR intentionally narrows CLI output to **< 0.2.6 only** to avoid spamming `0.2.6–0.3.0` users. `SECURITY.md` documents all three bands.

**Limitation:** PyPI wheels are immutable — users still on a pre-policy wheel will not see the advisory until they upgrade at least once.

### Type of Change

- [ ] Skill Proposal
- [ ] Bug Report Fix
- [ ] Doc Fix (partial — policy docs only)
- [x] **Framework Feature / RFC Updates**

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (`tests/test_version_policy.py`, `tests/test_cli.py` — 23 passed).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] `examples/README.md` — N/A (no example script changes).

## New or updated skill

N/A.

## Constitution & Safety

N/A — version policy and CLI messaging only. Vulnerability reporting unchanged (`security@arpacorp.net`, see `SECURITY.md`).

## Related Issues

Fixes #132