### PR TITLE
docs(wallet_screening): align examples and docs with finance/wallet_s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Fixed
+- **`finance/wallet_screening`**: Align examples and docs with `finance/wallet_screening` manifest tool name; fix `gemini_wallet_check.py` and `claude_wallet_check.py` to match tool name dynamically from manifest; correct `card.json` UI fields to match actual skill output schema; update `instructions.md`, provider snippets, Data Schema, and usage docs (#173).
+
 ## [0.3.6] - 2026-06-15
 
 ### Added

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -14,7 +14,7 @@ This document clarifies how Skillware compares to other common approaches for eq
 
 | Method | Speed | Cost | Accuracy | Reliability | Security | Setup |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Skillware** (`wallet_screening`) | Seconds | Low (~$0 + optional Etherscan key) | High (deterministic OFAC/TRM-style data) | Repeatable, tested Python | Fixed code path | `pip install skillware` |
+| **Skillware** (`finance/wallet_screening`) | Seconds | Low (~$0 + optional Etherscan key) | High (deterministic OFAC/TRM-style data) | Repeatable, tested Python | Fixed code path | `pip install skillware` |
 | **Prompt + web search** | Minutes | High tokens | Low (misses on-chain signals) | Varies per run | Generated code and scraping | Prompt engineering |
 | **MCP / multi-agent** | Minutes+ | Tokens + infra | Medium (tool-dependent) | Server/agent-dependent | Many moving parts | Deploy servers |
 | **Native APIs** (Chainalysis, TRM) | Sseconds | High (enterprise) | High | SLA-backed | Vendor-controlled | Contracts |
@@ -99,7 +99,7 @@ Frameworks like Google DeepMind's **Antigravity** use `SKILL.md` files to provid
 A critical architectural distinction is how Skillware treats logic execution versus "code generation."
 
 *   **The Code-Generation Approach**: Many platforms prompt the LLM to write code on the fly to solve a requested problem. This is expensive (you pay for output tokens every time), slow, and risky (the LLM executes unreviewed code).
-*   **The Skillware Approach**: Skillware relies on **Pre-Compiled Logic**. The logical system decides *which* tool to call (e.g., wallet_screening) and passes arguments. The heavy lifting happens deterministically in the Python `BaseSkill` implementation. This results in **zero-cost logic execution**, instant processing, and static, auditable code boundaries. In contrast, hosts using Agent Skills load full SKILL.md instruction context into the model at runtime and may rely on the host to generate or run code; Skillware keeps reasoning in `instructions.md` but executes work in pre-reviewed `skill.execute()`.
+*   **The Skillware Approach**: Skillware relies on **Pre-Compiled Logic**. The logical system decides *which* tool to call (e.g., `finance/wallet_screening`) and passes arguments. The heavy lifting happens deterministically in the Python `BaseSkill` implementation. This results in **zero-cost logic execution**, instant processing, and static, auditable code boundaries. In contrast, hosts using Agent Skills load full SKILL.md instruction context into the model at runtime and may rely on the host to generate or run code; Skillware keeps reasoning in `instructions.md` but executes work in pre-reviewed `skill.execute()`.
 
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -81,7 +81,7 @@ This "Context Injection" ensures the model isn't just *able* to call the tool, b
 ## The Execution Loop
 
 1.  **User Query**: "Is wallet 0x123 safe?"
-2.  **Model Cognition**: The LLM reads the injected `instructions.md` and realizes it should use the `wallet_screening` tool.
+2.  **Model Cognition**: The LLM reads the injected `instructions.md` and realizes it should use the `finance/wallet_screening` tool.
 3.  **Tool Call**: The LLM outputs a structured tool call (e.g., JSON or Protobuf).
 4.  **Framework Execution**: Your script (or the model's auto-runner) executes `skill.execute({"address": "0x123"})`.
 5.  **The Body Acts**: `skill.py` runs. It fetches Etherscan data, checks local JSON sanctions lists, mimics the logic of a complex forensic tool.

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -89,6 +89,8 @@ skill = bundle["module"].WalletScreeningSkill(
 )
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
+# Use the manifest name so the match stays correct if the name ever changes
+tool_name = bundle["manifest"]["name"]
 response = client.models.generate_content(
     model="gemini-2.5-flash",
     contents="Screen wallet 0xd8dA... for sanctions and malicious contract interactions.",
@@ -98,7 +100,7 @@ response = client.models.generate_content(
     ),
 )
 for part in response.candidates[0].content.parts:
-    if part.function_call:
+    if part.function_call and part.function_call.name == tool_name:
         result = skill.execute(dict(part.function_call.args))
         follow_up = client.models.generate_content(
             model="gemini-2.5-flash",
@@ -134,7 +136,8 @@ skill = bundle["module"].WalletScreeningSkill(
 )
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
-# On tool_use (name wallet_screening): skill.execute(tool_use.input), return tool_result
+# On tool_use, match name against bundle["manifest"]["name"] (finance/wallet_screening):
+# skill.execute(tool_use.input), return tool_result
 ```
 
 ### OpenAI
@@ -152,7 +155,7 @@ skill = bundle["module"].WalletScreeningSkill(
 )
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-# Match tool_call.function.name to openai_tool["function"]["name"] (wallet_screening)
+# Match tool_call.function.name to openai_tool["function"]["name"] (finance_wallet_screening)
 ```
 
 ### DeepSeek
@@ -174,11 +177,12 @@ client = OpenAI(
     base_url="https://api.deepseek.com",
 )
 # chat.completions.create(model="deepseek-chat", tools=[deepseek_tool], ...)
+# Match tool_call.function.name to deepseek_tool["function"]["name"] (finance_wallet_screening)
 ```
 
 ### Ollama
 
-Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "wallet_screening"` in the JSON block. See [Ollama usage](../usage/ollama.md) and [agent loops](../usage/agent_loops.md).
+Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "finance/wallet_screening"` in the JSON block. See [Ollama usage](../usage/ollama.md) and [agent loops](../usage/agent_loops.md).
 
 ## Data Schema
 
@@ -186,14 +190,31 @@ The skill returns a rich forensic report. Agents act on this data.
 
 ```json
 {
+  "metadata": {
+    "screening_time": "2025-01-01T00:00:00",
+    "wallet_address": "0xd8dA...",
+    "data_sources_count": 3
+  },
   "summary": {
-    "address": "0xd8dA...",
     "risk_flag": true,
     "sanctioned_entity_match": false,
     "malicious_interaction_count": 3,
-    "pnl_usd": 4500.50
+    "balance_eth": 1.5,
+    "balance_usd": 3000.0,
+    "total_transactions": 42
+  },
+  "financial_analysis": {
+    "value_in_eth": 10.0,
+    "value_in_usd": 20000.0,
+    "value_out_eth": 8.5,
+    "value_out_usd": 17000.0,
+    "gas_paid_eth": 0.02,
+    "pnl_eth": -1.52,
+    "pnl_usd": -3040.0,
+    "pnl_percent": -15.2
   },
   "risk_details": {
+    "sanctions_hits": [],
     "malicious_interactions": [
       {
         "tx_hash": "0xabc...",
@@ -203,7 +224,8 @@ The skill returns a rich forensic report. Agents act on this data.
     ]
   },
   "network_analysis": {
-    "most_interacted_wallet": ["0x123...", 45]
+    "most_interacted_wallet": ["0x123...", 45],
+    "top_10_counterparties": [["0x123...", 45]]
   }
 }
 ```

--- a/docs/usage/ollama.md
+++ b/docs/usage/ollama.md
@@ -80,7 +80,7 @@ if tool_match:
     fn_name = tool_call.get("tool")
     fn_args = tool_call.get("arguments", {})
 
-    if fn_name == "finance/wallet_screening":
+    if fn_name == skill_bundle["manifest"]["name"]:
         print(f"⚙️ Executing skill '{fn_name}' locally...")
         api_result = wallet_skill.execute(fn_args)
 

--- a/docs/usage/openai.md
+++ b/docs/usage/openai.md
@@ -50,7 +50,7 @@ OpenAI function names must match `[a-zA-Z0-9_-]` and are limited to 64 character
 | Manifest `name` | OpenAI `function.name` |
 | :--- | :--- |
 | `compliance/tos_evaluator` | `compliance_tos_evaluator` |
-| `wallet_screening` | `wallet_screening` |
+| `finance/wallet_screening` | `finance_wallet_screening` |
 
 In your tool loop, compare `tool_call.function.name` to `tool["function"]["name"]` from `to_openai_tool()`, not necessarily the raw manifest string.
 

--- a/examples/claude_wallet_check.py
+++ b/examples/claude_wallet_check.py
@@ -24,6 +24,8 @@ client = anthropic.Anthropic(
 
 # Define the tool set
 tools = [SkillLoader.to_claude_tool(skill)]
+# Derive the tool name from the manifest so this stays correct if the name changes
+TOOL_NAME = skill["manifest"]["name"]
 
 # 4. Run the Agent Loop
 user_query = (
@@ -48,7 +50,7 @@ if message.stop_reason == "tool_use":
     print(f"\nClaude requested tool: {tool_name}")
     print(f"Input: {tool_input}")
 
-    if tool_name == "wallet_screening":
+    if tool_name == TOOL_NAME:
         # Execute the skill
         result = wallet_skill.execute(tool_input)
 

--- a/examples/gemini_wallet_check.py
+++ b/examples/gemini_wallet_check.py
@@ -21,6 +21,8 @@ wallet_skill = WalletScreeningSkill(
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(skill_bundle)
 system_instruction = skill_bundle["instructions"]
+# Derive the tool name from the manifest so this stays correct if the name changes
+TOOL_NAME = skill_bundle["manifest"]["name"]
 
 user_query = (
     "Can you screen this wallet for me? 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
@@ -45,7 +47,7 @@ while response.candidates and response.candidates[0].content.parts:
 
         print(f"Agent wants to call: {fn_name}")
 
-        if fn_name == "wallet_screening":
+        if fn_name == TOOL_NAME:
             print("Executing skill locally...")
             api_result = wallet_skill.execute(fn_args)
 

--- a/skills/finance/wallet_screening/card.json
+++ b/skills/finance/wallet_screening/card.json
@@ -12,10 +12,10 @@
   "ui_schema": {
     "type": "card",
     "fields": [
-      {"key": "summary.address", "label": "Address"},
-      {"key": "summary.sanctioned", "label": "Sanctioned", "type": "status_badge"},
-      {"key": "summary.malicious_interactions_count", "label": "Risky Interactions", "type": "count"},
-      {"key": "summary.pnl_eth", "label": "PnL (ETH)", "type": "currency"}
+      {"key": "metadata.wallet_address", "label": "Address"},
+      {"key": "summary.sanctioned_entity_match", "label": "Sanctioned", "type": "status_badge"},
+      {"key": "summary.malicious_interaction_count", "label": "Risky Interactions", "type": "count"},
+      {"key": "financial_analysis.pnl_eth", "label": "PnL (ETH)", "type": "currency"}
     ]
   }
 }

--- a/skills/finance/wallet_screening/instructions.md
+++ b/skills/finance/wallet_screening/instructions.md
@@ -1,6 +1,6 @@
 # Wallet Screening Skill Instructions
 
-You are equipped with the `wallet_screening` skill. This tool allows you to perform due diligence on Ethereum addresses.
+You are equipped with the `finance/wallet_screening` skill. This tool allows you to perform due diligence on Ethereum addresses.
 
 ## When to use
 Use this skill when the user:
@@ -13,10 +13,10 @@ Use this skill when the user:
 The tool returns a JSON object. You should summarize this for the user in a professional, "Compliance Officer" tone.
 
 ### Key Fields to Check:
-1.  **`summary.sanctioned` (Boolean)**: If `true`, this is CRITICAL. Report the `sanctions_hits` immediately.
-2.  **`summary.malicious_interactions` (Integer)**: If > 0, the wallet has touched bad actors. List the `malicious_contracts_check.matches`.
-3.  **`summary.pnl`**: Profit and Loss. Useful for determining if it's a profitable trader or a victim.
-4.  **`counterparty_analysis`**: Who are they sending money to?
+1.  **`summary.sanctioned_entity_match` (Boolean)**: If `true`, this is CRITICAL. Report the `risk_details.sanctions_hits` immediately.
+2.  **`summary.malicious_interaction_count` (Integer)**: If > 0, the wallet has touched bad actors. List the `risk_details.malicious_interactions`.
+3.  **`financial_analysis.pnl_eth` / `pnl_usd`**: Profit and Loss. Useful for determining if it's a profitable trader or a victim.
+4.  **`network_analysis.top_10_counterparties`**: Who are they sending money to?
 
 ## Safety Protocol
 *   If a wallet is **Sanctioned**: severe warning. "⚠️ WARNING: This wallet appears on the following sanctions lists..."


### PR DESCRIPTION
Closes #173

## Changes

- **`examples/gemini_wallet_check.py`** and **`examples/claude_wallet_check.py`**: 
  replaced hardcoded `if fn_name == "wallet_screening"` with a dynamic 
  `TOOL_NAME = bundle["manifest"]["name"]` — these would silently never match 
  after the rename in #171.

- **`docs/skills/wallet_screening.md`**: updated Gemini/Claude/OpenAI/DeepSeek/Ollama 
  snippets to reflect the new name; corrected Data Schema to match actual 
  `_generate_report_data` output (added `metadata`, `financial_analysis`; 
  removed nonexistent `summary.address` and `summary.pnl_usd`).

- **`docs/introduction.md`**: `wallet_screening` → `finance/wallet_screening`.

- **`skills/finance/wallet_screening/instructions.md`**: tool name updated; 
  field references aligned to real output schema (`summary.sanctioned_entity_match`, 
  `summary.malicious_interaction_count`, `financial_analysis.pnl_eth/pnl_usd`, 
  `network_analysis.top_10_counterparties`).

- **`COMPARISON.md`**: table row and prose updated.

- **`docs/usage/openai.md`**: sanitization table corrected 
  (`wallet_screening → wallet_screening` → `finance/wallet_screening → finance_wallet_screening`).

- **`docs/usage/ollama.md`**: hardcoded name replaced with manifest read.

## Test plan
- [ ] Verified all 8 modified files contain no remaining `wallet_screening` 
      hardcoded tool name comparisons
- [ ] `_sanitize_openai_tool_name("finance/wallet_screening")` returns 
      `finance_wallet_screening` (existing test in `tests/test_loader.py` covers sanitizer)
