### PR TITLE
fix(novelty_extractor): mock embeddings in bundle tests for offline CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Added
 - **Tests**: Backfilled `test_skill.py` for six registry skills (`mica_module`, `pii_masker`, `synthetic_generator`, `wallet_screening`, `pdf_form_filler`, `prompt_rewriter`); all registry skills now ship co-located bundle tests. Fixed `prompt_rewriter` package export so pytest can collect the bundle (#158).
 
+### Fixed
+- **`novelty_extractor`**: Bundle tests mock fastembed embeddings so CI avoids HuggingFace downloads and rate limits (#159 follow-up).
+
 ### Changed
 - **CI**: GitHub Actions runs `pytest skills/` then `pytest tests/` after lint (bundle + framework/maintainer tests; closes #90) (#159).
 - **CI**: CodeQL GitHub Action upgraded from v3 to v4.

--- a/skills/data_engineering/novelty_extractor/test_skill.py
+++ b/skills/data_engineering/novelty_extractor/test_skill.py
@@ -1,32 +1,66 @@
+import os
+from unittest.mock import MagicMock
+
+import numpy as np
 import pytest
 import yaml
-import os
+
 from .skill import NoveltyExtractor
+
+
+def _mock_embed_vectors(texts):
+    """Deterministic keyword vectors — no HuggingFace download in CI."""
+    vectors = []
+    for text in texts:
+        t = text.lower()
+        if "bitcoin" in t:
+            vectors.append(np.array([1.0, 0.0, 0.0], dtype=float))
+        elif "sky" in t or "blue" in t:
+            vectors.append(np.array([0.0, 1.0, 0.0], dtype=float))
+        elif "python" in t:
+            vectors.append(np.array([0.0, 0.0, 1.0], dtype=float))
+        else:
+            vectors.append(np.array([0.1, 0.1, 0.1], dtype=float))
+    return vectors
+
+
+@pytest.fixture(autouse=True)
+def mock_embedding_model(monkeypatch):
+    """Bundle tests must stay offline; mock fastembed to avoid HF rate limits in CI."""
+    NoveltyExtractor._model = None
+    mock_model = MagicMock()
+    mock_model.embed.side_effect = _mock_embed_vectors
+
+    @classmethod
+    def _fake_get_model(cls):
+        if cls._model is None:
+            cls._model = mock_model
+        return cls._model
+
+    monkeypatch.setattr(NoveltyExtractor, "_get_model", _fake_get_model)
+    yield
+    NoveltyExtractor._model = None
 
 
 @pytest.fixture
 def skill():
-    """Fixture to initialize the skill."""
     return NoveltyExtractor()
 
 
 @pytest.fixture
 def manifest():
-    """Fixture to load manifest.yaml for validation."""
     manifest_path = os.path.join(os.path.dirname(__file__), "manifest.yaml")
     with open(manifest_path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
 def test_skill_manifest_consistency(skill, manifest):
-    """Verify the skill manifest matches manifest.yaml."""
     skill_manifest = skill.manifest
     assert skill_manifest["name"] == manifest["name"]
     assert skill_manifest["version"] == manifest["version"]
 
 
 def test_skill_returns_dict(skill):
-    """Execution result must be a dictionary."""
     result = skill.execute(
         {
             "dataset_chunk": "Bitcoin is going to rise.\n\nThe sky is blue.",
@@ -37,7 +71,6 @@ def test_skill_returns_dict(skill):
 
 
 def test_skill_output_keys(skill):
-    """Result must contain the three expected output keys."""
     result = skill.execute(
         {
             "dataset_chunk": "Bitcoin is going to rise.\n\nThe sky is blue.",
@@ -50,7 +83,6 @@ def test_skill_output_keys(skill):
 
 
 def test_skill_filters_redundant_chunks(skill):
-    """Semantically similar chunks should be filtered out."""
     result = skill.execute(
         {
             "dataset_chunk": (
@@ -67,7 +99,6 @@ def test_skill_filters_redundant_chunks(skill):
 
 
 def test_skill_empty_input(skill):
-    """Empty input should return empty result without crashing."""
     result = skill.execute(
         {
             "dataset_chunk": "",
@@ -79,7 +110,6 @@ def test_skill_empty_input(skill):
 
 
 def test_skill_baseline_filters_seen_content(skill):
-    """Chunks already in baseline should be filtered out."""
     baseline = "Bitcoin is going to rise.\n\nThe sky is blue."
     result = skill.execute(
         {
@@ -93,7 +123,6 @@ def test_skill_baseline_filters_seen_content(skill):
 
 
 def test_skill_sentence_strategy(skill):
-    """Sentence chunking strategy should work without crashing."""
     result = skill.execute(
         {
             "dataset_chunk": "Bitcoin is going to rise. The sky is blue. Python is great.",


### PR DESCRIPTION
Hotfix for CI failures after #159: `novelty_extractor` bundle tests no longer call real `fastembed` / HuggingFace. They mock `_get_model` with deterministic keyword vectors so `pytest skills/` stays offline and avoids 429 rate limits.

No changes to `skill.py` or runtime behavior — test-only.

Refs #159

## Description

After bundle tests entered CI, `novelty_extractor` tried to download `bge-small-en-v1.5` from HuggingFace on every matrix job. Rate limits caused empty results and two test failures (~3 min per job). Bundle tests should mock externals per TESTING.md; this aligns the skill with that policy.

### Type of Change

- [ ] **Skill Proposal**
- [x] **Bug Report Fix**
- [ ] **Doc Fix**
- [ ] **Framework Feature / RFC Updates**

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `pytest skills/` locally (76 passed).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [ ] `examples/README.md` — N/A.

## New or updated skill

N/A — `test_skill.py` only; no manifest or skill logic changes.

## Constitution & Safety

N/A — tests mock embeddings; production skill unchanged.

## Related Issues

Refs #159