### PR TITLE
ci: bump CodeQL action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,59 +1,40 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [main]
   schedule:
-    - cron: '21 7 * * 3'
+    - cron: "21 7 * * 3"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [python]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ## [Unreleased]
 
 ### Changed
+- **CI**: CodeQL GitHub Action upgraded from v3 to v4.
 - **Dependencies**: Extended `[all]` with registry skill runtime deps (`web3`, `fastembed`, `numpy`); added `[defi]` and `[embeddings]` optional extras. Documented manifest ↔ `pyproject.toml` convention in CONTRIBUTING and TESTING.md.
 - **Documentation**: [TESTING.md](docs/TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md), [ai_native_workflow.md](docs/contributing/ai_native_workflow.md), and README architecture tree document the bundle / framework / maintainer / example testing model. Pytest collects `tests/` and `skills/` only (`examples/` ignored).
 


### PR DESCRIPTION
## Description

Upgrades the CodeQL workflow after v3 auth failures on `main`.

**Changes:**
- `github/codeql-action/init`, `autobuild`, `analyze` → **v4**
- `actions/checkout` → **v4**
- Workflow-level `permissions` for code scanning (`contents: read`, `security-events: write`, `actions: read`)
- Trimmed redundant job-level config and comments

No application code changes. If init still fails after merge, enable **Code scanning** under repo **Settings → Code security and analysis** (org policy can block `security-events`).

After merge: **Re-run the CodeQL workflow** on `main` — no need to rerun Skillware CI.

### Type of Change

- [x] **Bug Report Fix** — CI / CodeQL workflow
- [ ] Framework Feature
- [ ] Doc Fix
- [ ] Skill Proposal

## Checklist

- [x] Agent Code of Conduct
- [x] N/A — workflow-only (no pytest/flake8 run required)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] N/A — no `examples/` changes

## Related Issues

Infra follow-up to CodeQL failures on `main` after #161 / #157 merges.