### PR TITLE
docs: update comparison for Agent Skills open standard and fair MCP framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Changed
 - **CI**: GitHub Actions installs dependencies from `pyproject.toml` only (`pip install -e ".[dev,all]"`); removed redundant manual pip pins. CI runs `pytest tests/` only; co-located `skills/**/test_skill.py` remains a local pre-PR step (#151).
 - **Documentation**: [TESTING.md](docs/TESTING.md) and [CONTRIBUTING.md](CONTRIBUTING.md) aligned with CI scope and local skill-test workflow (#151).
+- **Documentation**: Updated [COMPARISON.md](COMPARISON.md) and README for Agent Skills (SKILL.md) open standard and fairer MCP framing ([Docs]: Light refresh of COMPARISON.md #123).
 
 ## [0.3.3] - 2026-05-29
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -99,7 +99,7 @@ Frameworks like Google DeepMind's **Antigravity** use `SKILL.md` files to provid
 A critical architectural distinction is how Skillware treats logic execution versus "code generation."
 
 *   **The Code-Generation Approach**: Many platforms prompt the LLM to write code on the fly to solve a requested problem. This is expensive (you pay for output tokens every time), slow, and risky (the LLM executes unreviewed code).
-*   **The Skillware Approach**: Skillware relies on **Pre-Compiled Logic**. The logical system decides *which* tool to call (e.g., wallet_screening) and passes arguments. The heavy lifting happens deterministically in the Python `BaseSkill` implementation. This results in **zero-cost logic execution**, instant processing, and static, auditable code boundaries.
+*   **The Skillware Approach**: Skillware relies on **Pre-Compiled Logic**. The logical system decides *which* tool to call (e.g., wallet_screening) and passes arguments. The heavy lifting happens deterministically in the Python `BaseSkill` implementation. This results in **zero-cost logic execution**, instant processing, and static, auditable code boundaries. In contrast, hosts using Agent Skills load full SKILL.md instruction context into the model at runtime and may rely on the host to generate or run code; Skillware keeps reasoning in `instructions.md` but executes work in pre-reviewed `skill.execute()`.
 
 ---
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -2,7 +2,9 @@
 
 Skillware is a Python framework that decouples AI tool logic, cognition, and governance into self-contained, installable modules called **Skills**. For the project story and roadmap, see [docs/vision.md](docs/vision.md).
 
-This document clarifies how Skillware compares to other common approaches for equipping AI agents with tools, including **Model Context Protocol (MCP)**, **Anthropic Skills**, **LangChain Tools**, **AutoGen**, and others.
+This document clarifies how Skillware compares to other common approaches for equipping AI agents with tools, including **Model Context Protocol (MCP)**, **Agent Skills (SKILL.md)**, **LangChain Tools**, **AutoGen**, and others.
+
+**A note on ecosystem convergence**: [Agent Skills](https://agentskills.io) and MCP address adjacent problems—host-level agent guidance and tool transport, respectively. Skillware remains a runtime capability framework built on a typed `manifest.yaml` → `execute()` contract; there is no plan to replace the Skill Package Standard with the SKILL.md format.
 
 ---
 
@@ -26,24 +28,26 @@ Skill detail: [wallet_screening.md](docs/skills/wallet_screening.md). Multi-laye
 The [Model Context Protocol](https://github.com/modelcontextprotocol) (MCP) is an open standard that connects AI models to data sources and tools via a client-server architecture.
 
 ### Key Differences
-*   **Architecture**: MCP operates on a **Client-Server** model (using JSON-RPC over stdio or SSE). This requires running and managing separate servers for your tools. Skillware is **Python-Native**. It operates entirely within the Python runtime via library imports (`SkillLoader`). There is no network overhead or need to deploy external servers.
-*   **Deployment Complexity**: MCP is powerful for language-agnostic, distributed systems but introduces significant infrastructure overhead. Skillware is designed for direct embedding into GenAI application pipelines, making it trivial to deploy.
+*   **Architecture**: MCP operates on a **Client-Server** model (using JSON-RPC over stdio or SSE). While local stdio servers are an option, running and managing separate server processes is the norm. Skillware is **Python-Native**: it operates entirely within the Python runtime via library imports (`SkillLoader`) with no network overhead.
+*   **Deployment Complexity**: MCP is powerful for language-agnostic, distributed systems and can run locally via stdio; Skillware is designed for direct in-process embedding into GenAI application pipelines. The two are complementary layers—MCP as a tool-transport protocol, Skillware as an in-process capability framework—not an either/or choice.
 
 ---
 
-## 2. Skillware vs. Anthropic Skills
+## 2. Skillware vs. Agent Skills (SKILL.md)
 
-[Anthropic's Skills](https://github.com/anthropics/skills) repository provides reference tool implementations and prompts optimized specifically for Claude.
+The [Agent Skills](https://agentskills.io) standard (originally from [Anthropic](https://github.com/anthropics/skills), now a multi-host open format supported by Cursor, Copilot, Claude Code, Gemini CLI, and others) packages host-level agent guidance as `SKILL.md` files with optional `scripts/` including Python, loaded progressively by the host.
 
 ### Key Differences
-*   **Model Agnosticism**: Anthropic skills are hardcoded for Claude's specific tool-calling schemas. Skillware features **Universal Adapters**. You write a single `manifest.yaml`, and Skillware's `SkillLoader` translates it dynamically at runtime to fit Gemini, Claude, or OpenAI formats natively.
-*   **The "Managed" Runtime**: Anthropic provides standalone reference scripts. Skillware provides a comprehensive framework (`base_skill.py` and `loader.py`) that handles lifecycle, dynamic dependency checking, execution, and error handling automatically.
+*   **Model Agnosticism**: Agent Skills are host-dependent—execution is orchestrated by whichever client loads the SKILL.md (Claude Code, Cursor, etc.). Skillware features **Universal Adapters**: you write a single `manifest.yaml`, and `SkillLoader` translates it dynamically at runtime to fit Gemini, Claude, or OpenAI formats natively.
+*   **The "Managed" Runtime**: Both formats can bundle Python in a folder. The key difference is that Skillware enforces a **typed tool schema and a deterministic `skill.execute()` contract** via `SkillLoader`, rather than relying on host-orchestrated script runs alone. Skillware provides `base_skill.py` and `loader.py` for lifecycle, dependency checking, execution, and error handling automatically.
+
+Skillware is not adopting Agent Skills (SKILL.md) as its registry format.
 
 ---
 
 ## 3. Skillware vs. Antigravity ("Agentic" Skills)
 
-Frameworks like Google DeepMind's **Antigravity** use `SKILL.md` files to provide context to an autonomous coding agent working inside an IDE.
+Frameworks like Google DeepMind's **Antigravity** use `SKILL.md` files to provide context to an autonomous coding agent working inside an IDE. This is distinct from the open Agent Skills (SKILL.md) standard in §2: Antigravity targets IDE procedural memory, not host-agent skill packs.
 
 ### Key Differences
 *   **Target Audience**:
@@ -101,9 +105,9 @@ A critical architectural distinction is how Skillware treats logic execution ver
 
 ## Executive Summary Matrix
 
-| Feature | Skillware | Model Context Protocol (MCP) | Anthropic Skills | Antigravity Skills | LangChain Tools | AutoGen & CrewAI | Semantic Kernel |
+| Feature | Skillware | Model Context Protocol (MCP) | Agent Skills (SKILL.md) | Antigravity Skills | LangChain Tools | AutoGen & CrewAI | Semantic Kernel |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Primary Goal** | **Installable App Capabilities** | **Standardized Tool Integration** | Claude Capabilities Showcase | **Developer Agent Guidance** | **Chain / Execution Wrappers** | **Multi-Agent Orchestration** | **Enterprise Orchestration** |
+| **Primary Goal** | **Installable App Capabilities** | **Standardized Tool Integration** | Host-agent skill packs (open standard) | **Developer Agent Guidance** | **Chain / Execution Wrappers** | **Multi-Agent Orchestration** | **Enterprise Orchestration** |
 | **Architecture** | **Native Python Library** | **Client-Server (JSON-RPC)** | Standalone Scripts | Markdown Context Files | Python/JS Components | Python Framework | Enterprise SDK |
-| **Model Compatibility** | **Universal** (Adapters built-in) | Standardized Protocol Clients | Claude Specific | Context injection | Broad via Ecosystem | Broad | Broad via Connectors |
+| **Model Compatibility** | **Universal** (Adapters built-in) | Standardized Protocol Clients | Host-dependent (multi-vendor clients) | Context injection | Broad via Ecosystem | Broad | Broad via Connectors |
 | **Execution Context** | **Runtime Application** | Distributed / Networked | Runtime Application | IDE / Build Environment | LangChain Pipeline | Agent Workflows | Enterprise Service |

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Also read the [Agent Code of Conduct](CODE_OF_CONDUCT.md). Open PRs with the [pu
 
 ## Comparison
 
-Skillware differs from the Model Context Protocol (MCP), and Anthropic's Skills repository in several ways:
+Skillware differs from the Model Context Protocol (MCP), and Agent Skills (SKILL.md) in several ways:
 
 *   **Model Agnostic**: Native adapters for Gemini, Claude, Ollama, and OpenAI.
 *   **Code-First**: Skills are executable Python packages, not just server specs.


### PR DESCRIPTION

- Retitle §2 Anthropic Skills → Agent Skills (SKILL.md); reflect multi-host open standard (Cursor, Copilot, Claude Code, Gemini CLI) with links to agentskills.io and anthropics/skills
- Add convergence note in intro clarifying Skillware is not pivoting to SKILL.md
- Soften §1 MCP bullets: acknowledge local stdio option; add complementary- layers sentence (protocol vs in-process capability)
- Update Executive Summary Matrix: column label, Primary Goal cell, and Model Compatibility cell for the Agent Skills column
- Align README Comparison blurb with §2 wording

<!--
AUTOMATED AGENT GREETING

Greetings, netizen! We welcome your pull requests to Skillware.
Before submitting your code, please ensure you have:
1. Fully read and understood the linked GitHub Issue and its requirements.
2. Analyzed the core architecture (`loader.py`, `base_skill.py`) to ensure your approach aligns with the framework natively.
3. Verified all dependencies are documented in your `manifest.yaml` and logic executes deterministically.
4. Checked off all items in the checklist below.

We are excited to review your capabilities! Let's build together.
-->

## Description

<!--
Agents: Please summarize the logic, cognition, and governance changes introduced in this PR.
Humans: Please describe what this PR does and why it's needed.
-->

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip this section for framework-only, documentation-only, or other PRs that do not touch the skill registry.

### Bundle & metadata

- [ ] Skill lives at `skills/<category>/<skill_name>/` (copied from `templates/python_skill/` or equivalent).
- [ ] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
- [ ] `manifest.yaml` includes `issuer` with real `name` and `email` (not template placeholders).
- [ ] Optional: `short_description` in manifest (~80 chars) for `skillware list`.
- [ ] Optional: `issuer.github` and `issuer.org` set when applicable.
- [ ] `requirements` and `env_vars` are documented when the skill needs them.

### Logic, cognition, and UI

- [ ] `skill.py` is deterministic Python (no arbitrary LLM-generated code paths).
- [ ] `instructions.md` explains when and how to use the skill.
- [ ] `card.json` is present and its `issuer` matches `manifest.yaml` (`name` and `email` at minimum).

### Tests & loader

- [ ] `test_skill.py` covers execution and schema expectations.
- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps are documented).

### Documentation & catalog

- [ ] `docs/skills/<skill_name>.md` exists or is updated (ID, Issuer, usage).
- [ ] `docs/skills/README.md` lists the skill with ID and Issuer.

## Constitution & Safety (if adding or modifying a skill)

<!--
State the constitutional boundaries applied to this skill to ensure safe execution.
Example: "This skill only performs read operations on the blockchain and does not sign transactions."
-->

## Related Issues
<!-- Link to any related issues (e.g., Fixes #54) -->
Fixes #123 
