### PR TITLE
feat: extend [all] with registry skill runtime deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ## [Unreleased]
 
 ### Changed
+- **Dependencies**: Extended `[all]` with registry skill runtime deps (`web3`, `fastembed`, `numpy`); added `[defi]` and `[embeddings]` optional extras. Documented manifest ↔ `pyproject.toml` convention in CONTRIBUTING and TESTING.md.
 - **Documentation**: [TESTING.md](docs/TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md), [ai_native_workflow.md](docs/contributing/ai_native_workflow.md), and README architecture tree document the bundle / framework / maintainer / example testing model. Pytest collects `tests/` and `skills/` only (`examples/` ignored).
 
 ## [0.3.5] - 2026-06-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
   python -m pytest skills/<category>/<skill_name>/test_skill.py
   ```
 
-  Install packages from that skill's `manifest.yaml` `requirements` when they are not covered by `[all]`.
+- Install packages from that skill's `manifest.yaml` `requirements` when they are not covered by `[all]`. After adding a skill with new third-party deps, update the matching optional extra and `[all]` in `pyproject.toml` (see [Packaging](#packaging-pypi-and-pip-install)).
 - Wait for GitHub Actions CI to pass before requesting review.
 
 ### Pull request template
@@ -258,11 +258,18 @@ The primary guide for the host LLM.
 
 ### Packaging (PyPI and `pip install`)
 
-Registry skills are shipped inside the `skillware` wheel. You do **not** edit `pyproject.toml` per skill. Instead:
+Registry skills are shipped inside the `skillware` wheel. Per-skill layout uses `manifest.yaml` and packaging hooks below — not per-skill edits to CI.
 
 - Add an empty `__init__.py` in `skills/<category>/` when you introduce a **new category**, and in `skills/<category>/<skill_name>/` for each new skill directory (enforced by `tests/test_skill_issuer.py`).
 - Non-Python files (`manifest.yaml`, `instructions.md`, `card.json`, data files) are included automatically via `MANIFEST.in` and `[tool.setuptools.package-data]` (`skills = ["**/*"]`).
 - Confirm `SkillLoader.load_skill("<category>/<skill_name>")` works from the repo root and, when changing the loader, from a clean `pip install` of the built wheel.
+
+**Manifest `requirements` and optional extras**
+
+- List runtime packages in the skill's `manifest.yaml` `requirements` (source of truth for loaders and docs).
+- Mirror any package **not** already in core `[project.dependencies]` into `[project.optional-dependencies]` in `pyproject.toml`: use an existing group when it fits (`[gemini]`, `[office]`, `[defi]`, `[embeddings]`, …) and always add the same pins to `[all]`.
+- Core already includes `requests`, `pyyaml`, and `beautifulsoup4` (manifests may say `bs4`).
+- Contributors and CI install everything needed for bundle tests with `pip install -e ".[dev,all]"`.
 
 ### 6. `docs/skills/<skill_name>.md` (catalog page)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -126,7 +126,7 @@ python -m pytest tests/
 
 That covers **framework tests** and **maintainer skill tests** under `tests/`. It does not run `examples/` or skill bundle tests. Do not add per-skill pip lines or test paths to `.github/workflows/ci.yml`.
 
-Skill deps belong in each skill's `manifest.yaml` `requirements`; mirror them in `pyproject.toml` optional extras when contributors need a one-shot install via `[all]`.
+The `[all]` extra includes optional SDK groups plus registry skill runtime deps (`web3`, `fastembed`, `numpy`, …) so `pytest skills/` works after `pip install -e ".[dev,all]"`. When a skill adds new `manifest.yaml` `requirements`, add the same packages to the matching optional extra and to `[all]` in `pyproject.toml`.
 
 ### Local commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,22 @@ openai = [
 office = [
     "pymupdf",
 ]
+defi = [
+    "web3>=6.0.0",
+]
+embeddings = [
+    "fastembed",
+    "numpy",
+]
 all = [
     "rich>=13.0",
     "google-genai",
     "anthropic",
     "openai",
     "pymupdf",
+    "web3>=6.0.0",
+    "fastembed",
+    "numpy",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@
 #   pip install "skillware[claude]"        # + Anthropic SDK
 #   pip install "skillware[openai]"        # + OpenAI SDK
 #   pip install "skillware[office]"        # + PyMuPDF
-#   pip install "skillware[all]"           # + all optional SDKs
+#   pip install "skillware[defi]"            # + web3 (EVM skills)
+#   pip install "skillware[embeddings]"      # + fastembed, numpy
+#   pip install "skillware[all]"           # + all optional SDKs and skill runtime deps
 #   pip install "skillware[dev]"           # + testing and linting tools
 -e ".[dev,all]"


### PR DESCRIPTION
## Description

Extends optional extras so `pip install -e ".[dev,all]"` covers registry skill runtime deps needed for bundle tests — without touching **core** dependencies.

**Changes:**
- New extras: `[defi]` (`web3>=6.0.0`), `[embeddings]` (`fastembed`, `numpy`)
- `[all]` includes those packages alongside existing SDK/office extras
- CONTRIBUTING + TESTING: when a skill adds new `manifest.yaml` `requirements` not in core, mirror them in the matching extra and `[all]` (one-time per new dep class, not every skill PR)
- `requirements.txt` comment lines updated

Core install stays minimal; only `[all]` / `[dev,all]` grows for contributors and CI.

Verified: `pytest skills/` — 55 passed locally with `pip install -e ".[dev,all]"`.

### Type of Change

- [x] **Framework Feature / RFC Updates**
- [ ] Doc Fix (docs are supporting only)
- [ ] Skill Proposal
- [ ] Bug Report Fix

## Checklist

- [x] Agent Code of Conduct
- [x] `pytest tests/` and `pytest skills/` run locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] N/A — no `examples/` script changes

## Related Issues

Refs #157