### PR TITLE
Docs/issue 179 close testing epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **Tests**: `tests/test_skill_issuer.py` now requires `test_skill.py` for every registry skill under `skills/` (#160).
 - **Documentation**: Clarified that bundle tests must mock network calls and model downloads in CI (#170).
+- **Documentation**: Added testing-architecture **Status** section to [TESTING.md](docs/TESTING.md) — completed vs open phases for RFC #156 (#179).
 
 ## [0.3.7] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **Tests**: `tests/test_skill_issuer.py` now requires `test_skill.py` for every registry skill under `skills/` (#160).
 - **Documentation**: Clarified that bundle tests must mock network calls and model downloads in CI (#170).
-- **Documentation**: Added testing-architecture **Status** section to [TESTING.md](docs/TESTING.md) — completed vs open phases for RFC #156 (#179).
+- **Documentation**: Added a **Status** section to [TESTING.md](docs/TESTING.md) summarizing the current testing model and planned CLI work (#179).
 
 ## [0.3.7] - 2026-06-22
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,6 +4,25 @@ Skillware maintains high standards for code quality and reliability. Before subm
 
 Tests fall into four layers: **bundle**, **framework**, **maintainer**, and **example**. Use that vocabulary consistently in docs and PRs.
 
+## Status (testing architecture)
+
+Tracked under [RFC #156](https://github.com/ARPAHLS/skillware/issues/156). As of **0.3.7**, the target CI shape is in place:
+
+| Phase | Status | Notes |
+| :--- | :---: | :--- |
+| Bundle tests in CI (`pytest skills/`) | Done | Since 0.3.6 ([#159](https://github.com/ARPAHLS/skillware/issues/159)) |
+| Full registry `test_skill.py` backfill | Done | Since 0.3.6 ([#158](https://github.com/ARPAHLS/skillware/issues/158)) |
+| Docs: four-layer model in TESTING / CONTRIBUTING / ai_native_workflow | Done | ([#106](https://github.com/ARPAHLS/skillware/issues/106)) |
+| `[all]` extras for bundle-test runtime deps | Done | `pyproject.toml` + CONTRIBUTING convention |
+| Maintainer tests under `tests/skills/` | Done | Layout ([#86](https://github.com/ARPAHLS/skillware/issues/86)); still optional per skill |
+| Issuer enforces `test_skill.py` on every registry skill | Done | Since 0.3.7 ([#160](https://github.com/ARPAHLS/skillware/issues/160)) |
+| Bundle tests must mock network / model downloads in CI | Done | ([#170](https://github.com/ARPAHLS/skillware/issues/170)) |
+| CLI `skillware test` for bundle discovery | Open | ([#83](https://github.com/ARPAHLS/skillware/issues/83)) |
+
+**CI today** (every PR): `black --check`, `flake8`, `pytest skills/`, `pytest tests/`. Bundle tests are **not** local-only; they gate merge the same as framework and maintainer tests.
+
+Broader post-release doc alignment (README badges, category tables, `.env.example`) is tracked separately in ([#154](https://github.com/ARPAHLS/skillware/issues/154)) — not duplicated here.
+
 ## Quick Setup
 
 Install lint tools, pytest, and optional skill runtime deps in one go (matches GitHub Actions CI):

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,24 +4,19 @@ Skillware maintains high standards for code quality and reliability. Before subm
 
 Tests fall into four layers: **bundle**, **framework**, **maintainer**, and **example**. Use that vocabulary consistently in docs and PRs.
 
-## Status (testing architecture)
+## Status
 
-Tracked under [RFC #156](https://github.com/ARPAHLS/skillware/issues/156). As of **0.3.7**, the target CI shape is in place:
+| Capability | Status |
+| :--- | :---: |
+| Bundle tests in CI (`pytest skills/`) | Done |
+| Every registry skill ships `test_skill.py` | Done |
+| Issuer enforces bundle tests on new skills | Done |
+| Bundle tests mock network and model downloads in CI | Done |
+| Maintainer tests under `tests/skills/` (optional per skill) | Done |
+| `[all]` extra covers bundle-test runtime deps | Done |
+| CLI `skillware test` for bundle discovery | Planned |
 
-| Phase | Status | Notes |
-| :--- | :---: | :--- |
-| Bundle tests in CI (`pytest skills/`) | Done | Since 0.3.6 ([#159](https://github.com/ARPAHLS/skillware/issues/159)) |
-| Full registry `test_skill.py` backfill | Done | Since 0.3.6 ([#158](https://github.com/ARPAHLS/skillware/issues/158)) |
-| Docs: four-layer model in TESTING / CONTRIBUTING / ai_native_workflow | Done | ([#106](https://github.com/ARPAHLS/skillware/issues/106)) |
-| `[all]` extras for bundle-test runtime deps | Done | `pyproject.toml` + CONTRIBUTING convention |
-| Maintainer tests under `tests/skills/` | Done | Layout ([#86](https://github.com/ARPAHLS/skillware/issues/86)); still optional per skill |
-| Issuer enforces `test_skill.py` on every registry skill | Done | Since 0.3.7 ([#160](https://github.com/ARPAHLS/skillware/issues/160)) |
-| Bundle tests must mock network / model downloads in CI | Done | ([#170](https://github.com/ARPAHLS/skillware/issues/170)) |
-| CLI `skillware test` for bundle discovery | Open | ([#83](https://github.com/ARPAHLS/skillware/issues/83)) |
-
-**CI today** (every PR): `black --check`, `flake8`, `pytest skills/`, `pytest tests/`. Bundle tests are **not** local-only; they gate merge the same as framework and maintainer tests.
-
-Broader post-release doc alignment (README badges, category tables, `.env.example`) is tracked separately in ([#154](https://github.com/ARPAHLS/skillware/issues/154)) — not duplicated here.
+Every pull request runs `black --check`, `flake8`, `pytest skills/`, and `pytest tests/`. Bundle tests gate merge the same as framework and maintainer tests.
 
 ## Quick Setup
 

--- a/tests/test_skill_issuer.py
+++ b/tests/test_skill_issuer.py
@@ -65,7 +65,7 @@ def test_registry_skills_declare_issuer():
 
 
 def test_registry_skills_have_bundle_test():
-    """Every registry skill must ship a co-located bundle test (RFC #156)."""
+    """Every registry skill must ship a co-located bundle test (#156 / #160)."""
     for skill_dir in _discover_skill_dirs():
         rel = skill_dir.relative_to(REPO_ROOT).as_posix()
         assert (

--- a/tests/test_skill_issuer.py
+++ b/tests/test_skill_issuer.py
@@ -65,7 +65,7 @@ def test_registry_skills_declare_issuer():
 
 
 def test_registry_skills_have_bundle_test():
-    """Every registry skill must ship a co-located bundle test (#156 / #160)."""
+    """Every registry skill must ship a co-located bundle test."""
     for skill_dir in _discover_skill_dirs():
         rel = skill_dir.relative_to(REPO_ROOT).as_posix()
         assert (


### PR DESCRIPTION
## Summary
- Add **Status** section to `docs/TESTING.md` for RFC #156 (what landed in 0.3.6–0.3.7 vs open #83).
- CHANGELOG entry under `[Unreleased]`.

Closes #179

## Test plan
- [x] Docs-only; no code behavior change
- [ ] After merge: post closeout comment on #156 and move Testing Architecture board items to Done