### PR TITLE
docs: align CLI docs with examples menu and pip-install behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **Tests**: `tests/test_registry_docs.py` — CI doc-drift guards that verify skill catalog, examples index, and agent-loops reference matrix stay in sync with the registry (#183).
 
+### Changed
+
+- **Documentation**: Aligned CLI and examples docs (`docs/usage/cli.md`, `examples/README.md`) with the `skillware test` / `skillware examples` behavior shipped in 0.3.8–0.3.9 (#191).
+
 ## [0.3.9] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ skillware list
 
 This prints a table of all locally available skills and confirms the install
 and path resolution are working. Running `skillware` with no arguments opens
-the interactive menu.
+the interactive menu. As optional checks you can also run `skillware test` to
+execute bundle tests, and `skillware examples` to browse the runnable example
+index (fetched from GitHub when no local `examples/README.md` is present).
 
 If `skillware` is not recognized, Python's `Scripts` directory may not be on
 your PATH — use `python -m skillware list` as a fallback. See

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -79,7 +79,7 @@ Available commands:
 | Input | Command | Status |
 | :--- | :--- | :--- |
 | `1` / `list` | List all locally installed skills | Available |
-| `2` / `examples` | Browse runnable example scripts (index from `examples/README.md`) | Available |
+| `2` / `examples` | Browse runnable example scripts (index from `examples/README.md`, or from GitHub when no local copy exists) | Available |
 | `3` / `test` | Run bundle tests (`test_skill.py`) for one or all skills | Available |
 | `4` / `paths` | Show and repair skill directory resolution paths | Coming soon |
 | `5` / `help` | Print rich-formatted help with commands, flags, and examples | Available |

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -79,6 +79,7 @@ Available commands:
 | Input | Command | Status |
 | :--- | :--- | :--- |
 | `1` / `list` | List all locally installed skills | Available |
+| `2` / `examples` | Browse runnable example scripts (index from `examples/README.md`) | Available |
 | `3` / `test` | Run bundle tests (`test_skill.py`) for one or all skills | Available |
 | `4` / `paths` | Show and repair skill directory resolution paths | Coming soon |
 | `5` / `help` | Print rich-formatted help with commands, flags, and examples | Available |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -45,7 +45,7 @@ Multi-layer screening runs locally in one `execute()` call. No generated scraper
 Skillware is designed so agents and their operators can discover, vet, and integrate capabilities without reinventing the wheel.
 
 - **Manifests** declare inputs, outputs, dependencies, and constitution in `manifest.yaml`.
-- **`skillware list`** and **`skillware test`** (CLI) surface the local registry and run bundle tests.
+- **`skillware list`**, **`skillware examples`** / **`skillware list --examples`**, and **`skillware test`** (CLI) surface the local registry, browse the runnable example index, and run bundle tests.
 - **[Examples index](../examples/README.md)** maps runnable provider scripts to skills.
 - **[Usage guides](usage/README.md)** show the same load / tool-call / execute loop for Gemini, Claude, OpenAI, DeepSeek, and Ollama.
 - **[Agent contribution workflow](contributing/ai_native_workflow.md)** documents how supervised agents propose scoped changes and open PRs.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ them for a provider, execute local skill logic, and return tool results to an
 agent loop. After `pip install skillware`, run `skillware examples` or
 `skillware list --examples` from any directory to browse the index in the
 terminal; when no local `examples/README.md` is present, the index is fetched
-from GitHub (network required) (see
-[CLI reference](../docs/usage/cli.md)). Provider setup details live in the usage guides:
+from GitHub (network required); see
+[CLI reference](../docs/usage/cli.md). Provider setup details live in the usage guides:
 
 - [API keys for skills](../docs/usage/api_keys.md)
 - [Gemini](../docs/usage/gemini.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,8 +4,10 @@
 
 Runnable examples in this directory show how to load Skillware skills, adapt
 them for a provider, execute local skill logic, and return tool results to an
-agent loop. From the repository root, run `skillware examples` or
-`skillware list --examples` to browse the index in the terminal (see
+agent loop. After `pip install skillware`, run `skillware examples` or
+`skillware list --examples` from any directory to browse the index in the
+terminal; when no local `examples/README.md` is present, the index is fetched
+from GitHub (network required) (see
 [CLI reference](../docs/usage/cli.md)). Provider setup details live in the usage guides:
 
 - [API keys for skills](../docs/usage/api_keys.md)


### PR DESCRIPTION
Closes #191.

Brings the docs in line with the 0.3.8–0.3.9 CLI (`skillware examples`, `list --examples`, GitHub index fetch):

- **docs/usage/cli.md** — add the missing interactive-menu row `2` / `examples` (the table jumped from `1` / `list` to `3` / `test`; matches the menu defined in `skillware/cli.py`).
- **examples/README.md** — replace the "From the repository root" wording: `skillware examples` and `skillware list --examples` work after `pip install skillware` from any directory, and the index is fetched from GitHub when no local `examples/README.md` is present (network required).
- **docs/vision.md** — discoverability bullet now mentions `skillware examples` / `list --examples` alongside `list` and `test`.
- **README.md** — "Verify your installation" notes `skillware test` and `skillware examples` as optional checks.

Each claim was cross-checked against `skillware/cli.py` (menu row 2 = examples; `_fetch_examples_readme_from_github`; `list --examples`). Did not touch version-policy / SECURITY.md text per the issue.