### PR TITLE
[issue_resolver]: universal workflow v0.2, examples, and release …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-29
+
 ### Added
+- **`dev_tools/issue_resolver`**: GitHub issue workflow with sequential stage checklists, conditional verify/commit gates, and commit-message validation (#143).
+- **Examples**: `gemini_issue_resolver.py`, `claude_issue_resolver.py`, and `ollama_issue_resolver.py` for `dev_tools/issue_resolver` (#118).
 - **Version policy**: `skillware/version_policy.py` with supported-version thresholds; CLI prints one dim stderr advisory only for installs below `0.2.6` (#132).
 - **Tests**: `tests/test_version_policy.py` for advisory thresholds, opt-out, and CLI hook (#132).
 - **Documentation**: Added [docs/vision.md](docs/vision.md) with project story, roadmap, and agent discoverability (#133).
 
 ### Changed
+- **`finance/wallet_screening`**: Unified TRM/scam transaction risk index for analysis (#140).
 - **SECURITY.md**: Supported-version table aligned with `>= 0.3.1` security support and unsupported `< 0.2.6` band (#132).
 - **CLI**: Calls version advisory once at `main()` startup, not on menu re-loops (#132).
 - **Dependencies**: Added `packaging` for semver comparisons (#132).

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -48,7 +48,7 @@ Skills that assist developers in understanding codebases, planning changes, and 
 
 | Skill | ID | Issuer | Description |
 | :--- | :--- | :--- | :--- |
-| **[Issue Resolver](issue_resolver.md)** | `dev_tools/issue_resolver` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Analyzes any GitHub issue against its target repository and produces a structured resolution plan with ranked implementation options, affected files, and caveats. |
+| **[Issue Resolver](issue_resolver.md)** | `dev_tools/issue_resolver` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | GitHub issue URL prep, nine-stage agent workflow, conditional verify/commit gates, and commit-message validation. |
 
 ---
 

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -6,16 +6,21 @@
 
 [Skill Library](README.md) · [Testing](../TESTING.md)
 
-A universal developer-tools skill that accepts any GitHub issue URL and produces a structured resolution plan — issue summary, affected files, ranked implementation options, and caveats — before a single line of code is written.
+A developer-tools skill that accepts any **GitHub issue URL** and guides the calling agent through a structured resolution workflow — issue discovery, repository context, analysis, ranked implementation options, verification, commit, and pull request — before and after code is written.
 
-The skill is designed to work with **any public GitHub repository**. It imposes no project-specific assumptions; instead it reads the target repository's README, CONTRIBUTING guide, and directory structure at runtime to ground its analysis in actual conventions. Project-specific context can be injected via the optional `extra_instructions` parameter.
+The skill is designed to work with **any public or authenticated GitHub repository**. It imposes no project-specific assumptions; the agent reads the target repository's README, CONTRIBUTING guide, and directory structure at runtime to ground analysis in actual conventions. Project-specific context can be injected via the optional `extra_instructions` parameter.
+
+The skill itself does **not** call GitHub, run git, or write code. It validates the issue URL, returns pre-computed GitHub API endpoints, and supplies ordered **stage checklists** with **conditional rules** (`If this repo has X, do Y`) that the agent executes with its own tools.
 
 ## Capabilities
 
-- **Universal repository support**: Works with any public GitHub repository. No hardcoded project assumptions.
-- **Structured resolution plans**: Produces up to three ranked implementation options with rationale, estimated complexity, and a recommended winner.
-- **Affected file mapping**: Lists every path likely to change — source, tests, documentation, CI configuration — without fabricating paths that do not exist in the repository.
+- **Universal GitHub repository support**: Works with any public GitHub repository (private repos require `GITHUB_TOKEN`). No hardcoded project paths.
+- **Structured resolution plans**: Guides the agent to produce up to three ranked implementation options with rationale, estimated complexity, and a recommended winner.
+- **Affected file mapping**: Directs the agent to list every path likely to change — source, tests, documentation, CI configuration — without fabricating paths that do not exist in the repository.
 - **Ripple-effect analysis**: Surfaces downstream files and dependent modules that may be affected even if not directly modified.
+- **Sequential workflow gates**: Nine ordered stages from issue discovery through pull request, with `stage_checklist` payloads per stage.
+- **Conditional verification**: Each stage includes rules such as run tests if the repo has them, update release notes if the project maintains them, or infer conventions from README when CONTRIBUTING is missing.
+- **Commit-message validation**: `validate_commit_message` rejects AI co-author trailers by default before commit.
 - **Caller-injectable context**: The `extra_instructions` field lets any caller inject project-specific style rules, scope constraints, or workflow requirements without modifying the skill.
 - **Graceful authentication**: Operates without a token against public repositories (subject to GitHub's 60 req/hr unauthenticated limit) and upgrades to 5000 req/hr when `GITHUB_TOKEN` is provided.
 
@@ -23,19 +28,20 @@ The skill is designed to work with **any public GitHub repository**. It imposes 
 
 The skill lives in `skills/dev_tools/issue_resolver/`.
 
-### The Body (`skill.py`)
+### The Body (`skill.py` + `workflow.py`)
 
-A thin, deterministic input layer. It validates the issue URL against the GitHub URL pattern, normalises the token source (runtime parameter takes precedence over environment variable), pre-computes all GitHub API and raw content URLs the agent will need, and returns a `status: ready` payload. It makes no network calls and has no runtime dependencies beyond the Python standard library and `PyYAML`.
+A thin, deterministic action router. It validates the issue URL against the GitHub URL pattern, normalises the token source (runtime parameter takes precedence over environment variable), pre-computes all GitHub API and raw content URLs the agent will need, and returns stage checklists and commit gates on demand. It makes no network calls and has no runtime dependencies beyond the Python standard library and `PyYAML`.
+
+| action | Purpose |
+|--------|---------|
+| `prepare` | Validate issue URL; return GitHub API and raw content URLs |
+| `workflow_overview` | Ordered list of all workflow stages |
+| `stage_checklist` | Steps and conditionals for one stage |
+| `validate_commit_message` | Pre-commit message gate |
 
 ### The Mind (`instructions.md`)
 
-A precise five-stage workflow the calling agent executes using its own tool-use capabilities:
-
-1. Fetch the issue (body, labels, comments, linked PRs).
-2. Understand the repository (README, CONTRIBUTING, directory tree, relevant existing files).
-3. Analyse (problem statement, acceptance criteria, affected files, ripple effects, options).
-4. Produce and present the resolution plan. Wait for user approval.
-5. Implement only after explicit approval, constrained to the approved plan.
+Agent-facing rules: when to use the skill, how to call each action, mandatory stage order, gate rules, and the structured **plan** output contract. Detailed steps and conditionals for each stage are returned at runtime by `stage_checklist` (defined in `workflow.py`).
 
 ## Integration Guide
 
@@ -55,7 +61,15 @@ Sample user message: *Analyse issue #56 in ARPAHLS/skillware and produce a resol
 
 ### Runnable examples
 
-See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. Runnable example: pending — `dev_tools/issue_resolver` does not yet have a dedicated script under `examples/`, so the provider sections below remain catalog snippets until issue #118 lands.
+| Script | Provider | Env vars |
+| :--- | :--- | :--- |
+| [`gemini_issue_resolver.py`](../../examples/gemini_issue_resolver.py) | Gemini | `GOOGLE_API_KEY`; optional `GITHUB_TOKEN` |
+| [`claude_issue_resolver.py`](../../examples/claude_issue_resolver.py) | Claude | `ANTHROPIC_API_KEY`; optional `GITHUB_TOKEN` |
+| [`ollama_issue_resolver.py`](../../examples/ollama_issue_resolver.py) | Ollama | optional `GITHUB_TOKEN`; local Ollama (`gemma4:e2b` or `qwen3.5:4b`) |
+
+All three scripts use [issue #123](https://github.com/ARPAHLS/skillware/issues/123) as the sample issue. After `prepare`, the example script fetches issue and README content from GitHub and returns it to the model — demonstrating that the skill returns URLs and checklists, not a finished plan.
+
+See [examples/README.md](../../examples/README.md) and [Agent loops](../usage/agent_loops.md) for the full inventory.
 
 ### Direct execute
 
@@ -87,12 +101,14 @@ load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
 skill = bundle["module"].IssueResolverSkill()
 client = genai.Client()
-tool = SkillLoader.to_gemini_tool(bundle)
+tool_decl = SkillLoader.to_gemini_tool(bundle)
+tool_decl["name"] = SkillLoader._sanitize_function_tool_name("dev_tools/issue_resolver")
+gemini_tool = types.Tool(function_declarations=[tool_decl])
 response = client.models.generate_content(
-    model="gemini-2.5-flash",
+    model="gemini-2.5-flash-lite",
     contents="Analyze https://github.com/owner/repo/issues/123 and propose a fix plan.",
     config=types.GenerateContentConfig(
-        tools=[tool],
+        tools=[gemini_tool],
         system_instruction=bundle["instructions"],
     ),
 )
@@ -100,7 +116,7 @@ for part in response.candidates[0].content.parts:
     if part.function_call:
         result = skill.execute(dict(part.function_call.args))
         follow_up = client.models.generate_content(
-            model="gemini-2.5-flash",
+            model="gemini-2.5-flash-lite",
             contents=[
                 "Use this tool result to answer the original request.",
                 {
@@ -111,7 +127,7 @@ for part in response.candidates[0].content.parts:
                 },
             ],
             config=types.GenerateContentConfig(
-                tools=[tool],
+                tools=[gemini_tool],
                 system_instruction=bundle["instructions"],
             ),
         )
@@ -201,21 +217,42 @@ response = client.chat.completions.create(
 
 ## Data Schema
 
-### Input
+### Input (action prepare)
 
 ```json
 {
+  "action": "prepare",
   "issue_url": "https://github.com/owner/repo/issues/42",
-  "extra_instructions": "Optional. Project-specific context or scope constraints.",
-  "github_token": "Optional. Runtime token; overrides GITHUB_TOKEN env var."
+  "extra_instructions": "Optional caller context."
 }
 ```
 
-### Output (status: ready)
+### Input (stage checklist)
+
+```json
+{
+  "action": "stage_checklist",
+  "stage": "verify"
+}
+```
+
+### Input (commit validation)
+
+```json
+{
+  "action": "validate_commit_message",
+  "message": "Fix parser edge case\n\nFixes #42",
+  "allow_ai_coauthor": false
+}
+```
+
+### Output (status: ready — prepare)
 
 ```json
 {
   "status": "ready",
+  "action": "prepare",
+  "workflow_version": "0.2",
   "issue": {
     "url": "https://github.com/owner/repo/issues/42",
     "api_url": "https://api.github.com/repos/owner/repo/issues/42",
@@ -235,7 +272,7 @@ response = client.chat.completions.create(
     "note": "No GITHUB_TOKEN configured. Unauthenticated rate limit applies (60 req/hr)."
   },
   "extra_instructions": null,
-  "next_step": "Follow the workflow in instructions.md. Fetch the issue, read the repository context, then produce the structured resolution plan as described."
+  "next_step": "Call action workflow_overview or stage_checklist for discover_issue. Follow instructions.md stages in order; do not skip gates."
 }
 ```
 
@@ -250,10 +287,13 @@ response = client.chat.completions.create(
 
 ## Limitations
 
+- **Agent-driven execution**: The skill returns checklists and gates; the agent must fetch GitHub data, run tests, git, and open pull requests.
 - **Public repositories only (without token)**: Private repositories require a `GITHUB_TOKEN` with appropriate read access.
-- **Analysis, not implementation**: The skill produces planning output. Writing code is the responsibility of the calling agent, which should follow the plan only after user approval.
-- **Rate limits**: Without a token, the GitHub API allows 60 unauthenticated requests per hour per IP. Large repositories with many referenced files may approach this limit during Stage 2 analysis.
-- **Repository tree size**: Very large repositories (tens of thousands of files) may return truncated tree responses from the GitHub API. The agent should note truncation and inspect directories selectively.
+- **Planning quality depends on the agent**: The skill does not produce the resolution plan itself; the calling model must follow `instructions.md` and use repository context it fetches.
+- **Rate limits**: Without a token, the GitHub API allows 60 unauthenticated requests per hour per IP. Large repositories with many referenced files may approach this limit during repository discovery.
+- **Repository tree size**: Very large repositories may return truncated tree responses from the GitHub API. The agent should note truncation and inspect directories selectively.
+
+Skill history and version notes: [CHANGELOG.md](../../CHANGELOG.md) (#56, #143).
 
 ---
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -65,3 +65,4 @@ skills in one harness.
 | `optimization/prompt_rewriter` | `prompt_compression_demo.py` (local execute) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | `ollama_skills_test.py` (multi-skill) |
 | `data_engineering/synthetic_generator` | `build_dataset_demo.py` (local execute, Gemini backend) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
 | `data_engineering/novelty_extractor` | `novelty_extractor_demo.py` (local execute) | `gemini_novelty_extractor.py` | (catalog page) | (catalog page) | (catalog page) | `ollama_novelty_extractor.py` |
+| `dev_tools/issue_resolver` | - | `gemini_issue_resolver.py` | `claude_issue_resolver.py` | (catalog page) | (catalog page) | `ollama_issue_resolver.py` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ with editable install: `pip install -e ".[gemini]"`.
 | `build_dataset_demo.py` | `data_engineering/synthetic_generator` | Local execute (Gemini backend) | `[gemini]` | `GOOGLE_API_KEY` | Generates a JSONL synthetic dataset with the synthetic generator skill. |
 | `claude_pdf_form_filler.py` | `office/pdf_form_filler` | Claude | `[claude]`, `[office]` | `ANTHROPIC_API_KEY` | Uses Claude with the PDF form filler skill to map instructions to fields. |
 | `claude_tos_evaluator.py` | `compliance/tos_evaluator` | Claude | `[claude]` | `ANTHROPIC_API_KEY` | Runs a Claude tool loop for website automation policy review. |
+| `claude_issue_resolver.py` | `dev_tools/issue_resolver` | Claude | `[claude]` | `ANTHROPIC_API_KEY`; optional `GITHUB_TOKEN` | Claude loop for GitHub issue analysis; fetches issue data after `prepare` (sample: issue #123). |
 | `claude_wallet_check.py` | `finance/wallet_screening` | Claude | `[claude]` | `ANTHROPIC_API_KEY`, `ETHERSCAN_API_KEY` | Screens an Ethereum wallet and returns the result through a Claude tool loop. |
 | `deepseek_tos_evaluator.py` | `compliance/tos_evaluator` | DeepSeek | `[openai]` | `DEEPSEEK_API_KEY` | Uses the OpenAI-compatible DeepSeek API for terms-of-service evaluation. |
 | `gemini_pdf_form_filler.py` | `office/pdf_form_filler` | Gemini | `[gemini]`, `[office]` | `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY` | Uses Gemini as the agent while the PDF skill calls Anthropic for form filling. |
@@ -39,15 +40,8 @@ with editable install: `pip install -e ".[gemini]"`.
 | `novelty_extractor_demo.py` | `data_engineering/novelty_extractor` | Local execute | `pip install fastembed numpy` | None | Demonstrates multi-turn corpus distillation using local embeddings with no API key. |
 | `gemini_novelty_extractor.py` | `data_engineering/novelty_extractor` | Gemini | `[gemini]`, `pip install fastembed numpy` | `GOOGLE_API_KEY` | Runs the novelty extractor with a Gemini function-calling loop. |
 | `ollama_novelty_extractor.py` | `data_engineering/novelty_extractor` | Ollama | `pip install fastembed numpy`; install `ollama` separately | None | Runs the novelty extractor with local Ollama prompt-mode calls. |
-
-## Skills Without Runnable Examples
-
-The catalog also includes skills that do not yet have a dedicated runnable
-script under `examples/`:
-
-| Skill ID | Status |
-| :--- | :--- |
-| `dev_tools/issue_resolver` | No runnable example yet. The skill has `skills/dev_tools/issue_resolver/test_skill.py`, but no provider or local workflow script in `examples/`. |
+| `gemini_issue_resolver.py` | `dev_tools/issue_resolver` | Gemini | `[gemini]` | `GOOGLE_API_KEY`; optional `GITHUB_TOKEN` | Gemini loop for GitHub issue analysis; fetches issue data after `prepare` (sample: issue #123). |
+| `ollama_issue_resolver.py` | `dev_tools/issue_resolver` | Ollama | No Skillware extra; install `ollama` separately | optional `GITHUB_TOKEN`; `OLLAMA_MODEL` (default `gemma4:e2b`) | Ollama prompt-mode loop for GitHub issue analysis (sample: issue #123). |
 
 ## Notes
 

--- a/examples/claude_issue_resolver.py
+++ b/examples/claude_issue_resolver.py
@@ -1,0 +1,85 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from issue_resolver_github_context import execute_skill  # noqa: E402
+
+from skillware.core.env import load_env_file  # noqa: E402
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+load_env_file()
+
+SKILL_ID = "dev_tools/issue_resolver"
+ISSUE_URL = "https://github.com/ARPAHLS/skillware/issues/123"
+
+bundle = SkillLoader.load_skill(SKILL_ID)
+print(f"Loaded Skill: {bundle['manifest']['name']}")
+
+IssueResolverSkill = bundle["module"].IssueResolverSkill
+skill = IssueResolverSkill()
+github_token = os.environ.get("GITHUB_TOKEN") or None
+
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+system = bundle["instructions"]
+
+user_query = (
+    f"Analyze {ISSUE_URL} and produce a structured resolution plan. "
+    "Use the issue_resolver skill: start with action prepare, call stage_checklist "
+    "for discover_issue and discover_repository, then present the plan. "
+    "Do not implement code or commit."
+)
+print(f"User: {user_query}")
+
+messages = [{"role": "user", "content": user_query}]
+response = None
+
+while True:
+    response = client.messages.create(
+        model=os.environ.get("ANTHROPIC_MODEL", "claude-3-5-sonnet-latest"),
+        max_tokens=4096,
+        system=system,
+        tools=tools,
+        messages=messages,
+    )
+
+    if response.stop_reason != "tool_use":
+        break
+
+    tool_uses = [block for block in response.content if block.type == "tool_use"]
+    if not tool_uses:
+        break
+
+    messages.append({"role": "assistant", "content": response.content})
+    tool_results = []
+
+    for tool_use in tool_uses:
+        print(f"Claude requested tool: {tool_use.name}")
+        print(f"Input: {tool_use.input}")
+
+        if tool_use.name != SKILL_ID:
+            break
+
+        result = execute_skill(skill, tool_use.input, github_token)
+        print(json.dumps(result, indent=2))
+        tool_results.append(
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_use.id,
+                "content": json.dumps(result),
+            }
+        )
+    else:
+        messages.append({"role": "user", "content": tool_results})
+        continue
+    break
+
+print("\nFinal Response:")
+if response is not None:
+    for block in response.content:
+        if hasattr(block, "text"):
+            print(block.text)

--- a/examples/gemini_issue_resolver.py
+++ b/examples/gemini_issue_resolver.py
@@ -1,0 +1,94 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import google.genai as genai
+from google.genai import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from issue_resolver_github_context import execute_skill  # noqa: E402
+
+from skillware.core.env import load_env_file  # noqa: E402
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+load_env_file()
+
+SKILL_ID = "dev_tools/issue_resolver"
+ISSUE_URL = "https://github.com/ARPAHLS/skillware/issues/123"
+
+bundle = SkillLoader.load_skill(SKILL_ID)
+print(f"Loaded Skill: {bundle['manifest']['name']}")
+
+IssueResolverSkill = bundle["module"].IssueResolverSkill
+skill = IssueResolverSkill()
+github_token = os.environ.get("GITHUB_TOKEN") or None
+
+client = genai.Client()
+tool_decl = SkillLoader.to_gemini_tool(bundle)
+tool_decl["name"] = SkillLoader._sanitize_function_tool_name(SKILL_ID)
+gemini_tool = types.Tool(function_declarations=[tool_decl])
+gemini_fn_name = tool_decl["name"]
+system_instruction = bundle["instructions"]
+model = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+user_query = (
+    f"Analyze {ISSUE_URL} and produce a structured resolution plan. "
+    "Use the issue_resolver skill: start with action prepare, call stage_checklist "
+    "for discover_issue and discover_repository, then present the plan. "
+    "Do not implement code or commit."
+)
+print(f"User: {user_query}")
+
+contents: list = [user_query]
+
+response = client.models.generate_content(
+    model=model,
+    contents=contents,
+    config=types.GenerateContentConfig(
+        tools=[gemini_tool],
+        system_instruction=system_instruction,
+    ),
+)
+
+while response.candidates and response.candidates[0].content.parts:
+    part = response.candidates[0].content.parts[0]
+    if not part.function_call:
+        break
+
+    fn_name = part.function_call.name
+    fn_args = dict(part.function_call.args)
+    print(f"Gemini requested tool: {fn_name}")
+    print(f"Input: {fn_args}")
+
+    if fn_name != gemini_fn_name:
+        break
+
+    result = execute_skill(skill, fn_args, github_token)
+    print(json.dumps(result, indent=2))
+
+    contents.append(response.candidates[0].content)
+    contents.append(
+        types.Content(
+            role="user",
+            parts=[
+                types.Part(
+                    function_response=types.FunctionResponse(
+                        name=fn_name,
+                        response={"result": result},
+                    )
+                )
+            ],
+        )
+    )
+    response = client.models.generate_content(
+        model=model,
+        contents=contents,
+        config=types.GenerateContentConfig(
+            tools=[gemini_tool],
+            system_instruction=system_instruction,
+        ),
+    )
+
+print("\nFinal Response:")
+print(response.text)

--- a/examples/issue_resolver_github_context.py
+++ b/examples/issue_resolver_github_context.py
@@ -1,0 +1,105 @@
+"""
+Shared helpers for dev_tools/issue_resolver agent-loop examples.
+
+The skill returns API URLs and checklists only. Example scripts fetch GitHub
+issue context after ``prepare`` to demonstrate the two-phase pattern agents follow.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+
+def _github_get(url: str, token: Optional[str] = None) -> Any:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "skillware-issue-resolver-example",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        return {"_fetch_error": exc.code, "_url": url}
+
+
+def _raw_get(url: str, limit: int = 8000) -> str:
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "skillware-issue-resolver-example"}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode()[:limit]
+    except urllib.error.HTTPError:
+        return ""
+
+
+def enrich_prepare_result(
+    result: Dict[str, Any], token: Optional[str] = None
+) -> Dict[str, Any]:
+    """Attach issue body, comments, and README excerpt after action prepare."""
+    if result.get("status") != "ready" or result.get("action") != "prepare":
+        return result
+
+    issue_api = result["issue"]["api_url"]
+    issue_data = _github_get(issue_api, token)
+    comments = _github_get(f"{issue_api}/comments", token)
+    readme_excerpt = _raw_get(result["repository"]["readme_url"])
+
+    enriched = dict(result)
+    enriched["agent_fetched_context"] = {
+        "issue": issue_data,
+        "comments": comments if isinstance(comments, list) else [],
+        "readme_excerpt": readme_excerpt,
+        "note": (
+            "Fetched by the example script after prepare. "
+            "The skill itself does not call GitHub."
+        ),
+    }
+    return enriched
+
+
+def slim_for_local_model(
+    result: Dict[str, Any],
+    max_body: int = 4000,
+    max_readme: int = 3000,
+) -> Dict[str, Any]:
+    """Trim large GitHub payloads for smaller local models."""
+    if "agent_fetched_context" not in result:
+        return result
+    slim = dict(result)
+    ctx = dict(slim["agent_fetched_context"])
+    issue = ctx.get("issue")
+    if isinstance(issue, dict) and isinstance(issue.get("body"), str):
+        body = issue["body"]
+        if len(body) > max_body:
+            ctx["issue"] = {
+                **issue,
+                "body": body[:max_body] + "\n...[truncated for model context]...",
+            }
+    readme = ctx.get("readme_excerpt")
+    if isinstance(readme, str) and len(readme) > max_readme:
+        ctx["readme_excerpt"] = readme[:max_readme] + "\n...[truncated]..."
+    slim["agent_fetched_context"] = ctx
+    return slim
+
+
+def execute_skill(
+    skill: Any,
+    arguments: Dict[str, Any],
+    github_token: Optional[str] = None,
+    *,
+    slim: bool = False,
+) -> Dict[str, Any]:
+    """Run skill.execute and enrich prepare results like the agent loops do."""
+    result = skill.execute(arguments)
+    if result.get("action") == "prepare":
+        result = enrich_prepare_result(result, github_token)
+        if slim:
+            result = slim_for_local_model(result)
+    return result

--- a/examples/ollama_issue_resolver.py
+++ b/examples/ollama_issue_resolver.py
@@ -1,0 +1,94 @@
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import ollama
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from issue_resolver_github_context import execute_skill  # noqa: E402
+
+from skillware.core.env import load_env_file  # noqa: E402
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+load_env_file()
+
+if not os.environ.get("OLLAMA_HOST"):
+    os.environ["OLLAMA_HOST"] = "127.0.0.1:11434"
+
+SKILL_ID = "dev_tools/issue_resolver"
+ISSUE_URL = "https://github.com/ARPAHLS/skillware/issues/123"
+MODEL_NAME = os.environ.get("OLLAMA_MODEL", "gemma4:e2b")
+
+bundle = SkillLoader.load_skill(SKILL_ID)
+print(f"Loaded Skill: {bundle['manifest']['name']}")
+
+IssueResolverSkill = bundle["module"].IssueResolverSkill
+skill = IssueResolverSkill()
+github_token = os.environ.get("GITHUB_TOKEN") or None
+
+tool_description = SkillLoader.to_ollama_prompt(bundle)
+tool_description += f"\n**Cognitive Instructions:**\n{bundle['instructions']}\n"
+
+system_prompt = f"""You are an intelligent agent equipped with a GitHub issue resolver skill.
+To use a skill, output exactly one JSON code block:
+```json
+{{
+  "tool": "the_tool_name",
+  "arguments": {{
+    "param_name": "value"
+  }}
+}}
+```
+Wait for the system response containing the tool result before continuing.
+
+Available skill:
+{tool_description}
+"""
+
+user_query = (
+    f"Analyze {ISSUE_URL} and produce a structured resolution plan. "
+    "Start with action prepare on the issue URL, then call stage_checklist for "
+    "discover_issue. Stop after presenting the plan — do not implement code."
+)
+print(f"User: {user_query}")
+print(f"Ollama model: {MODEL_NAME}")
+
+messages = [
+    {"role": "system", "content": system_prompt},
+    {"role": "user", "content": user_query},
+]
+
+tool_pattern = re.compile(r"```json\s*({.*?})\s*```", re.DOTALL)
+
+while True:
+    response = ollama.chat(model=MODEL_NAME, messages=messages)
+    message_content = response.get("message", {}).get("content", "")
+    print(message_content)
+
+    tool_match = tool_pattern.search(message_content)
+    if not tool_match:
+        break
+
+    tool_call = json.loads(tool_match.group(1))
+    fn_name = tool_call.get("tool")
+    fn_args = tool_call.get("arguments", {})
+
+    if fn_name != SKILL_ID:
+        break
+
+    result = execute_skill(skill, fn_args, github_token, slim=True)
+    print(json.dumps(result, indent=2))
+
+    messages.append({"role": "assistant", "content": message_content})
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                "SYSTEM RESPONSE:\n"
+                f"```json\n{json.dumps(result)}\n```\n"
+                "Please provide the final answer."
+            ),
+        }
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillware"
-version = "0.3.2"
+version = "0.3.3"
 description = "A framework for modular, self-contained AI skills."
 readme = "README.md"
 authors = [

--- a/skills/dev_tools/issue_resolver/card.json
+++ b/skills/dev_tools/issue_resolver/card.json
@@ -1,6 +1,6 @@
 {
     "name": "Issue Resolver",
-    "description": "Analyzes any GitHub issue against its target repository and produces a structured resolution plan with ranked implementation options, affected files, and caveats.",
+    "description": "Guides an agent through resolving a GitHub issue on any repository: validates the issue URL, returns GitHub API endpoints, and provides sequential stage checklists with verify, commit, and pull request gates.",
     "issuer": {
         "name": "Ross Peili",
         "email": "vpeilivanidis@gmail.com",

--- a/skills/dev_tools/issue_resolver/instructions.md
+++ b/skills/dev_tools/issue_resolver/instructions.md
@@ -2,7 +2,9 @@
 
 You are using the `dev_tools/issue_resolver` skill.
 
-Load this skill when the user provides a GitHub issue URL and asks you to understand, plan, or begin resolving it. The skill applies to any public GitHub repository. It is model-agnostic and does not assume any particular project's conventions.
+Load this skill when the user provides a **GitHub issue URL** and asks you to understand, plan, or resolve it. The skill applies to any public or authenticated GitHub repository. It is model-agnostic and does not assume any particular project's conventions, language, or directory layout.
+
+The skill does **not** call GitHub, run git, or write code. It returns URLs, ordered stage checklists with conditional rules, and commit-message gates. **You** fetch issue data, inspect the repository, and execute each stage with your own tools.
 
 ## When to use this skill
 
@@ -10,64 +12,37 @@ Load this skill when the user provides a GitHub issue URL and asks you to unders
 - The user asks you to analyse an issue, understand its scope, or produce an implementation plan.
 - The user wants to know which files will be affected before any code is written.
 - The user wants ranked options and a recommended approach before committing to implementation.
+- The user wants end-to-end guidance through verify, commit, and pull request — with gates before each advance.
 
-## Workflow you must follow after receiving the skill payload
+## Skill actions
 
-The skill's `execute()` call returns a `status: ready` payload containing pre-computed URLs. Use those URLs with your available tools to carry out the following stages in order. Do not skip stages.
+Call `execute()` with an `action`:
 
-### Stage 1 — Fetch the issue
+| action | When |
+|--------|------|
+| `prepare` (default) | Start: requires `issue_url`; returns GitHub API and raw content URLs |
+| `workflow_overview` | List all stages in order |
+| `stage_checklist` | Requires `stage`; returns steps and conditionals for that stage |
+| `validate_commit_message` | Requires `message`; gate before commit |
 
-Using the `issue.api_url` from the payload:
+## Workflow you must follow
 
-1. Fetch the issue via the GitHub API. If `auth.token_provided` is true, include the `Authorization: Bearer <token>` header.
-2. Extract: title, body, labels, state, assignees, milestone.
-3. Fetch any linked comments (`issue.api_url/comments`) and skim for decisions, constraints, or acceptance criteria that are not in the body.
-4. Check for linked pull requests or referenced issues in the body.
+1. Call `prepare` with the issue URL.
+2. Call `workflow_overview` or proceed directly to stages in order.
+3. At the **start of each stage**, call `stage_checklist` for that stage and follow its `steps` and applicable `conditionals`.
+4. Do not advance while blockers remain or required conditionals for this repository are unaddressed.
 
-### Stage 2 — Understand the repository
+**Stage order (mandatory):**
 
-Using the `repository` URLs from the payload:
+`discover_issue` → `discover_repository` → `analyze` → `plan` → `implement` → `verify` → `pre_commit` → `commit` → `pull_request`
 
-1. Fetch and read `repository.readme_url`. Identify: project purpose, tech stack, install instructions, any stated conventions.
-2. Fetch and read `repository.contributing_url` if it exists (do not fail if it returns 404). Identify: contribution workflow, code style, PR requirements, any skill or module standards.
-3. Fetch the directory tree via `repository.tree_api_url`. Identify the top-level structure: key source directories, test directories, docs directories, CI configuration, and any existing analogues to what the issue requests.
-4. If the issue references specific files or directories, fetch and inspect their current contents.
+Per-stage steps and conditionals live in the skill (`stage_checklist` responses), not in this file. Apply only conditionals that match what you observed in **discover_repository**; skip irrelevant ones and document ambiguous skips.
 
-### Stage 3 — Analyse
+**Key rules:**
 
-Produce a structured internal analysis covering:
-
-- **Problem statement**: what the issue is actually asking for, including unstated implications.
-- **Acceptance criteria**: verifiable bullets extracted or inferred from the issue body and comments.
-- **Affected files**: every path likely to change — source, tests, documentation, CI, changelogs, configuration. Only list paths you have confirmed exist or have strong reason to expect.
-- **Ripple effects**: downstream files, dependent modules, or external consumers that may be affected even if not directly changed.
-- **Options**: up to three distinct implementation approaches with honest trade-off analysis (complexity, risk, alignment with project conventions, reversibility).
-- **Recommendation**: one approach with a clear rationale.
-- **Out of scope**: what you will not do in this resolution cycle and why.
-- **Caveats**: required dependencies, breaking changes, security concerns, or prerequisites.
-
-### Stage 4 — Produce the resolution plan
-
-Format your output as a structured plan. Present it clearly to the user before writing any code. Include:
-
-1. Issue summary (2-4 sentences).
-2. Acceptance criteria (bulleted list).
-3. Affected files table (path, change type: new / modify / delete, rationale).
-4. Implementation options (ranked 1-3, each with title, approach, rationale, estimated complexity: low / medium / high).
-5. Recommended option with rationale.
-6. Caveats (bulleted list).
-7. Out of scope (bulleted list).
-
-Wait for explicit user approval of the plan before proceeding to implementation.
-
-### Stage 5 — Implementation (only after approval)
-
-Proceed only if the user explicitly approves a plan option. Then:
-
-- Implement only what the approved plan describes. Do not refactor unrelated code.
-- Follow project conventions observed in Stage 2.
-- After implementing, verify your work against every acceptance criterion.
-- Report verification results to the user with evidence.
+- Wait for explicit user approval after **plan** before **implement**.
+- If verification fails, return to **implement**; do not advance to **pre_commit**.
+- Call `validate_commit_message` before commit; do not commit until it returns `"ok": true` and the operator authorized push.
 
 ## Handling the extra_instructions field
 
@@ -75,18 +50,18 @@ If `extra_instructions` is present in the payload, treat it as caller-supplied c
 
 ## Handling missing repository files
 
-- If `README.md` returns 404, note the absence and proceed.
-- If `CONTRIBUTING.md` returns 404, note the absence and rely on directory structure and code conventions instead.
+- If `README.md` returns 404, note the absence and proceed using the tree and code.
+- If `CONTRIBUTING.md` returns 404, note the absence and rely on directory structure, CI, and code conventions instead.
 - If the repository is private and no token is provided, report the authentication requirement clearly and stop.
 
-## Output contract
+## Plan output contract
 
-When presenting the plan, populate these fields so callers can parse them programmatically if needed:
+When presenting the plan (stage **plan**), populate these fields so callers can parse them programmatically if needed:
 
 ```json
 {
   "issue_summary": "string",
-  "affected_files": ["path/to/file", "..."],
+  "affected_files": ["path/to/file"],
   "implementation_plans": [
     {
       "rank": 1,
@@ -97,8 +72,9 @@ When presenting the plan, populate these fields so callers can parse them progra
     }
   ],
   "recommended_plan": 1,
-  "caveats": ["string", "..."]
+  "caveats": ["string"],
+  "out_of_scope": ["string"]
 }
 ```
 
-Do not include emojis in any output field.
+Do not include emojis in any structured output field.

--- a/skills/dev_tools/issue_resolver/manifest.yaml
+++ b/skills/dev_tools/issue_resolver/manifest.yaml
@@ -1,7 +1,7 @@
 name: "dev_tools/issue_resolver"
-version: "0.1.0"
-description: "Analyzes any GitHub issue against its target repository and produces a structured resolution plan with ranked implementation options, affected files, and caveats."
-short_description: "Analyzes a GitHub issue and produces a ranked implementation plan."
+version: "0.2.0"
+description: "Guides an agent through resolving a GitHub issue on any repository: validates the issue URL, returns GitHub API endpoints, and provides sequential stage checklists with conditional verify, commit, and pull request gates."
+short_description: "GitHub issue resolver: URL prep, staged checklists, and commit-message gate."
 issuer:
   name: Ross Peili
   email: vpeilivanidis@gmail.com
@@ -15,42 +15,49 @@ env_vars:
 parameters:
   type: object
   properties:
+    action:
+      type: string
+      description: "Workflow action: prepare (default), workflow_overview, stage_checklist, validate_commit_message."
+      enum:
+        - prepare
+        - workflow_overview
+        - stage_checklist
+        - validate_commit_message
     issue_url:
       type: string
-      description: "Full GitHub issue URL, e.g. https://github.com/owner/repo/issues/42"
+      description: "Required for action prepare. Full GitHub issue URL."
+    stage:
+      type: string
+      description: "Required for action stage_checklist. One of discover_issue, discover_repository, analyze, plan, implement, verify, pre_commit, commit, pull_request."
+    message:
+      type: string
+      description: "Required for action validate_commit_message. Proposed git commit message body."
+    allow_ai_coauthor:
+      type: boolean
+      description: "When true, allow Co-authored-by trailers that credit AI tools. Default false."
     extra_instructions:
       type: string
-      description: "Optional free-text instructions appended to the analysis prompt. Use this to inject project-specific context, style constraints, or scope limits."
+      description: "Optional caller context. Supplements but does not override the workflow or constitution."
     github_token:
       type: string
-      description: "Optional GitHub Personal Access Token passed at runtime. Takes precedence over the GITHUB_TOKEN environment variable."
-  required:
-    - issue_url
+      description: "Optional GitHub token at runtime. Takes precedence over GITHUB_TOKEN env var."
+  required: []
 outputs:
-  issue_summary:
+  status:
     type: string
-    description: "Plain-language summary of what the issue is asking for, including unstated implications."
-  affected_files:
-    type: array
-    description: "Paths of files likely to be touched, including source, tests, docs, and CI."
-  implementation_plans:
-    type: array
-    description: "Up to three ranked approaches. Each entry contains: rank, title, approach, rationale, estimated_complexity."
-  recommended_plan:
-    type: integer
-    description: "Rank (1-based) of the recommended implementation plan."
-  caveats:
-    type: array
-    description: "Dependencies, breaking changes, security concerns, or out-of-scope items the implementing agent must be aware of."
+    description: "ready, rejected, or error."
+  workflow_version:
+    type: string
+    description: "Workflow schema version (0.2)."
 constitution: |
-  1. Read the full issue body, labels, and any linked comments or PRs before forming an opinion.
-  2. Inspect the repository README, CONTRIBUTING guide, and top-level directory structure to understand project conventions before proposing changes.
-  3. Never fabricate file paths; only list paths that can be confirmed from the repository structure you observed.
-  4. Rank implementation options honestly based on complexity, risk, and alignment with existing project patterns.
-  5. Surface caveats explicitly rather than burying them inside plan prose.
-  6. Keep output deterministic and JSON-serializable; do not embed conversational filler in structured fields.
-  7. Do not write or propose actual implementation code; this skill produces analysis and planning output only.
-  8. Respect any extra_instructions provided by the caller, but do not let them override points 1-7 of this constitution.
+  1. Apply to any public or authenticated GitHub repository; do not assume Skillware or fixed directory layouts.
+  2. Follow workflow stages in order; use stage_checklist conditionals that apply to the target repository.
+  3. Never fabricate file paths; list only paths confirmed from the issue or repository tree.
+  4. Wait for explicit approval after plan before implementation.
+  5. Run validate_commit_message before commit unless the operator explicitly skips commit stages.
+  6. Keep skill output deterministic and JSON-serializable; the skill does not call GitHub, run git, or write code.
+  7. Respect extra_instructions unless they conflict with points 1-6.
+  8. Do not add AI agent Co-authored-by trailers in commit messages unless allow_ai_coauthor is true.
 presentation:
   icon: "git-pull-request"
   color: "#6E57E0"

--- a/skills/dev_tools/issue_resolver/skill.py
+++ b/skills/dev_tools/issue_resolver/skill.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import re
 from typing import Any, Dict
@@ -5,18 +6,48 @@ from typing import Any, Dict
 from skillware.core.base_skill import BaseSkill
 
 
+def _import_workflow():
+    try:
+        from . import workflow as wf  # type: ignore[import-not-found]
+    except ImportError:
+        wf_path = os.path.join(os.path.dirname(__file__), "workflow.py")
+        spec = importlib.util.spec_from_file_location(
+            "issue_resolver_workflow", wf_path
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load workflow module from {wf_path}")
+        wf = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(wf)
+    return wf
+
+
+_wf = _import_workflow()
+WORKFLOW_VERSION = _wf.WORKFLOW_VERSION
+get_stage_checklist = _wf.get_stage_checklist
+get_workflow_overview = _wf.get_workflow_overview
+validate_commit_message = _wf.validate_commit_message
+
+
 class IssueResolverSkill(BaseSkill):
     """
-    Parses and validates inputs for the Issue Resolver skill, then returns a
-    structured prompt payload the calling agent uses to perform analysis.
+    Universal GitHub issue resolution assistant for any repository.
 
-    The skill itself does not call the GitHub API or write code. It normalises
-    inputs, resolves credentials, builds a deterministic analysis context, and
-    hands control back to the agent's own reasoning and tool-use capabilities.
+    The skill does not call GitHub, run git, or write code. It returns
+    deterministic workflow payloads, stage checklists with conditional logic,
+    and commit-message gates for the calling agent to execute in order.
     """
 
     _GITHUB_ISSUE_RE = re.compile(
         r"https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<number>\d+)"
+    )
+
+    _VALID_ACTIONS = frozenset(
+        {
+            "prepare",
+            "workflow_overview",
+            "stage_checklist",
+            "validate_commit_message",
+        }
     )
 
     @property
@@ -30,11 +61,6 @@ class IssueResolverSkill(BaseSkill):
         return {}
 
     def _parse_issue_url(self, url: str) -> Dict[str, str]:
-        """
-        Extracts owner, repo, and issue number from a GitHub issue URL.
-        Returns a dict with keys: owner, repo, number, api_url, raw_url.
-        Raises ValueError if the URL does not match the expected pattern.
-        """
         match = self._GITHUB_ISSUE_RE.match(url.strip())
         if not match:
             raise ValueError(
@@ -55,10 +81,6 @@ class IssueResolverSkill(BaseSkill):
         }
 
     def _resolve_token(self, params: Dict[str, Any]) -> str:
-        """
-        Returns the GitHub token to use, preferring the runtime parameter over
-        the environment variable. Returns an empty string if neither is set.
-        """
         token = (params.get("github_token") or "").strip()
         if not token:
             token = (
@@ -66,20 +88,18 @@ class IssueResolverSkill(BaseSkill):
             )
         return token
 
-    def execute(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Validates inputs and returns a structured analysis context.
+    def _action(self, params: Dict[str, Any]) -> str:
+        action = (params.get("action") or "prepare").strip().lower()
+        if action not in self._VALID_ACTIONS:
+            return "__invalid__"
+        return action
 
-        The returned dict contains everything the calling agent needs to begin
-        the resolution workflow using its own tools (HTTP fetching, file
-        inspection, reasoning). The agent should follow the instructions in
-        instructions.md when interpreting this payload.
-        """
+    def _prepare(self, params: Dict[str, Any]) -> Dict[str, Any]:
         issue_url = (params.get("issue_url") or "").strip()
         if not issue_url:
             return {
                 "status": "error",
-                "message": "issue_url is required and must not be empty.",
+                "message": "issue_url is required for action prepare.",
             }
 
         try:
@@ -102,6 +122,8 @@ class IssueResolverSkill(BaseSkill):
 
         return {
             "status": "ready",
+            "action": "prepare",
+            "workflow_version": WORKFLOW_VERSION,
             "issue": {
                 "url": parsed["raw_url"],
                 "api_url": parsed["api_url"],
@@ -131,8 +153,55 @@ class IssueResolverSkill(BaseSkill):
             },
             "extra_instructions": extra_instructions or None,
             "next_step": (
-                "Follow the workflow in instructions.md. Fetch the issue, "
-                "read the repository context, then produce the structured "
-                "resolution plan as described."
+                "Call action workflow_overview or stage_checklist for discover_issue. "
+                "Follow instructions.md stages in order; do not skip gates."
             ),
         }
+
+    def _stage_checklist(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        stage = (params.get("stage") or "").strip().lower()
+        if not stage:
+            return {
+                "status": "error",
+                "message": "stage is required for action stage_checklist.",
+            }
+        payload = get_stage_checklist(stage)
+        if payload is None:
+            return {
+                "status": "error",
+                "message": f"Unknown stage {stage!r}. Call workflow_overview for valid names.",
+            }
+        payload["action"] = "stage_checklist"
+        return payload
+
+    def _validate_commit_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        message = params.get("message")
+        if message is None or not str(message).strip():
+            return {
+                "status": "error",
+                "message": "message is required for action validate_commit_message.",
+            }
+        allow = bool(params.get("allow_ai_coauthor", False))
+        result = validate_commit_message(str(message), allow_ai_coauthor=allow)
+        result["action"] = "validate_commit_message"
+        return result
+
+    def execute(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        action = self._action(params)
+        if action == "__invalid__":
+            allowed = ", ".join(sorted(self._VALID_ACTIONS))
+            return {
+                "status": "error",
+                "message": f"Unknown action. Supported actions: {allowed}.",
+            }
+        if action == "prepare":
+            return self._prepare(params)
+        if action == "workflow_overview":
+            overview = get_workflow_overview()
+            overview["action"] = "workflow_overview"
+            return overview
+        if action == "stage_checklist":
+            return self._stage_checklist(params)
+        if action == "validate_commit_message":
+            return self._validate_commit_message(params)
+        return {"status": "error", "message": "Unhandled action."}

--- a/skills/dev_tools/issue_resolver/test_skill.py
+++ b/skills/dev_tools/issue_resolver/test_skill.py
@@ -43,6 +43,7 @@ def test_manifest_name(skill, manifest):
 def test_manifest_version(skill, manifest):
     """Skill internal manifest version must match manifest.yaml."""
     assert skill.manifest["version"] == manifest["version"]
+    assert manifest["version"] == "0.2.0"
 
 
 def test_manifest_has_real_issuer(manifest):
@@ -68,10 +69,13 @@ def test_card_issuer_matches_manifest(manifest, card):
 
 
 def test_missing_issue_url_returns_error(skill):
-    """execute() must return a structured error when issue_url is absent."""
+    """prepare requires issue_url."""
     result = skill.execute({})
     assert result["status"] == "error"
     assert "issue_url" in result["message"].lower()
+
+    result = skill.execute({"action": "prepare"})
+    assert result["status"] == "error"
 
 
 def test_empty_issue_url_returns_error(skill):
@@ -183,3 +187,60 @@ def test_next_step_present(skill):
     assert "next_step" in result
     assert isinstance(result["next_step"], str)
     assert len(result["next_step"]) > 0
+
+
+def test_prepare_includes_workflow_version(skill):
+    result = skill.execute({"issue_url": VALID_URL})
+    assert result["workflow_version"] == "0.2"
+    assert result["action"] == "prepare"
+
+
+def test_workflow_overview(skill):
+    result = skill.execute({"action": "workflow_overview"})
+    assert result["status"] == "ready"
+    assert result["action"] == "workflow_overview"
+    assert len(result["stage_order"]) == 9
+    assert result["stage_order"][0] == "discover_issue"
+
+
+def test_stage_checklist_discover_issue(skill):
+    result = skill.execute({"action": "stage_checklist", "stage": "discover_issue"})
+    assert result["status"] == "ready"
+    assert result["stage"] == "discover_issue"
+    assert result["steps"]
+    assert result["conditionals"]
+    assert result["next_stage"] == "discover_repository"
+
+
+def test_stage_checklist_unknown_stage(skill):
+    result = skill.execute({"action": "stage_checklist", "stage": "not_a_stage"})
+    assert result["status"] == "error"
+
+
+def test_validate_commit_message_rejects_ai_coauthor(skill):
+    result = skill.execute(
+        {
+            "action": "validate_commit_message",
+            "message": "Fix bug\n\nCo-authored-by: Cursor <cursoragent@cursor.com>",
+        }
+    )
+    assert result["status"] == "rejected"
+    assert result["ok"] is False
+    assert result["violations"]
+
+
+def test_validate_commit_message_accepts_clean_message(skill):
+    result = skill.execute(
+        {
+            "action": "validate_commit_message",
+            "message": "Fix null handling in parser\n\nFixes #143",
+        }
+    )
+    assert result["status"] == "ready"
+    assert result["ok"] is True
+    assert result["violations"] == []
+
+
+def test_unknown_action(skill):
+    result = skill.execute({"action": "fly"})
+    assert result["status"] == "error"

--- a/skills/dev_tools/issue_resolver/workflow.py
+++ b/skills/dev_tools/issue_resolver/workflow.py
@@ -1,0 +1,293 @@
+"""Resolution workflow definitions for dev_tools/issue_resolver."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+WORKFLOW_VERSION = "0.2"
+
+# Ordered stages — agent must complete each before advancing.
+STAGE_ORDER: List[str] = [
+    "discover_issue",
+    "discover_repository",
+    "analyze",
+    "plan",
+    "implement",
+    "verify",
+    "pre_commit",
+    "commit",
+    "pull_request",
+]
+
+STAGES: Dict[str, Dict[str, Any]] = {
+    "discover_issue": {
+        "title": "Discover the issue",
+        "summary": "Fetch and understand the GitHub issue before touching the repository.",
+        "steps": [
+            "Fetch the issue via the GitHub API using issue.api_url from the prepare payload.",
+            "Extract title, body, labels, state, assignees, and milestone.",
+            "Fetch issue comments and note decisions or acceptance criteria not in the body.",
+            "Note linked pull requests, referenced issues, and blocking relationships.",
+        ],
+        "conditionals": [
+            "If the issue is closed, confirm with the user before investing in a new fix.",
+            "If labels imply type (bug, docs, enhancement), carry that into later analysis.",
+            "If acceptance criteria are missing, infer verifiable criteria from the body and comments.",
+        ],
+        "next_stage": "discover_repository",
+    },
+    "discover_repository": {
+        "title": "Discover the repository",
+        "summary": "Learn how this project is organized and how it expects contributions.",
+        "steps": [
+            "Read README (repository.readme_url) for purpose, stack, and setup.",
+            "Read CONTRIBUTING if present (repository.contributing_url); continue if 404.",
+            "Fetch the repository tree (repository.tree_api_url) and map source, test, docs, and CI areas.",
+            "Inspect files explicitly referenced by the issue.",
+        ],
+        "conditionals": [
+            "If CONTRIBUTING is missing, infer conventions from README, CI config, and existing code.",
+            "If the tree response is truncated, inspect relevant directories selectively.",
+            "If the repository is private and no token is configured, stop and request authentication.",
+            "If a root-level contributor workflow file exists (any name), read it before planning.",
+        ],
+        "next_stage": "analyze",
+    },
+    "analyze": {
+        "title": "Analyze impact",
+        "summary": "Produce a structured understanding before proposing a plan.",
+        "steps": [
+            "Write a clear problem statement tied to the issue.",
+            "List verifiable acceptance criteria.",
+            "List affected paths only after confirming they exist in the tree or issue.",
+            "Identify ripple effects on dependents, APIs, or consumers.",
+            "Draft up to three options with trade-offs and one recommendation.",
+            "State explicit out-of-scope items and caveats.",
+        ],
+        "conditionals": [
+            "If the issue touches public API surface, include compatibility and migration impact.",
+            "If the issue mentions security, include threat and data-handling caveats.",
+            "If multiple valid approaches exist, rank them; do not hide uncertainty.",
+        ],
+        "next_stage": "plan",
+    },
+    "plan": {
+        "title": "Present plan and wait for approval",
+        "summary": "Deliver the resolution plan and obtain explicit approval before coding.",
+        "steps": [
+            (
+                "Present issue summary, acceptance criteria, affected files, "
+                "options, recommendation, caveats, and out-of-scope."
+            ),
+            "Use the structured output contract from instructions.md.",
+            "Wait for explicit user or operator approval of one option.",
+        ],
+        "conditionals": [
+            "If the user narrows scope during review, update the plan before implementation.",
+            "If approval is ambiguous, ask one clarifying question instead of guessing.",
+            "Do not write implementation code until approval is explicit.",
+        ],
+        "next_stage": "implement",
+    },
+    "implement": {
+        "title": "Implement the approved plan",
+        "summary": "Make the minimal change set that satisfies the approved plan.",
+        "steps": [
+            "Implement only what the approved plan describes.",
+            "Follow conventions observed in discover_repository.",
+            "Avoid drive-by refactors, unrelated formatting, or scope creep.",
+        ],
+        "conditionals": [
+            "If the approved plan proves wrong mid-implementation, stop and re-plan with the user.",
+            "If new files are required, place them where similar files already live in this repository.",
+            "If dependencies change, update whatever manifest or lockfile this project uses.",
+        ],
+        "next_stage": "verify",
+    },
+    "verify": {
+        "title": "Verify the solution",
+        "summary": "Prove the change meets acceptance criteria using this repository's own quality gates.",
+        "steps": [
+            "Map each acceptance criterion to a diff hunk, test, or observable outcome.",
+            "Run verification commands appropriate to this repository and attach evidence.",
+            "Re-read the diff for unrelated changes, secrets, and accidental artifacts.",
+        ],
+        "conditionals": [
+            "If the repository defines automated tests, run them and report pass or fail output.",
+            "If a linter or formatter is documented or configured, run it on touched paths.",
+            (
+                "If the project maintains release notes or a changelog and the "
+                "change is user-visible, update the file this project uses."
+            ),
+            "If CI configuration exists, confirm the change is unlikely to break declared checks.",
+            "If no automated tests exist, document manual verification steps performed.",
+            "If verification fails, return to implement; do not advance to pre_commit.",
+        ],
+        "next_stage": "pre_commit",
+    },
+    "pre_commit": {
+        "title": "Pre-commit gate",
+        "summary": "Confirm the change set is safe to commit.",
+        "steps": [
+            "Confirm all verify-stage conditionals relevant to this repo are satisfied.",
+            "Confirm no credentials, tokens, or .env content appear in the diff.",
+            "Confirm the diff contains only files required by the approved plan.",
+            "Draft the commit message; call validate_commit_message before committing.",
+        ],
+        "conditionals": [
+            "If validate_commit_message returns violations, fix the message and validate again.",
+            "If unrelated staged files exist, unstage them before commit.",
+            "If the operator has not authorized commit, stop and hand off the validated message and diff summary.",
+        ],
+        "next_stage": "commit",
+    },
+    "commit": {
+        "title": "Commit and push",
+        "summary": "Create a clean git commit on the correct branch and push to the operator remote.",
+        "steps": [
+            "Confirm current branch name matches the issue (e.g. feat/issue-N-short-desc).",
+            "Confirm push remote points at the operator fork when contributing via fork workflow.",
+            "Run git status, scoped git add, git commit, git push -u origin <branch>.",
+        ],
+        "conditionals": [
+            "If origin is the upstream canonical repo, confirm the operator intends to push there.",
+            "If the branch tracks the wrong remote, fix upstream before push.",
+            "Never force-push shared or default branches unless explicitly instructed.",
+            "If commit hooks fail, fix issues and create a new commit; do not skip hooks unless instructed.",
+        ],
+        "next_stage": "pull_request",
+    },
+    "pull_request": {
+        "title": "Open or update pull request",
+        "summary": "Prepare a reviewable PR and support CI through merge.",
+        "steps": [
+            "Draft a PR description: why, what, how verified, link to the issue.",
+            "Complete the repository's pull request template if one exists.",
+            "Monitor CI; if checks fail, diagnose, fix, and push follow-up commits.",
+            "Address review comments with focused commits.",
+        ],
+        "conditionals": [
+            "If the repository uses Fixes #N or Closes #N linking, include the appropriate reference.",
+            "If draft PR is preferred for early feedback, mark draft until verify evidence is attached.",
+            "If CI is required and failing, do not declare the resolution complete.",
+        ],
+        "next_stage": None,
+    },
+}
+
+# Patterns that indicate AI tooling in Co-authored-by trailers (case-insensitive).
+AI_COAUTHOR_PATTERNS: Tuple[re.Pattern[str], ...] = (
+    re.compile(r"cursor", re.I),
+    re.compile(r"cursoragent", re.I),
+    re.compile(r"claude", re.I),
+    re.compile(r"anthropic", re.I),
+    re.compile(r"copilot", re.I),
+    re.compile(r"openai", re.I),
+    re.compile(r"chatgpt", re.I),
+    re.compile(r"github-actions\[bot\]", re.I),
+)
+
+CO_AUTHOR_LINE = re.compile(r"^Co-authored-by:\s*(.+)$", re.I | re.M)
+EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001F300-\U0001FAFF"
+    "\U00002600-\U000027BF"
+    "\U0001F600-\U0001F64F"
+    "]+"
+)
+
+
+def get_stage_checklist(stage: str) -> Optional[Dict[str, Any]]:
+    """Return checklist payload for a workflow stage, or None if unknown."""
+    if stage not in STAGES:
+        return None
+    meta = STAGES[stage]
+    index = STAGE_ORDER.index(stage)
+    return {
+        "status": "ready",
+        "workflow_version": WORKFLOW_VERSION,
+        "stage": stage,
+        "stage_index": index + 1,
+        "stage_count": len(STAGE_ORDER),
+        "title": meta["title"],
+        "summary": meta["summary"],
+        "steps": list(meta["steps"]),
+        "conditionals": list(meta["conditionals"]),
+        "next_stage": meta["next_stage"],
+        "must_complete_before": meta["next_stage"],
+        "gate_rule": (
+            "Do not advance to the next stage while blockers remain or "
+            "required conditionals for this repository are unaddressed."
+        ),
+    }
+
+
+def get_workflow_overview() -> Dict[str, Any]:
+    """Return ordered stage list for agents starting a resolution."""
+    return {
+        "status": "ready",
+        "workflow_version": WORKFLOW_VERSION,
+        "stage_order": list(STAGE_ORDER),
+        "stages": [
+            {
+                "stage": name,
+                "title": STAGES[name]["title"],
+                "next_stage": STAGES[name]["next_stage"],
+            }
+            for name in STAGE_ORDER
+        ],
+        "future_profiles_note": (
+            "v3 may support a repository-root workflow file (e.g. ISSUE_RESOLVER.md) "
+            "that extends these universal stages with project-specific checks."
+        ),
+    }
+
+
+def validate_commit_message(
+    message: str,
+    *,
+    allow_ai_coauthor: bool = False,
+) -> Dict[str, Any]:
+    """Validate a proposed commit message against universal contribution rules."""
+    violations: List[str] = []
+    msg = (message or "").strip()
+
+    if not msg:
+        violations.append("Commit message is empty.")
+    else:
+        subject = msg.splitlines()[0].strip()
+        if not subject:
+            violations.append("Commit subject line is empty.")
+        if EMOJI_PATTERN.search(subject):
+            violations.append("Commit subject must not contain emojis.")
+
+        for match in CO_AUTHOR_LINE.finditer(msg):
+            trailer_value = match.group(1).strip()
+            if allow_ai_coauthor:
+                continue
+            for pattern in AI_COAUTHOR_PATTERNS:
+                if pattern.search(trailer_value):
+                    violations.append(
+                        "Co-authored-by trailer appears to credit an AI tool or agent "
+                        f"({trailer_value}). Remove unless allow_ai_coauthor is true."
+                    )
+                    break
+
+    required = [
+        "Imperative mood subject line (Add, Fix, Document, ...).",
+        "Reference the issue when applicable (Fixes #N or Refs #N).",
+        "No emojis in the subject.",
+    ]
+    if not allow_ai_coauthor:
+        required.append(
+            "No Co-authored-by trailers crediting AI agents unless allow_ai_coauthor is true."
+        )
+
+    ok = len(violations) == 0
+    return {
+        "status": "ready" if ok else "rejected",
+        "ok": ok,
+        "violations": violations,
+        "required_before_commit": required,
+    }


### PR DESCRIPTION
## Description

This PR ships **`dev_tools/issue_resolver` v0.2** and closes the runnable-examples gap for that skill.

The skill now guides agents through a **universal GitHub issue workflow**: validate the issue URL, return GitHub API endpoints, then supply ordered **stage checklists** with **conditional rules** (`If this repo has X, do Y`) through verify, commit, and pull request. It still does not call GitHub, run git, or write code — the agent executes each stage with its own tools.

Also included:

- **`workflow.py`** — deterministic stage definitions and commit-message gate
- **Runnable examples** — `gemini_issue_resolver.py`, `claude_issue_resolver.py`, `ollama_issue_resolver.py`, plus shared `issue_resolver_github_context.py` (fetches issue/README after `prepare` to demonstrate the two-phase pattern)
- **Docs** — `docs/skills/issue_resolver.md`, catalog, `examples/README.md`, `agent_loops.md`
- **Release prep** — `CHANGELOG.md` `[0.3.3]`, `pyproject.toml` bump to `0.3.3`

Sample issue used in examples: https://github.com/ARPAHLS/skillware/issues/123

Fixes #143  
Fixes #118

---

### Type of Change (Matches Issue Templates)

- [x] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`) — *major update to existing skill*
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

---

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[0.3.3]` for user-visible behavior.
- [x] `examples/README.md` is updated (added Gemini, Claude, and Ollama issue_resolver scripts; removed “Skills Without Runnable Examples” row).

---

## New or updated skill

### Bundle & metadata

- [x] Skill lives at `skills/dev_tools/issue_resolver/`.
- [x] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
- [x] `manifest.yaml` includes `issuer` with real `name` and `email`.
- [x] `short_description` in manifest for `skillware list`.
- [x] `issuer.github` and `issuer.org` set.
- [x] `env_vars` documents optional `GITHUB_TOKEN`.

### Logic, cognition, and UI

- [x] `skill.py` is deterministic Python (action router; no LLM paths).
- [x] `instructions.md` explains when and how to use the skill; per-stage detail via `stage_checklist`.
- [x] `card.json` present; `issuer` matches `manifest.yaml`.

### Tests & loader

- [x] `test_skill.py` covers prepare, workflow actions, stage checklists, commit gate, and errors (24 tests).
- [x] `SkillLoader.load_skill("dev_tools/issue_resolver")` succeeds (relative import handled for standalone module load).

### Documentation & catalog

- [x] `docs/skills/issue_resolver.md` updated (actions, schema, runnable examples).
- [x] `docs/skills/README.md` lists the skill with ID and Issuer.

---

## Constitution & Safety

- Skill output is deterministic JSON only; no GitHub API calls, git execution, or code generation inside `execute()`.
- Agents must wait for explicit approval after **plan** before **implement**.
- `validate_commit_message` rejects AI `Co-authored-by` trailers by default.
- No fabricated file paths; conditionals adapt per target repository (no Skillware-specific hardcoded paths).

---

## Related Issues

- Fixes #143 — universal issue resolver workflow v0.2
- Fixes #118 — runnable Gemini / Claude / Ollama examples for `dev_tools/issue_resolver`