### PR TITLE
docs: test_registry_docs.py cross-links and PR checklist reminders. Refs #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Added
 
 - **Tests**: `tests/test_registry_docs.py` — CI doc-drift guards that verify skill catalog, examples index, and agent-loops reference matrix stay in sync with the registry (#183).
+- **Documentation**: Cross-linked `tests/test_registry_docs.py` in `ai_native_workflow.md` and `CONTRIBUTING.md` so contributors know doc-drift guards run in CI; added explicit PR checklist reminder in `CONTRIBUTING.md` (#193).
 
 ## [0.3.9] - 2026-06-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 
 - Add or update tests in the correct layer when behavior changes (see [TESTING.md](docs/TESTING.md)).
 - **Skill bundle test** — `skills/<category>/<name>/test_skill.py` (required for new skills; ships in the wheel; runs in CI via `pytest skills/`).
-- **Framework test** — `tests/test_*.py` at repo root (loader, CLI, issuer rules).
+- **Framework test** — `tests/test_*.py` at repo root (loader, CLI, issuer rules, doc-drift guards).
 - **Maintainer skill test** — optional `tests/skills/<category>/test_<name>.py` for extra loader or edge-case coverage.
 - **Usage examples** — `examples/*.py` are not tests and are not run in CI.
 - **GitHub Actions** installs `pip install -e ".[dev,all]"`, runs `python -m black --check .`, then `flake8 .`, then **`pytest skills/`** (bundle tests), then **`pytest tests/`** (framework + maintainer tests). Do not add per-skill pip lines or hardcoded skill paths to `.github/workflows/ci.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,13 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 
 Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Complete the **New or updated skill** section only when this PR adds or changes files under `skills/`.
 
+Before requesting review, verify your PR template checklist:
+
+- Select the correct **change type** (skill, documentation, framework, bug fix).
+- Confirm **local `flake8`, `black` and `pytest`** pass (both `pytest skills/` and `pytest tests/`).
+- Add a **CHANGELOG** entry under `[Unreleased]` when the change is user-visible.
+- Fill only the checkboxes that truthfully apply; do not leave unchecked defaults.
+
 ### AI agents and operators
 
 Agents must follow [Agent Contribution Workflow](docs/contributing/ai_native_workflow.md). Human operators: approve the agent's plan before implementation, verify tests, and own the fork, commit, and PR. The operator remains responsible for the merged diff.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,6 +15,7 @@ Tests fall into four layers: **bundle**, **framework**, **maintainer**, and **ex
 | Maintainer tests under `tests/skills/` (optional per skill) | Done |
 | `[all]` extra covers bundle-test runtime deps | Done |
 | CLI `skillware test` for bundle discovery | Done |
+| Doc-drift guards (`test_registry_docs.py`) | Done |
 
 Every pull request runs `black --check`, `flake8`, `pytest skills/`, and `pytest tests/`. Bundle tests gate merge the same as framework and maintainer tests.
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -90,9 +90,9 @@ You must:
 
 | If the issue involves... | You must also inspect |
 | :--- | :--- |
-| New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed |
+| New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed. Doc-drift guards in `tests/test_registry_docs.py` verify that `docs/skills/README.md`, `examples/README.md`, and `docs/usage/agent_loops.md` stay in sync with manifests and scripts on disk — these run automatically via `pytest tests/`. |
 | Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
-| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/` |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/`. If your change touches `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md`, run `pytest tests/test_registry_docs.py` to catch drift before pushing. |
 | Release / user-visible change | Root [CHANGELOG.md](../../CHANGELOG.md) under `[Unreleased]` when behavior, CLI, skills, or user-facing docs change (maintainers cut version sections) |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |
 | Good first issue | Issue labels and acceptance criteria—take them literally |
@@ -146,6 +146,14 @@ For a single skill:
 pytest skills/<category>/<skill_name>/test_skill.py
 pytest tests/test_skill_issuer.py
 ```
+
+If your change touches `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md`, also run the doc-drift guards explicitly to catch parity issues early:
+
+```bash
+pytest tests/test_registry_docs.py
+```
+
+These checks are part of `pytest tests/` and will run in CI regardless, but an early local run saves a round-trip.
 
 Before Stage 5, scan your diff for:
 
@@ -270,6 +278,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `docs/skills/<skill_name>.md` and catalog row in `docs/skills/README.md`
 - [ ] **Usage Examples** on the catalog page (all five providers per [skill usage template](../usage/skill_usage_template.md)); link to `docs/usage/` and list skill `env_vars` without duplicating [api_keys.md](../usage/api_keys.md)
 - [ ] `pytest tests/test_skill_issuer.py` passes
+- [ ] `pytest tests/test_registry_docs.py` passes (catalog index, examples index, and agent-loops parity)
 - [ ] `SkillLoader.load_skill("<category>/<skill_name>")` works or deps are documented
 - [ ] `examples/README.md` updated if a new or changed script lives under `examples/`
 - [ ] No placeholders under `skills/`
@@ -281,6 +290,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] All issue acceptance criteria met
 - [ ] Links valid
 - [ ] `examples/README.md` row added or updated if the issue touches runnable examples
+- [ ] `pytest tests/test_registry_docs.py` passes when `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md` were edited
 - [ ] `CHANGELOG.md` updated under `[Unreleased]` when the change is user-visible
 - [ ] No emojis; tone matches repo
 - [ ] No unrelated code changes

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -92,7 +92,7 @@ You must:
 | :--- | :--- |
 | New or updated skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed. Doc-drift guards in `tests/test_registry_docs.py` verify that `docs/skills/README.md`, `examples/README.md`, and `docs/usage/agent_loops.md` stay in sync with manifests and scripts on disk — these run automatically via `pytest tests/`. |
 | Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
-| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/`. If your change touches `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md`, run `pytest tests/test_registry_docs.py` to catch drift before pushing. |
+| Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/`. Run `pytest tests/test_registry_docs.py` to confirm catalog and examples docs still match manifests and scripts on disk. |
 | Release / user-visible change | Root [CHANGELOG.md](../../CHANGELOG.md) under `[Unreleased]` when behavior, CLI, skills, or user-facing docs change (maintainers cut version sections) |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |
 | Good first issue | Issue labels and acceptance criteria—take them literally |
@@ -147,7 +147,7 @@ pytest skills/<category>/<skill_name>/test_skill.py
 pytest tests/test_skill_issuer.py
 ```
 
-If your change touches `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md`, also run the doc-drift guards explicitly to catch parity issues early:
+If your change adds, renames, or removes a skill or example script, run the doc-drift guards to verify that `docs/skills/README.md`, `examples/README.md`, and `docs/usage/agent_loops.md` still match what is on disk:
 
 ```bash
 pytest tests/test_registry_docs.py
@@ -290,7 +290,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] All issue acceptance criteria met
 - [ ] Links valid
 - [ ] `examples/README.md` row added or updated if the issue touches runnable examples
-- [ ] `pytest tests/test_registry_docs.py` passes when `docs/skills/README.md`, `examples/README.md`, or `docs/usage/agent_loops.md` were edited
+- [ ] `pytest tests/test_registry_docs.py` passes when the change affects skill catalog pages, example scripts, or `docs/usage/agent_loops.md`
 - [ ] `CHANGELOG.md` updated under `[Unreleased]` when the change is user-visible
 - [ ] No emojis; tone matches repo
 - [ ] No unrelated code changes


### PR DESCRIPTION
<!--
AUTOMATED AGENT GREETING

Greetings, netizen! We welcome your pull requests to Skillware.
Before submitting your code, please ensure you have:
1. Fully read and understood the linked GitHub Issue and its requirements.
2. Analyzed the core architecture (`loader.py`, `base_skill.py`) to ensure your approach aligns with the framework natively.
3. Verified all dependencies are documented in your `manifest.yaml` and logic executes deterministically.
4. Checked off all items in the checklist below.

We are excited to review your capabilities! Let's build together.
-->

## Description

<!--
Agents: Please summarize the logic, cognition, and governance changes introduced in this PR.
Humans: Please describe what this PR does and why it's needed.
-->
Cross-links `tests/test_registry_docs.py` in contributor-facing documentation and adds a pre-review PR checklist reminder.

Changes:

1. `docs/TESTING.md` — Adds a status row for doc-drift guards consistent with existing rows like bundle tests and skillware test.
2. `docs/contributing/ai_native_workflow.md` — References test_registry_docs.py in the complementary paths table (Stage 2), implementation commands (Stage 4), and verification checklists for both "New or updated skill" and "Documentation only" contribution types.
3. `CONTRIBUTING.md` — Adds "doc-drift guards" to the framework test bullet; expands the PR template section with an explicit reminder to verify change type, local lint/test results, and CHANGELOG before requesting review.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .`, `pytest skills/` (or `skillware test`), and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [ ] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## Related Issues
<!-- Link to any related issues (e.g., Fixes #54) -->
Closes #193 