### PR TITLE
Align CI with pyproject install and document test scope (#151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-mock
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        # Attempt to install skill dependencies manually for now (since we don't have a single setup.py yet)
-        pip install pymupdf anthropic requests
+        pip install -e ".[dev,all]"
 
     - name: Lint with flake8
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Changed
+- **CI**: GitHub Actions installs dependencies from `pyproject.toml` only (`pip install -e ".[dev,all]"`); removed redundant manual pip pins. CI runs `pytest tests/` only; co-located `skills/**/test_skill.py` remains a local pre-PR step (#151).
+- **Documentation**: [TESTING.md](docs/TESTING.md) and [CONTRIBUTING.md](CONTRIBUTING.md) aligned with CI scope and local skill-test workflow (#151).
+
 ## [0.3.3] - 2026-05-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,9 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 ### Tests and CI
 
 - Add or update tests when behavior changes.
-- Run `python -m flake8 .` and `pytest tests/` before opening a PR.
+- **GitHub Actions** installs `pip install -e ".[dev,all]"`, runs `flake8 .`, then **`pytest tests/`** only. Do not add per-skill pip lines or test paths to `.github/workflows/ci.yml`.
+- Run `python -m flake8 .` and `pytest tests/` locally before opening a PR (same scope as CI).
+- For skill work, also run `pytest skills/<category>/<skill_name>/test_skill.py` locally and install any packages from that skill's `manifest.yaml` `requirements`.
 - Wait for GitHub Actions CI to pass before requesting review.
 
 ### Pull request template

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,10 +4,16 @@ Skillware maintains high standards for code quality and reliability. Before subm
 
 ## Quick Setup
 
-Install all testing and linting dependencies in one go:
+Install framework tests, lint tools, and optional SDK extras in one go (matches GitHub Actions CI):
 
 ```bash
-pip install -e .[dev]
+pip install -e ".[dev,all]"
+```
+
+Or use the dev pointer file:
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## 1. Code Formatting (Black)
@@ -25,7 +31,7 @@ Run Black on the entire repository to automatically fix formatting issues:
 python -m black .
 ```
 
-If your PR fails the CI check for formatting, running this command locally will resolve it.
+Black is recommended locally before opening a PR. CI does not gate on Black yet; a future release may add `black --check` after the codebase is fully formatted.
 
 ## 2. Linting (Flake8)
 
@@ -54,21 +60,28 @@ pip install pytest
 ```
 
 ### Usage
-Run the full test suite:
+
+**CI and framework tests** — GitHub Actions runs only the `tests/` tree:
+
 ```bash
 python -m pytest tests/
 ```
 
-### Testing Individual Skills
-Every skill now comes with a `test_skill.py` boilerplate. You can run tests for a specific skill without running the entire suite:
+This covers the loader, CLI, issuer rules, and integration tests under `tests/skills/`. New skill PRs do not need edits to `.github/workflows/ci.yml` when they add co-located skill tests.
+
+### Testing individual skills (local / pre-PR)
+
+Every skill ships with a `test_skill.py` boilerplate. Run it **locally** before opening a skill PR (not in CI):
 
 ```bash
 python -m pytest skills/<category>/<skill_name>/test_skill.py
 ```
 
+Install any packages listed in the skill's `manifest.yaml` `requirements` before running co-located tests (for example `pip install web3` for DeFi skills). Skill deps are declared in the manifest, not added to CI per skill.
+
 ### Writing Tests
-- **Global Tests**: Place core framework tests in the `tests/` directory.
-- **Skill Tests**: Place skill-specific logic tests in a `test_skill.py` file within the skill's own directory.
+- **Framework tests**: Place core and cross-skill integration tests in `tests/` (including `tests/skills/` when appropriate).
+- **Skill bundle tests**: Place skill-specific logic in `skills/<category>/<name>/test_skill.py` and run locally.
 - Use `conftest.py` for shared fixtures (e.g., mocking LLM clients).
 
 ## Pre-Commit Checklist
@@ -78,5 +91,5 @@ Before pushing your code, run the following commands to ensure your changes are 
 1. `skillware list` (Verify install and path resolution are working)
 2. `python -m black .` (Format code)
 3. `python -m flake8 .` (Check quality)
-4. `python -m pytest tests/` (Verify framework functionality)
-5. `python -m pytest skills/` (Verify all skills pass their local tests)
+4. `python -m pytest tests/` (Verify framework functionality — same scope as CI)
+5. `python -m pytest skills/<category>/<skill_name>/test_skill.py` when your PR touches that skill (local only)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-# Development convenience — installs core + all optional extras for local work.
+# Development convenience — same install GitHub Actions CI uses (see pyproject.toml).
+# Installs core + dev tools (pytest, flake8, black) + all optional SDK extras.
 # For production installs use pyproject.toml extras instead, e.g.:
 #   pip install skillware                  # core only
 #   pip install "skillware[cli]"           # + rich terminal


### PR DESCRIPTION
## Description

Streamlines GitHub Actions CI to install dependencies from `pyproject.toml` only (`pip install -e ".[dev,all]"`) and removes redundant manual pip pins and stale comments.

Documents the CI contract in `TESTING.md` and `CONTRIBUTING.md`: **CI runs `pytest tests/`**; co-located `skills/**/test_skill.py` stays a **local pre-PR** step for skill authors. No per-skill workflow edits when new skills land.

Fixes #151

### Type of Change

- [ ] Skill Proposal
- [ ] Bug Report Fix
- [x] Doc Fix
- [x] Framework Feature / RFC Updates

## Checklist

- [x] Agent Code of Conduct
- [x] `flake8 .` and `pytest tests/` run locally (71 passed)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `examples/README.md` (N/A)

## New or updated skill

N/A — no changes under `skills/`.

## Related Issues

Fixes #151

Related: #150 (defi skill PRs should not add CI workflow edits)