### PR TITLE
docs: document skill category selection guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Documentation
+
+- **CONTRIBUTING**: Category selection guidance for contributors; issue-first policy for new top-level folders (#204).
+
 ### Changed
 
 - **GitHub**: Overhauled issue templates (CLI, Skill Upgrade, Examples, Packaging), issue chooser `config.yml`, PR template, and label taxonomy with pastel colors; labels sync automatically from `.github/labels.json` via CI on merge to `main` (#227).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ Registry-wide issuer rules are enforced in `tests/test_skill_issuer.py` (skills 
 
 ## Skill categories
 
-Place each skill under one top-level directory under `skills/`. Use an existing category when it fits; propose a new category in the issue if none apply.
+Place each skill under one top-level directory under `skills/`. Use an existing category when it fits.
 
 | Category | Purpose | Examples in registry |
 | :--- | :--- | :--- |
@@ -341,13 +341,19 @@ Place each skill under one top-level directory under `skills/`. Use an existing 
 | `data_engineering` | Datasets, generation, ETL-style tooling | `synthetic_generator`, `novelty_extractor` |
 | `defi` | On-chain trading and agent wallet execution | `evm_tx_handler` |
 | `dev_tools` | Developer workflows, issue resolution, repo tooling | `issue_resolver` |
-| `finance` | Blockchain, risk, financial analysis | `wallet_screening` |
+| `finance` | Blockchain, risk, financial analysis | `wallet_screening`, `uk_companies_house_handler` |
 | `office` | Documents, productivity | `pdf_form_filler` |
 | `optimization` | Middleware, compression, efficiency | `prompt_rewriter` |
 | `monitoring` | Agent loop observability, budget gates, task control | `token_limiter` |
 | `wellness` | Coaching guardrails, mental health support | `mental_coach` |
 
-Skill IDs follow `category/skill_name` and should match the path under `skills/` and the `name` field in `manifest.yaml`. For the live registry, see [Skill Library](docs/skills/README.md). Propose new top-level categories in an issue before adding a folder.
+### Choosing a category
+
+The table above is **illustrative**, not a closed list. When contributing a new skill, pick the category whose purpose best matches the skill's primary function.
+
+Registry IDs are always `category/skill_name` from the folder path and must match the `name` field in `manifest.yaml` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). For the live registry, see [Skill Library](docs/skills/README.md).
+
+**New top-level category?** Open an issue and discuss with maintainers **before** adding a folder — do not create `skills/<new_category>/` in a pull request without that agreement.
 
 ---
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -241,7 +241,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 - `card.json` issuer must match manifest `name` and `email` when present
 - Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
 - On each catalog page, add a **Usage Examples** section (Gemini, Claude, OpenAI, DeepSeek, Ollama prompt mode) per [skill usage template](../usage/skill_usage_template.md). Keep provider mechanics in `docs/usage/`; put skill-specific paths, sample user messages, and `execute` payloads on the skill page.
-- Categories: `compliance`, `data_engineering`, `defi`, `dev_tools`, `finance`, `monitoring`, `office`, `optimization`, `wellness` — see [Skill library](../skills/README.md) for the live registry; propose new top-level categories in the issue first
+- Categories: `compliance`, `data_engineering`, `defi`, `dev_tools`, `finance`, `monitoring`, `office`, `optimization`, `wellness` — see [Skill library](../skills/README.md) for the live registry; [Choosing a category](../../CONTRIBUTING.md#choosing-a-category) in CONTRIBUTING.md (issue first for new top-level folders)
 - Do not bump `pyproject.toml` version in skill-only PRs unless requested
 - Logic in `skill.py`; prompts and persona in `instructions.md`
 - Never commit secrets; document `env_vars` in the manifest

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -30,7 +30,7 @@ In integration, a "Skill" is not just a function. It is a living unit of capabil
 
 ## The Architecture: How It Works
 
-Skillware relies on a strict, modular layout. Instead of hardcoding tools into your primary application, you maintain a structured registry of capabilities:
+Skillware relies on a strict, modular layout. Instead of hardcoding tools into your primary application, you maintain a structured registry of capabilities grouped by domain folders under `skills/` (see [Skill categories](../CONTRIBUTING.md#skill-categories) when contributing):
 
 ```text
 Skillware/

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the official catalog of Skillware capabilities. New here? Start with the [project README](../../README.md).
 
-Browse by category below, or run `skillware list` after `pip install skillware` to see locally available skills.
+Browse by category below, or run `skillware list` after `pip install skillware` to see locally available skills. When contributing a new skill, see [Choosing a category](../../CONTRIBUTING.md#choosing-a-category) in CONTRIBUTING.md.
 
 ## Office
 Skills for document processing, email automation, and productivity.


### PR DESCRIPTION
Fixes #204

## Summary

Adds contributor guidance for picking a skill category: illustrative category table, **Choosing a category** subsection with issue-first policy for new top-level folders, and cross-links from the skill catalog / introduction / agent workflow doc.

## Changes
- `CONTRIBUTING.md` — `### Choosing a category`
- `CHANGELOG.md` — `[Unreleased]` documentation entry
- `docs/skills/README.md`, `docs/introduction.md`, `docs/contributing/ai_native_workflow.md` — pointers to CONTRIBUTING

## Checklist
- [x] Doc Fix
- [x] CHANGELOG
