### PR TITLE
Add __main__.py, cmd_help, --version, and move rich to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Added
 - **Tests**: Backfilled `test_skill.py` for six registry skills (`mica_module`, `pii_masker`, `synthetic_generator`, `wallet_screening`, `pdf_form_filler`, `prompt_rewriter`); all registry skills now ship co-located bundle tests. Fixed `prompt_rewriter` package export so pytest can collect the bundle (#158).
+- **CLI**: `skillware/__main__.py` enables `python -m skillware` as a fallback when the `skillware` command is not on PATH (#135). Added `cmd_help()` for rich-formatted help, wired to `skillware --help`/`-h` and interactive menu option `4`. Added `--version`/`-V` flag.
 
 ### Fixed
 - **`novelty_extractor`**: Bundle tests mock fastembed embeddings so CI avoids HuggingFace downloads and rate limits (#159 follow-up).
@@ -19,6 +20,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **CI**: CodeQL GitHub Action upgraded from v3 to v4.
 - **Dependencies**: Extended `[all]` with registry skill runtime deps (`web3`, `fastembed`, `numpy`); added `[defi]` and `[embeddings]` optional extras. Documented manifest ↔ `pyproject.toml` convention in CONTRIBUTING and TESTING.md.
 - **Documentation**: [TESTING.md](docs/TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md), [ai_native_workflow.md](docs/contributing/ai_native_workflow.md), and README architecture tree document the bundle / framework / maintainer / example testing model. Pytest collects `tests/` and `skills/` only (`examples/` ignored).
+- **Dependencies**: Moved `rich>=13.0` from `[cli]` extra to core dependencies; CLI is now available immediately after `pip install skillware`. The `[cli]` extra is kept as an empty deprecated alias for backward compatibility (#135).
 
 ## [0.3.5] - 2026-06-05
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,16 @@ pip install -e .
 ### 2. Verify your installation
 
 ```bash
-pip install "skillware[cli]"
 skillware list
 ```
 
-This prints a table of all locally available skills and confirms the install and path resolution are working. Running `skillware` with no arguments opens the interactive menu.
+This prints a table of all locally available skills and confirms the install
+and path resolution are working. Running `skillware` with no arguments opens
+the interactive menu.
+
+If `skillware` is not recognized, Python's `Scripts` directory may not be on
+your PATH — use `python -m skillware list` as a fallback. See
+[CLI Reference](docs/usage/cli.md#running-the-cli) for details.
 
 ### 3. Configuration
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the official catalog of Skillware capabilities. New here? Start with the [project README](../../README.md).
 
-Browse by category below, or run `skillware list` after `pip install "skillware[cli]"` to see locally available skills.
+Browse by category below, or run `skillware list` after `pip install skillware` to see locally available skills.
 
 ## Office
 Skills for document processing, email automation, and productivity.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -7,9 +7,42 @@ agent can load.
 
 ## Installation
 
-The CLI depends on `rich` for terminal output. Install it with the `cli` extra:
+Install Skillware — `rich` is included as a core dependency:
 
-    pip install "skillware[cli]"
+    pip install skillware
+
+## Running the CLI
+
+After installation, the `skillware` command is available directly:
+
+    skillware
+    skillware list
+    skillware --version
+
+If `skillware` is not recognized, Python's `Scripts` directory may not be on
+your PATH.
+
+**Unix** — verify with:
+
+    which skillware
+
+**Windows** — verify with:
+
+    where skillware
+
+If the command is not found, use the module fallback (works on any OS as long
+as Python is installed):
+
+    python -m skillware
+    python -m skillware list
+    python -m skillware list --category compliance
+    python -m skillware --help
+
+**Windows PATH fix** — add both `Python3x\` and `Python3x\Scripts\` to your
+system PATH, or use the `py` launcher:
+
+    py -3 -m pip install skillware
+    py -3 -m skillware list
 
 ## Version advisory
 
@@ -45,7 +78,7 @@ Available commands:
 | `1` / `list` | List all locally installed skills | Available |
 | `2` / `paths` | Show and repair skill directory resolution paths | Coming in #81 |
 | `3` / `test` | Run test_skill.py for one or all skills | Coming in #83 |
-| `4` / `help` | Print usage information | Available |
+| `4` / `help` | Print rich-formatted help with commands, flags, and examples | Available |
 
 ## Commands
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -106,7 +106,7 @@ Honest snapshot for **v0** (current v0.3.x line):
 
 - **Registry**: Skills under `skills/` with docs in [docs/skills/](skills/README.md).
 - **Loader**: Dynamic import, dependency checks, and adapters for major LLM tool formats.
-- **CLI**: `skillware list` and an interactive menu (install with `skillware[cli]` today; default packaging may expand).
+- **CLI**: `skillware list` and an interactive menu, included with `pip install skillware`.
 - **Active work**: Wallet screening enhancements ([RFC #115](https://github.com/ARPAHLS/skillware/issues/115)), CLI polish, contributor docs, and good first issues across docs and framework.
 
 Browse [open good first issues](https://github.com/ARPAHLS/skillware/issues?q=is%3Aopen+label%3A%22good+first+issue%22) if you want a low-risk entry point.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "python-dotenv",
     "beautifulsoup4",
     "packaging",
+    "rich>=13.0",
 ]
 requires-python = ">=3.10"
 
@@ -36,9 +37,7 @@ dev = [
     "flake8",
     "black",
 ]
-cli = [
-    "rich>=13.0",
-]
+cli = []
 gemini = [
     "google-genai",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # Installs core + dev tools (pytest, flake8, black) + all optional SDK extras.
 # For production installs use pyproject.toml extras instead, e.g.:
 #   pip install skillware                  # core only
-#   pip install "skillware[cli]"           # + rich terminal
 #   pip install "skillware[gemini]"        # + Google Gemini SDK
 #   pip install "skillware[claude]"        # + Anthropic SDK
 #   pip install "skillware[openai]"        # + OpenAI SDK

--- a/skillware/__main__.py
+++ b/skillware/__main__.py
@@ -1,0 +1,4 @@
+from skillware.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -182,6 +182,14 @@ def cmd_help(console=None) -> None:
     console.print("  test      coming in #83", style="dim")
     console.print()
 
+    console.print(Text("Interactive mode", style=f"bold {TABLE_STYLE}"))
+    console.print(
+        "  skillware                     — open interactive menu", style="dim"
+    )
+    console.print("  1-4 or command name           — select a menu option", style="dim")
+    console.print("  q or Ctrl+C                   — exit", style="dim")
+    console.print()
+
     console.print(Text("Examples", style=f"bold {TABLE_STYLE}"))
     console.print("  skillware list --category compliance", style=MENU_STYLE)
     console.print("  skillware list --issuer rosspeili", style=MENU_STYLE)
@@ -285,7 +293,14 @@ def main() -> None:
     """CLI entry point."""
     emit_upgrade_advisory()
 
-    parser = argparse.ArgumentParser(prog="skillware")
+    parser = argparse.ArgumentParser(prog="skillware", add_help=False)
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        help="Show this help message and exit.",
+    )
 
     _ver = get_installed_version()
     _version_str = str(_ver) if _ver else "dev"
@@ -298,7 +313,6 @@ def main() -> None:
     )
 
     subparsers = parser.add_subparsers(dest="command")
-
     list_parser = subparsers.add_parser("list", help="List all available skills.")
     list_parser.add_argument(
         "--skills-root",
@@ -318,6 +332,10 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    if args.help and args.command is None:
+        cmd_help(Console())
+        return
 
     if args.command == "list":
         cmd_list(

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -3,8 +3,15 @@ import yaml
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+from rich.table import Table
+from rich.console import Console
+from rich.text import Text
+from rich import box
+
+import importlib.metadata
+
 from skillware.core.loader import SkillLoader
-from skillware.version_policy import emit_upgrade_advisory
+from skillware.version_policy import emit_upgrade_advisory, get_installed_version
 
 TABLE_STYLE = "bold #C7CEEA"  # lavender  - headers
 CATEGORY_STYLE = "bold #FFDAC1"  # peach     - category column
@@ -106,15 +113,6 @@ def cmd_list(
     console=None,
 ) -> None:
     """Print a formatted table of all available skills."""
-    try:
-        from rich.table import Table
-        from rich.console import Console
-        from rich import box
-    except ImportError:
-        raise SystemExit(
-            "rich is required for the CLI. Install it with: pip install 'skillware[cli]'"
-        )
-
     if console is None:
         console = Console()
 
@@ -164,18 +162,45 @@ def _print_menu(console, menu) -> None:
     console.print()
 
 
+def cmd_help(console=None) -> None:
+    """Print rich-formatted help to the console."""
+    if console is None:
+        console = Console()
+
+    console.print(Text("Usage", style=f"bold {TABLE_STYLE}"))
+    console.print("  skillware                     — open interactive menu")
+    console.print("  skillware list                — list all installed skills")
+    console.print("  skillware list --category <n> — filter by category")
+    console.print("  skillware list --issuer <h>   — filter by issuer")
+    console.print("  skillware list --skills-root  — override skills directory")
+    console.print("  skillware --version           — print installed version")
+    console.print()
+
+    console.print(Text("Commands", style=f"bold {TABLE_STYLE}"))
+    console.print("  list      available now", style=ID_STYLE)
+    console.print("  paths     coming in #81", style="dim")
+    console.print("  test      coming in #83", style="dim")
+    console.print()
+
+    console.print(Text("Examples", style=f"bold {TABLE_STYLE}"))
+    console.print("  skillware list --category compliance", style=MENU_STYLE)
+    console.print("  skillware list --issuer rosspeili", style=MENU_STYLE)
+    console.print("  skillware list --skills-root /path/to/skills", style=MENU_STYLE)
+    console.print()
+
+    console.print(Text("Install", style=f"bold {TABLE_STYLE}"))
+    console.print("  pip install skillware", style="dim")
+    console.print()
+
+    console.print(Text("Docs", style=f"bold {TABLE_STYLE}"))
+    console.print(
+        "  https://github.com/arpahls/skillware/blob/main/docs/usage/cli.md",
+        style=f"dim {SPLASH_STYLE}",
+    )
+
+
 def cmd_interactive(console=None, parser=None) -> None:
     """Launch ASCII splash screen and interactive menu."""
-    try:
-        from rich.console import Console
-        from rich.text import Text
-    except ImportError:
-        raise SystemExit(
-            "rich is required for the CLI. Install it with: pip install 'skillware[cli]'"
-        )
-
-    import importlib.metadata
-
     if console is None:
         console = Console()
 
@@ -248,12 +273,7 @@ def cmd_interactive(console=None, parser=None) -> None:
                 style="dim",
             )
         elif command == "help":
-            if parser:
-                parser.print_help()
-            else:
-                console.print(
-                    "  Run 'skillware --help' for usage information.", style="dim"
-                )
+            cmd_help(console=console)
         else:
             console.print(f"  Unknown command: '{choice}'", style="dim #FF9AA2")
 
@@ -266,6 +286,17 @@ def main() -> None:
     emit_upgrade_advisory()
 
     parser = argparse.ArgumentParser(prog="skillware")
+
+    _ver = get_installed_version()
+    _version_str = str(_ver) if _ver else "dev"
+
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"skillware {_version_str}",
+    )
+
     subparsers = parser.add_subparsers(dest="command")
 
     list_parser = subparsers.add_parser("list", help="List all available skills.")

--- a/skillware/version_policy.py
+++ b/skillware/version_policy.py
@@ -41,7 +41,7 @@ def should_emit_unsupported_advisory(installed: Version) -> bool:
 def format_unsupported_message(installed: Version) -> str:
     return (
         f"Skillware {installed} is unsupported. "
-        f'Upgrade to >={UPGRADE_TARGET}: pip install -U "skillware[cli]"'
+        f"Upgrade to >={UPGRADE_TARGET}: pip install -U skillware"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ from skillware.cli import (
     cmd_help,
 )
 
+import pytest
+
 
 def test_discover_skills_returns_skills(tmp_path):
     # Create a fake skill directory structure
@@ -260,3 +262,20 @@ def test_interactive_help_dispatches_to_cmd_help(monkeypatch):
     output = buf.getvalue()
     assert "--category" in output
     assert "--issuer" in output
+
+
+def test_version_flag(capsys):
+    """skillware --version should print the installed version and exit."""
+    import sys
+    from skillware.cli import main
+
+    monkeypatch_argv = sys.argv
+    sys.argv = ["skillware", "--version"]
+    try:
+        with pytest.raises(SystemExit):
+            main()
+    finally:
+        sys.argv = monkeypatch_argv
+
+    captured = capsys.readouterr()
+    assert "skillware" in captured.out.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from skillware.cli import (
     cmd_list,
     cmd_interactive,
     _short_description,
+    cmd_help,
 )
 
 
@@ -219,3 +220,43 @@ def test_cmd_interactive_list_dispatch(tmp_path, monkeypatch):
 
     output = buf.getvalue()
     assert "test_skill" in output
+
+
+def test_main_module_invocation():
+    """python -m skillware should be importable and callable."""
+    import skillware.__main__  # noqa: F401 — just verify it imports cleanly
+    from skillware.__main__ import main
+
+    assert callable(main)
+
+
+def test_cmd_help_includes_list_examples(capsys):
+    """cmd_help should include category and issuer examples."""
+    import io
+    from rich.console import Console
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    cmd_help(console=console)
+
+    output = buf.getvalue()
+    assert "--category" in output
+    assert "--issuer" in output
+    assert "--skills-root" in output
+
+
+def test_interactive_help_dispatches_to_cmd_help(monkeypatch):
+    """Interactive menu option 4 / help should call cmd_help."""
+    import io
+    from rich.console import Console
+
+    responses = iter(["4", "q"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    cmd_interactive(console=console)
+
+    output = buf.getvalue()
+    assert "--category" in output
+    assert "--issuer" in output


### PR DESCRIPTION
<!--
AUTOMATED AGENT GREETING

Greetings, netizen! We welcome your pull requests to Skillware.
Before submitting your code, please ensure you have:
1. Fully read and understood the linked GitHub Issue and its requirements.
2. Analyzed the core architecture (`loader.py`, `base_skill.py`) to ensure your approach aligns with the framework natively.
3. Verified all dependencies are documented in your `manifest.yaml` and logic executes deterministically.
4. Checked off all items in the checklist below.

We are excited to review your capabilities! Let's build together.
-->

## Description

Improves CLI discoverability and help UX following #135.

**`skillware/__main__.py`** — new file that delegates to `skillware.cli:main`,
enabling `python -m skillware` and `python -m skillware list` as fallbacks when
the `skillware` command is not on PATH. Matches the standard pattern used by
`pip`, `pytest`, and `black`.

**`cmd_help(console)`** — new function in `cli.py` that prints rich-formatted
help to the same console as the menu. Covers all commands (list available,
paths/test stubbed with issue references), list flags with copy-paste examples,
install reminder, and docs link. Wired to interactive menu option `4 / help`.

**`--version` / `-V`** — top-level flag that prints the installed skillware
version using `get_installed_version()` from `version_policy.py`.

**`rich` moved to core** — `rich>=13.0` moved from `[project.optional-dependencies]`
to `[project.dependencies]` in `pyproject.toml`. CLI is now a first-class surface
and `rich` is lightweight (~11 MB). The `[cli]` extra is kept as an empty
deprecated alias for backward compatibility.

**`docs/usage/cli.md`** — updated Installation section (no `[cli]` extra needed),
new Running the CLI section with PATH instructions, Unix/Windows verification
commands, `python -m skillware` fallback, and Windows `py` launcher examples.
Interactive menu table updated to reflect `help` behavior.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .` and `pytest tests/` locally (or the subset relevant to this change).
- [ ] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip this section for framework-only, documentation-only, or other PRs that do not touch the skill registry.

### Bundle & metadata

- [ ] Skill lives at `skills/<category>/<skill_name>/` (copied from `templates/python_skill/` or equivalent).
- [ ] `manifest.yaml` has `name`, `version`, `description`, valid `parameters`, and `constitution`.
- [ ] `manifest.yaml` includes `issuer` with real `name` and `email` (not template placeholders).
- [ ] Optional: `short_description` in manifest (~80 chars) for `skillware list`.
- [ ] Optional: `issuer.github` and `issuer.org` set when applicable.
- [ ] `requirements` and `env_vars` are documented when the skill needs them.

### Logic, cognition, and UI

- [ ] `skill.py` is deterministic Python (no arbitrary LLM-generated code paths).
- [ ] `instructions.md` explains when and how to use the skill.
- [ ] `card.json` is present and its `issuer` matches `manifest.yaml` (`name` and `email` at minimum).

### Tests & loader

- [ ] `test_skill.py` covers execution and schema expectations.
- [ ] `SkillLoader.load_skill("<category>/<skill_name>")` succeeds (or missing deps are documented).

### Documentation & catalog

- [ ] `docs/skills/<skill_name>.md` exists or is updated (ID, Issuer, usage).
- [ ] `docs/skills/README.md` lists the skill with ID and Issuer.

## Constitution & Safety (if adding or modifying a skill)

<!--
State the constitutional boundaries applied to this skill to ensure safe execution.
Example: "This skill only performs read operations on the blockchain and does not sign transactions."
-->

## Related Issues
Fixes #135 
