### PR TITLE
feat(monitoring): add token_limiter skill for agent loop budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Added
 
+- **`monitoring/token_limiter`**: New monitoring skill that evaluates cumulative token usage and returns CONTINUE, WARN, or FORCE_TERMINATE for autonomous agent loops; bundled indicative model pricing, ROI scaffold fields for v2, local and provider loop examples (#23).
 - **Tests**: `tests/test_registry_docs.py` — CI doc-drift guards that verify skill catalog, examples index, and agent-loops reference matrix stay in sync with the registry (#183).
 - **Documentation**: Cross-linked `tests/test_registry_docs.py` in `ai_native_workflow.md` and `CONTRIBUTING.md` so contributors know doc-drift guards run in CI; added explicit PR checklist reminder in `CONTRIBUTING.md` (#193).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Documentation**: `docs/skills/token_limiter.md` — budget disclaimer callout, limitations clarity, and enterprise disclaimer (#23).
 - **Documentation**: README Stats section and live PyPI download badges (pepy / PyPI Stats dashboards, header `DLs ↓` total).
 - **Documentation**: Aligned CLI and examples docs (`docs/usage/cli.md`, `examples/README.md`, `docs/vision.md`, `README.md`) with the `skillware test` / `skillware examples` behavior shipped in 0.3.8–0.3.9 (#191).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,6 +331,7 @@ Place each skill under one top-level directory under `skills/`. Use an existing 
 | `finance` | Blockchain, risk, financial analysis | `wallet_screening` |
 | `office` | Documents, productivity | `pdf_form_filler` |
 | `optimization` | Middleware, compression, efficiency | `prompt_rewriter` |
+| `monitoring` | Agent loop observability, budget gates, task control | `token_limiter` |
 | `wellness` | Coaching guardrails, mental health support | `mental_coach` |
 
 Skill IDs follow `category/skill_name` and should match the path under `skills/`. For the live registry, see [Skill Library](docs/skills/README.md). Propose new top-level categories in an issue before adding a folder.

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -237,7 +237,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 - `card.json` issuer must match manifest `name` and `email` when present
 - Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
 - On each catalog page, add a **Usage Examples** section (Gemini, Claude, OpenAI, DeepSeek, Ollama prompt mode) per [skill usage template](../usage/skill_usage_template.md). Keep provider mechanics in `docs/usage/`; put skill-specific paths, sample user messages, and `execute` payloads on the skill page.
-- Categories: `compliance`, `data_engineering`, `defi`, `dev_tools`, `finance`, `office`, `optimization`, `wellness` — see [Skill library](../skills/README.md) for the live registry; propose new top-level categories in the issue first
+- Categories: `compliance`, `data_engineering`, `defi`, `dev_tools`, `finance`, `monitoring`, `office`, `optimization`, `wellness` — see [Skill library](../skills/README.md) for the live registry; propose new top-level categories in the issue first
 - Do not bump `pyproject.toml` version in skill-only PRs unless requested
 - Logic in `skill.py`; prompts and persona in `instructions.md`
 - Never commit secrets; document `env_vars` in the manifest

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -56,6 +56,13 @@ Skills that assist developers in understanding codebases, planning changes, and 
 | :--- | :--- | :--- | :--- |
 | **[Issue Resolver](issue_resolver.md)** | `dev_tools/issue_resolver` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | GitHub issue URL prep, nine-stage agent workflow, conditional verify/commit gates, and commit-message validation. |
 
+## Monitoring
+Observability and guardrails for long-running autonomous agent loops.
+
+| Skill | ID | Issuer | Description |
+| :--- | :--- | :--- | :--- |
+| **[Token Limiter](token_limiter.md)** | `monitoring/token_limiter` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Deterministic token budget gate that returns CONTINUE, WARN, or FORCE_TERMINATE for host loops. |
+
 ## Wellness
 Supportive coaching guardrails, crisis triage, and grounded psychoeducation for host agents.
 

--- a/docs/skills/token_limiter.md
+++ b/docs/skills/token_limiter.md
@@ -1,0 +1,259 @@
+# Token Limiter
+
+**Domain:** `monitoring`
+**Skill ID:** `monitoring/token_limiter`
+**Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+
+[Skill Library](README.md) · [Testing](../TESTING.md)
+
+A deterministic **token budget gate** for autonomous agent loops. After each model turn, the host passes cumulative token usage; the skill returns `CONTINUE`, `WARN`, or `FORCE_TERMINATE`. The host loop must stop when the action is `FORCE_TERMINATE`.
+
+This skill does **not** kill processes, cancel provider sessions, or call billing APIs. It returns a structured decision the orchestrator acts on.
+
+## Capabilities
+
+- **Hard token ceiling**: Terminates (signals termination) when cumulative tokens reach `max_allowed_tokens`.
+- **Soft warning threshold**: Default 80% utilization returns `WARN` before the hard limit.
+- **Indicative cost estimates**: Optional `model_id` maps to bundled list prices in `data/model_pricing.json`.
+- **Idempotent retries**: Optional `turn_id` caches the decision for the same turn metrics.
+- **ROI scaffold (v2)**: Accepts `roi_value_usd`, `expected_outcome`, and `outcome_delivered` for future outcome-aware gates. **Not enforced in v1.**
+
+## Internal Architecture
+
+The skill lives in `skills/monitoring/token_limiter/`.
+
+### The Body (`skill.py` + `budget.py`)
+
+Pure Python evaluation. Loads pricing data at init, tracks an in-memory turn cache for idempotent retries, and returns JSON-serializable payloads. No network calls.
+
+| action | Purpose |
+|--------|---------|
+| `check` (default) | Evaluate cumulative token usage against limits |
+| `reset` | Clear cached turn results for a `task_id` |
+
+### The Mind (`instructions.md`)
+
+Tells the host agent when to call the tool, that cumulative counts are required, and that `FORCE_TERMINATE` means stop the loop immediately.
+
+## Integration Guide
+
+### Environment
+
+No skill-specific environment variables. The host loop supplies token counts from provider usage metadata.
+
+Configure agent keys per [API keys for skills](../usage/api_keys.md) when running provider loop examples.
+
+## Cost metrics
+
+Indicative USD rates live in `skills/monitoring/token_limiter/data/model_pricing.json`. They are **not** invoice-grade. Refresh the file when public list prices change.
+
+| Model ID | Input USD / 1M | Output USD / 1M |
+| :--- | ---: | ---: |
+| `gpt-4o` | 2.50 | 10.00 |
+| `gpt-4o-mini` | 0.15 | 0.60 |
+| `claude-3-5-sonnet-latest` | 3.00 | 15.00 |
+| `claude-3-5-haiku-latest` | 0.80 | 4.00 |
+| `gemini-2.5-flash` | 0.15 | 0.60 |
+| `gemini-2.5-flash-lite` | 0.075 | 0.30 |
+| `deepseek-chat` | 0.27 | 1.10 |
+| Unknown models | Fallback blended 5.00 USD / 1M | |
+
+## Usage Examples
+
+Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). No skill-specific API keys.
+
+Sample user message: *Check whether task `scrape_amazon_listings_101` should continue; it has used 125000 tokens with a 100000 limit.*
+
+### Runnable examples
+
+| Script | Provider | Env vars |
+| :--- | :--- | :--- |
+| [`token_limiter_loop.py`](../../examples/token_limiter_loop.py) | Local execute | None |
+| [`gemini_token_limiter.py`](../../examples/gemini_token_limiter.py) | Gemini | Optional `GOOGLE_API_KEY` for Phase 2 |
+| [`claude_token_limiter.py`](../../examples/claude_token_limiter.py) | Claude | Optional `ANTHROPIC_API_KEY` for Phase 2 |
+
+Phase 1 in the provider scripts runs the deterministic local loop without API keys. Phase 2 calls the live model when the provider key is set.
+
+See [examples/README.md](../../examples/README.md) and [Agent loops](../usage/agent_loops.md).
+
+### Direct execute
+
+```python
+from skillware.core.loader import SkillLoader
+
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+result = skill.execute({
+    "task_id": "scrape_amazon_listings_101",
+    "current_token_count": 125_000,
+    "max_allowed_tokens": 100_000,
+    "model_id": "gpt-4o",
+})
+# result["action"] == "FORCE_TERMINATE"
+print(result["reason"])
+```
+
+### Gemini
+
+```python
+import os
+import google.genai as genai
+from google.genai import types
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+client = genai.Client()
+tool_decl = SkillLoader.to_gemini_tool(bundle)
+tool_decl["name"] = SkillLoader._sanitize_function_tool_name("monitoring/token_limiter")
+gemini_tool = types.Tool(function_declarations=[tool_decl])
+response = client.models.generate_content(
+    model="gemini-2.5-flash-lite",
+    contents=(
+        "Check task scrape_amazon_listings_101: 125000 tokens used, limit 100000."
+    ),
+    config=types.GenerateContentConfig(
+        tools=[gemini_tool],
+        system_instruction=bundle["instructions"],
+    ),
+)
+for part in response.candidates[0].content.parts:
+    if part.function_call:
+        result = skill.execute(dict(part.function_call.args))
+        print(result["action"], result["reason"])
+```
+
+### Claude
+
+```python
+import os
+import anthropic
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+tools = [SkillLoader.to_claude_tool(bundle)]
+response = client.messages.create(
+    model="claude-3-5-haiku-latest",
+    max_tokens=1024,
+    system=bundle["instructions"],
+    tools=tools,
+    messages=[{
+        "role": "user",
+        "content": (
+            "Check task scrape_amazon_listings_101: 125000 tokens used, limit 100000."
+        ),
+    }],
+)
+for block in response.content:
+    if block.type == "tool_use":
+        result = skill.execute(dict(block.input))
+        print(result["action"], result["reason"])
+```
+
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+tool = SkillLoader.to_openai_tool(bundle)
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {"role": "system", "content": bundle["instructions"]},
+        {
+            "role": "user",
+            "content": (
+                "Check task scrape_amazon_listings_101: 125000 tokens used, limit 100000."
+            ),
+        },
+    ],
+    tools=[tool],
+)
+message = response.choices[0].message
+if message.tool_calls:
+    import json
+    args = json.loads(message.tool_calls[0].function.arguments)
+    result = skill.execute(args)
+    print(result["action"], result["reason"])
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+tool = SkillLoader.to_deepseek_tool(bundle)
+response = client.chat.completions.create(
+    model="deepseek-chat",
+    messages=[
+        {"role": "system", "content": bundle["instructions"]},
+        {
+            "role": "user",
+            "content": (
+                "Check task scrape_amazon_listings_101: 125000 tokens used, limit 100000."
+            ),
+        },
+    ],
+    tools=[tool],
+)
+message = response.choices[0].message
+if message.tool_calls:
+    import json
+    args = json.loads(message.tool_calls[0].function.arguments)
+    result = skill.execute(args)
+    print(result["action"], result["reason"])
+```
+
+### Ollama (prompt mode)
+
+```python
+import json
+from skillware.core.loader import SkillLoader
+
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["module"].TokenLimiterSkill()
+prompt = (
+    "You may call tools as JSON blocks.\n"
+    f"Tool: {bundle['manifest']['name']}\n"
+    f"Instructions:\n{bundle['instructions']}\n"
+    "User: Check task scrape_amazon_listings_101 with 125000 tokens and limit 100000."
+)
+print(prompt)
+# When the model emits JSON tool args, pass them to execute:
+result = skill.execute({
+    "task_id": "scrape_amazon_listings_101",
+    "current_token_count": 125_000,
+    "max_allowed_tokens": 100_000,
+})
+print(json.dumps(result, indent=2))
+```
+
+## Limitations
+
+- Host must track **cumulative** token counts; the skill does not read provider usage APIs.
+- Cost figures are estimates from bundled list prices, not billing records.
+- ROI fields are scaffold-only in v1; only token limits trigger `FORCE_TERMINATE`.
+- Turn cache is in-memory per skill instance; restart the process to clear all cache.

--- a/docs/skills/token_limiter.md
+++ b/docs/skills/token_limiter.md
@@ -10,6 +10,8 @@ A deterministic **token budget gate** for autonomous agent loops. After each mod
 
 This skill does **not** kill processes, cancel provider sessions, or call billing APIs. It returns a structured decision the orchestrator acts on.
 
+> **Budget disclaimer:** This skill provides an operational budget signal only. It is not billing authority, financial advice, or a guarantee that spend is within budget. A `CONTINUE` result does not approve further spend; the host loop must track token usage from your provider or tokenizer and act on `FORCE_TERMINATE`. Cost estimates use bundled list prices and may differ from invoices.
+
 ## Capabilities
 
 - **Hard token ceiling**: Terminates (signals termination) when cumulative tokens reach `max_allowed_tokens`.
@@ -253,7 +255,14 @@ print(json.dumps(result, indent=2))
 
 ## Limitations
 
-- Host must track **cumulative** token counts; the skill does not read provider usage APIs.
+- **Provider-agnostic integration**: Works with any agent loop (local Ollama, cloud APIs, custom orchestrators) as long as the host passes cumulative `current_token_count`; the skill does not read provider usage APIs.
+- **Not billing authority**: Budget decisions are heuristic signals based on counts you supply and optional indicative pricing. They do not replace provider dashboards, invoices, or finance controls.
 - Cost figures are estimates from bundled list prices, not billing records.
 - ROI fields are scaffold-only in v1; only token limits trigger `FORCE_TERMINATE`.
 - Turn cache is in-memory per skill instance; restart the process to clear all cache.
+
+---
+
+## Enterprise disclaimer
+
+This skill is provided for demonstration and integration purposes. It is intended as a starting point that you can adapt to your own budgets, token accounting, and operational requirements. For an enterprise-grade version of this skill with dedicated support, SLAs, and customization, contact skills@arpacorp.net.

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -68,4 +68,5 @@ skills in one harness.
 | `dev_tools/issue_resolver` | - | `gemini_issue_resolver.py` | `claude_issue_resolver.py` | (catalog page) | (catalog page) | `ollama_issue_resolver.py` |
 | `wellness/mental_coach` | `mental_coach_demo.py` (local execute) | (catalog page) | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
 | `defi/evm_tx_handler` | - | `gemini_evm_tx_handler.py` | `claude_evm_tx_handler.py` | - | - | - |
+| `monitoring/token_limiter` | `token_limiter_loop.py` (local execute) | `gemini_token_limiter.py` | `claude_token_limiter.py` | (catalog page) | (catalog page) | (catalog page) |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,6 +51,9 @@ with editable install: `pip install -e ".[gemini]"`.
 | `ollama_novelty_extractor.py` | `data_engineering/novelty_extractor` | Ollama | `pip install fastembed numpy`; install `ollama` separately | None | Runs the novelty extractor with local Ollama prompt-mode calls. |
 | `gemini_issue_resolver.py` | `dev_tools/issue_resolver` | Gemini | `[gemini]` | `GOOGLE_API_KEY`; optional `GITHUB_TOKEN` | Gemini loop for GitHub issue analysis; fetches issue data after `prepare` (sample: issue #123). |
 | `ollama_issue_resolver.py` | `dev_tools/issue_resolver` | Ollama | No Skillware extra; install `ollama` separately | optional `GITHUB_TOKEN`; `OLLAMA_MODEL` (default `gemma4:e2b`) | Ollama prompt-mode loop for GitHub issue analysis (sample: issue #123). |
+| `token_limiter_loop.py` | `monitoring/token_limiter` | Local execute | base install only | None | Simulates a runaway task hitting a token ceiling with deterministic budget checks. |
+| `gemini_token_limiter.py` | `monitoring/token_limiter` | Gemini | `[gemini]` | Optional `GOOGLE_API_KEY` for Phase 2 live loop | Local budget simulation plus optional Gemini tool loop. |
+| `claude_token_limiter.py` | `monitoring/token_limiter` | Claude | `[claude]` | Optional `ANTHROPIC_API_KEY` for Phase 2 live loop | Local budget simulation plus optional Claude tool loop. |
 
 ## Notes
 

--- a/examples/claude_token_limiter.py
+++ b/examples/claude_token_limiter.py
@@ -1,0 +1,80 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from token_limiter_common import simulate_budget_loop  # noqa: E402
+
+from skillware.core.env import load_env_file  # noqa: E402
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+SKILL_ID = "monitoring/token_limiter"
+
+
+def run_local_simulation(skill) -> None:
+    print("Phase 1: local deterministic budget loop (no LLM)...")
+    simulate_budget_loop(
+        skill,
+        task_id="claude_scrape_demo",
+        max_allowed_tokens=50_000,
+        turn_deltas=[15_000, 15_000, 15_000, 10_000],
+        model_id="claude-3-5-sonnet-latest",
+    )
+
+
+def run_claude_loop(skill, bundle) -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("Skipping live Claude demo: ANTHROPIC_API_KEY is not set.")
+        return
+
+    print("\nPhase 2: Claude tool loop with budget check...")
+    client = anthropic.Anthropic(api_key=api_key)
+    tools = [SkillLoader.to_claude_tool(bundle)]
+    system = bundle["instructions"]
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-3-5-haiku-latest")
+
+    user_query = (
+        "You are running a bounded scrape task with task_id claude_scrape_demo. "
+        "Call monitoring/token_limiter with current_token_count 125000 and "
+        "max_allowed_tokens 100000, then explain whether the loop should stop."
+    )
+    print(f"User: {user_query}")
+
+    response = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=system,
+        tools=tools,
+        messages=[{"role": "user", "content": user_query}],
+    )
+
+    tool_uses = [block for block in response.content if block.type == "tool_use"]
+    if not tool_uses:
+        print("Model did not request the budget tool.")
+        for block in response.content:
+            if hasattr(block, "text"):
+                print(block.text)
+        return
+
+    tool_use = tool_uses[0]
+    print(f"Claude requested tool: {tool_use.name}")
+    print(f"Input: {tool_use.input}")
+    result = skill.execute(dict(tool_use.input))
+    print(json.dumps(result, indent=2))
+
+
+def run_demo(live_claude: bool = True) -> None:
+    load_env_file()
+    bundle = SkillLoader.load_skill(SKILL_ID)
+    skill = bundle["module"].TokenLimiterSkill()
+    run_local_simulation(skill)
+    if live_claude:
+        run_claude_loop(skill, bundle)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/gemini_token_limiter.py
+++ b/examples/gemini_token_limiter.py
@@ -1,0 +1,81 @@
+import json
+import os
+import sys
+from pathlib import Path
+import google.genai as genai
+from google.genai import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from token_limiter_common import simulate_budget_loop  # noqa: E402
+
+from skillware.core.env import load_env_file  # noqa: E402
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+SKILL_ID = "monitoring/token_limiter"
+
+
+def run_local_simulation(skill) -> None:
+    print("Phase 1: local deterministic budget loop (no LLM)...")
+    simulate_budget_loop(
+        skill,
+        task_id="gemini_scrape_demo",
+        max_allowed_tokens=50_000,
+        turn_deltas=[15_000, 15_000, 15_000, 10_000],
+        model_id="gemini-2.5-flash",
+    )
+
+
+def run_gemini_loop(skill, bundle) -> None:
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print("Skipping live Gemini demo: GOOGLE_API_KEY is not set.")
+        return
+
+    print("\nPhase 2: Gemini tool loop with budget check...")
+    client = genai.Client()
+    tool_decl = SkillLoader.to_gemini_tool(bundle)
+    tool_decl["name"] = SkillLoader._sanitize_function_tool_name(SKILL_ID)
+    gemini_tool = types.Tool(function_declarations=[tool_decl])
+    system_instruction = bundle["instructions"]
+    model = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+    user_query = (
+        "You are running a bounded scrape task with task_id gemini_scrape_demo. "
+        "Call monitoring/token_limiter with current_token_count 125000 and "
+        "max_allowed_tokens 100000, then explain whether the loop should stop."
+    )
+    print(f"User: {user_query}")
+
+    response = client.models.generate_content(
+        model=model,
+        contents=[user_query],
+        config=types.GenerateContentConfig(
+            tools=[gemini_tool],
+            system_instruction=system_instruction,
+        ),
+    )
+
+    part = response.candidates[0].content.parts[0]
+    if not part.function_call:
+        print("Model did not request the budget tool.")
+        print(response.text)
+        return
+
+    fn_args = dict(part.function_call.args)
+    print(f"Gemini requested tool: {part.function_call.name}")
+    print(f"Input: {fn_args}")
+    result = skill.execute(fn_args)
+    print(json.dumps(result, indent=2))
+
+
+def run_demo(live_gemini: bool = True) -> None:
+    load_env_file()
+    bundle = SkillLoader.load_skill(SKILL_ID)
+    skill = bundle["module"].TokenLimiterSkill()
+    run_local_simulation(skill)
+    if live_gemini:
+        run_gemini_loop(skill, bundle)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/token_limiter_common.py
+++ b/examples/token_limiter_common.py
@@ -1,0 +1,40 @@
+"""Shared helpers for token hard limit examples."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+def simulate_budget_loop(
+    skill: Any,
+    *,
+    task_id: str,
+    max_allowed_tokens: int,
+    turn_deltas: List[int],
+    model_id: str = "gpt-4o",
+) -> List[Dict[str, Any]]:
+    """Simulate an agent loop that checks the budget after each turn."""
+    cumulative = 0
+    results: List[Dict[str, Any]] = []
+
+    for index, delta in enumerate(turn_deltas, start=1):
+        cumulative += delta
+        result = skill.execute(
+            {
+                "task_id": task_id,
+                "turn_id": f"turn-{index}",
+                "current_token_count": cumulative,
+                "max_allowed_tokens": max_allowed_tokens,
+                "model_id": model_id,
+                "input_tokens": delta // 2,
+                "output_tokens": delta - (delta // 2),
+            }
+        )
+        results.append(result)
+        print(f"Turn {index}: action={result['action']} tokens={cumulative}")
+        print(json.dumps(result, indent=2))
+        if result.get("action") == "FORCE_TERMINATE":
+            break
+
+    return results

--- a/examples/token_limiter_loop.py
+++ b/examples/token_limiter_loop.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from token_limiter_common import simulate_budget_loop  # noqa: E402
+
+from skillware.core.loader import SkillLoader  # noqa: E402
+
+
+def run_demo() -> None:
+    bundle = SkillLoader.load_skill("monitoring/token_limiter")
+    skill = bundle["module"].TokenLimiterSkill()
+
+    print("Simulating a runaway scrape task with a 100k token ceiling...")
+    results = simulate_budget_loop(
+        skill,
+        task_id="scrape_amazon_listings_101",
+        max_allowed_tokens=100_000,
+        turn_deltas=[30_000, 30_000, 30_000, 20_000],
+    )
+
+    final = results[-1]
+    assert final["action"] == "FORCE_TERMINATE"
+    print("\nLoop stopped as expected:")
+    print(final["reason"])
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/skills/monitoring/__init__.py
+++ b/skills/monitoring/__init__.py
@@ -1,0 +1,1 @@
+# Monitoring skills package.

--- a/skills/monitoring/token_limiter/__init__.py
+++ b/skills/monitoring/token_limiter/__init__.py
@@ -1,0 +1,1 @@
+# Token hard limit skill package.

--- a/skills/monitoring/token_limiter/budget.py
+++ b/skills/monitoring/token_limiter/budget.py
@@ -1,0 +1,286 @@
+"""Deterministic token budget evaluation for agent loops."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+SCHEMA_VERSION = "1.0"
+DEFAULT_SOFT_THRESHOLD_PCT = 80.0
+VALID_ACTIONS = frozenset({"check", "reset"})
+VALID_DECISIONS = frozenset({"CONTINUE", "WARN", "FORCE_TERMINATE"})
+
+
+def utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def load_pricing(data_dir: str) -> Dict[str, Any]:
+    pricing_path = os.path.join(data_dir, "model_pricing.json")
+    with open(pricing_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _positive_int(value: Any, field: str) -> Tuple[Optional[int], Optional[str]]:
+    if value is None:
+        return None, f"{field} is required."
+    if isinstance(value, bool):
+        return None, f"{field} must be an integer."
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None, f"{field} must be an integer."
+    if parsed < 0:
+        return None, f"{field} must be zero or greater."
+    return parsed, None
+
+
+def _optional_non_negative_int(
+    value: Any, field: str
+) -> Tuple[Optional[int], Optional[str]]:
+    if value is None:
+        return None, None
+    return _positive_int(value, field)
+
+
+def _soft_threshold_pct(value: Any) -> Tuple[float, Optional[str]]:
+    if value is None:
+        return DEFAULT_SOFT_THRESHOLD_PCT, None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_SOFT_THRESHOLD_PCT, "soft_threshold_pct must be a number."
+    if parsed <= 0 or parsed > 100:
+        return (
+            DEFAULT_SOFT_THRESHOLD_PCT,
+            "soft_threshold_pct must be between 0 and 100.",
+        )
+    return parsed, None
+
+
+def estimate_cost_usd(
+    pricing: Dict[str, Any],
+    model_id: Optional[str],
+    current_token_count: int,
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+) -> Tuple[Optional[float], List[str]]:
+    warnings: List[str] = []
+    if not model_id:
+        return None, warnings
+
+    models = pricing.get("models", {})
+    model_key = str(model_id).strip()
+    rates = models.get(model_key)
+
+    if rates is None:
+        fallback = pricing.get("fallback", {})
+        blended = float(fallback.get("blended_usd_per_1m", 5.0))
+        warnings.append(
+            f"Unknown model_id {model_key!r}; using fallback blended rate "
+            f"{blended} USD per 1M tokens."
+        )
+        cost = (current_token_count / 1_000_000.0) * blended
+        return round(cost, 6), warnings
+
+    input_rate = float(rates.get("input_usd_per_1m", 0.0))
+    output_rate = float(rates.get("output_usd_per_1m", 0.0))
+
+    if input_tokens is None and output_tokens is None:
+        input_tokens = current_token_count // 2
+        output_tokens = current_token_count - input_tokens
+        warnings.append(
+            "input_tokens and output_tokens were not provided; "
+            "assuming a 50/50 split for cost estimation."
+        )
+    elif input_tokens is None:
+        input_tokens = max(0, current_token_count - int(output_tokens))
+    elif output_tokens is None:
+        output_tokens = max(0, current_token_count - int(input_tokens))
+
+    cost = (input_tokens / 1_000_000.0) * input_rate + (
+        output_tokens / 1_000_000.0
+    ) * output_rate
+    return round(cost, 6), warnings
+
+
+def build_roi_scaffold(
+    params: Dict[str, Any], cost_usd: Optional[float]
+) -> Dict[str, Any]:
+    roi_value = params.get("roi_value_usd")
+    expected_outcome = params.get("expected_outcome")
+    outcome_delivered = params.get("outcome_delivered")
+
+    scaffold: Dict[str, Any] = {
+        "enabled": False,
+        "status": "not_evaluated",
+        "notes": (
+            "ROI enforcement is not active in v1. Token limits are the sole "
+            "termination trigger. Future versions may compare expected_outcome "
+            "and outcome_delivered against token spend."
+        ),
+    }
+
+    if roi_value is not None or expected_outcome or outcome_delivered is not None:
+        scaffold["enabled"] = True
+        scaffold["roi_value_usd"] = roi_value
+        scaffold["expected_outcome"] = expected_outcome
+        scaffold["outcome_delivered"] = outcome_delivered
+        scaffold["cost_incurred_usd"] = cost_usd
+        scaffold["status"] = "scaffold_only"
+
+    return scaffold
+
+
+def evaluate_budget(
+    params: Dict[str, Any],
+    pricing: Dict[str, Any],
+    turn_cache: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    action = (params.get("action") or "check").strip().lower()
+    if action not in VALID_ACTIONS:
+        return {
+            "status": "error",
+            "message": f"Invalid action {action!r}. Expected one of: check, reset.",
+        }
+
+    task_id = (params.get("task_id") or "").strip()
+    if not task_id:
+        return {"status": "error", "message": "task_id is required."}
+
+    if action == "reset":
+        prefix = f"{task_id}|"
+        keys_to_delete = [key for key in turn_cache if key.startswith(prefix)]
+        for key in keys_to_delete:
+            del turn_cache[key]
+        return {
+            "status": "ready",
+            "schema_version": SCHEMA_VERSION,
+            "action": "RESET",
+            "task_id": task_id,
+            "message": f"Cleared {len(keys_to_delete)} cached turn result(s) for task.",
+            "timestamp": utc_now_iso(),
+        }
+
+    current_token_count, err = _positive_int(
+        params.get("current_token_count"), "current_token_count"
+    )
+    if err:
+        return {"status": "error", "message": err}
+
+    max_allowed_tokens, err = _positive_int(
+        params.get("max_allowed_tokens"), "max_allowed_tokens"
+    )
+    if err:
+        return {"status": "error", "message": err}
+
+    if max_allowed_tokens == 0:
+        return {
+            "status": "error",
+            "message": "max_allowed_tokens must be greater than zero.",
+        }
+
+    soft_threshold_pct, soft_err = _soft_threshold_pct(params.get("soft_threshold_pct"))
+    turn_id = (params.get("turn_id") or "").strip()
+    cache_key = f"{task_id}|{turn_id}|{current_token_count}|{max_allowed_tokens}"
+
+    if turn_id and cache_key in turn_cache:
+        cached = dict(turn_cache[cache_key])
+        cached["metadata"] = dict(cached.get("metadata", {}))
+        cached["metadata"]["cache_hit"] = True
+        return cached
+
+    input_tokens, input_err = _optional_non_negative_int(
+        params.get("input_tokens"), "input_tokens"
+    )
+    if input_err:
+        return {"status": "error", "message": input_err}
+
+    output_tokens, output_err = _optional_non_negative_int(
+        params.get("output_tokens"), "output_tokens"
+    )
+    if output_err:
+        return {"status": "error", "message": output_err}
+
+    model_id = (params.get("model_id") or "").strip() or None
+    cost_usd, cost_warnings = estimate_cost_usd(
+        pricing,
+        model_id,
+        current_token_count,
+        input_tokens,
+        output_tokens,
+    )
+
+    utilization_pct = round((current_token_count / max_allowed_tokens) * 100.0, 2)
+    tokens_over_budget = max(0, current_token_count - max_allowed_tokens)
+    soft_limit = int(max_allowed_tokens * (soft_threshold_pct / 100.0))
+
+    warnings: List[str] = []
+    if soft_err:
+        warnings.append(soft_err)
+    warnings.extend(cost_warnings)
+
+    if current_token_count >= max_allowed_tokens:
+        decision = "FORCE_TERMINATE"
+        reason = (
+            f"Token budget exceeded by {tokens_over_budget} "
+            f"({utilization_pct}% of limit)."
+        )
+    elif current_token_count >= soft_limit:
+        decision = "WARN"
+        reason = (
+            f"Token utilization at {utilization_pct}% "
+            f"(soft threshold {soft_threshold_pct}%)."
+        )
+    else:
+        decision = "CONTINUE"
+        reason = (
+            f"Token utilization at {utilization_pct}% "
+            f"({current_token_count}/{max_allowed_tokens})."
+        )
+
+    roi = build_roi_scaffold(params, cost_usd)
+
+    result: Dict[str, Any] = {
+        "status": "ready",
+        "schema_version": SCHEMA_VERSION,
+        "action": decision,
+        "task_id": task_id,
+        "reason": reason,
+        "budget": {
+            "current_token_count": current_token_count,
+            "max_allowed_tokens": max_allowed_tokens,
+            "utilization_pct": utilization_pct,
+            "tokens_over_budget": tokens_over_budget,
+            "soft_threshold_pct": soft_threshold_pct,
+            "soft_limit_tokens": soft_limit,
+        },
+        "cost": {
+            "incurred_usd": cost_usd,
+            "model_id": model_id,
+            "pricing_source": "data/model_pricing.json",
+            "pricing_last_updated": pricing.get("last_updated"),
+        },
+        "roi": roi,
+        "metadata": {
+            "warnings": warnings,
+            "turn_id": turn_id or None,
+            "cache_hit": False,
+            "host_responsibility": (
+                "The host loop must stop when action is FORCE_TERMINATE."
+            ),
+        },
+        "timestamp": utc_now_iso(),
+    }
+
+    if turn_id:
+        turn_cache[cache_key] = dict(result)
+
+    return result

--- a/skills/monitoring/token_limiter/card.json
+++ b/skills/monitoring/token_limiter/card.json
@@ -1,0 +1,22 @@
+{
+  "name": "Token Limiter",
+  "description": "Budget gate for autonomous agent loops. Returns CONTINUE, WARN, or FORCE_TERMINATE.",
+  "issuer": {
+    "name": "Ross Peili",
+    "email": "vpeilivanidis@gmail.com",
+    "github": "rosspeili",
+    "org": "ARPAHLS"
+  },
+  "icon": "activity",
+  "color": "orange",
+  "ui_schema": {
+    "type": "card",
+    "fields": [
+      {"key": "task_id", "label": "Task"},
+      {"key": "action", "label": "Decision", "type": "status_badge"},
+      {"key": "budget.utilization_pct", "label": "Utilization %", "type": "percent"},
+      {"key": "budget.current_token_count", "label": "Tokens Used", "type": "count"},
+      {"key": "cost.incurred_usd", "label": "Est. Cost (USD)", "type": "currency"}
+    ]
+  }
+}

--- a/skills/monitoring/token_limiter/data/model_pricing.json
+++ b/skills/monitoring/token_limiter/data/model_pricing.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.0",
+  "last_updated": "2026-05-24",
+  "currency": "USD",
+  "notes": "Indicative public list prices for cost estimates only. Not billing-grade.",
+  "models": {
+    "gpt-4o": {
+      "input_usd_per_1m": 2.5,
+      "output_usd_per_1m": 10.0
+    },
+    "gpt-4o-mini": {
+      "input_usd_per_1m": 0.15,
+      "output_usd_per_1m": 0.6
+    },
+    "claude-3-5-sonnet-latest": {
+      "input_usd_per_1m": 3.0,
+      "output_usd_per_1m": 15.0
+    },
+    "claude-3-5-haiku-latest": {
+      "input_usd_per_1m": 0.8,
+      "output_usd_per_1m": 4.0
+    },
+    "gemini-2.5-flash": {
+      "input_usd_per_1m": 0.15,
+      "output_usd_per_1m": 0.6
+    },
+    "gemini-2.5-flash-lite": {
+      "input_usd_per_1m": 0.075,
+      "output_usd_per_1m": 0.3
+    },
+    "deepseek-chat": {
+      "input_usd_per_1m": 0.27,
+      "output_usd_per_1m": 1.1
+    }
+  },
+  "fallback": {
+    "blended_usd_per_1m": 5.0
+  }
+}

--- a/skills/monitoring/token_limiter/instructions.md
+++ b/skills/monitoring/token_limiter/instructions.md
@@ -1,0 +1,42 @@
+# Cognition Instructions: Token Limiter
+
+You have access to the `monitoring/token_limiter` tool.
+
+This skill is a **budget gate** for long-running autonomous loops. It does **not** stop the loop itself. After each model turn (or before the next one), call it with the **cumulative** token count for the task. If the result is `FORCE_TERMINATE`, you must **stop the loop immediately** and report the reason to the operator.
+
+## When to use this skill
+
+- Before starting a high-risk autonomous task (scraping, multi-step research, codegen loops).
+- After **every** model turn in a loop where token spend must stay bounded.
+- When the operator sets a maximum token budget for a task.
+
+## Required host behavior
+
+1. Track `task_id` for the session and pass **cumulative** `current_token_count` (not just the last turn delta unless you maintain the running total yourself).
+2. Set `max_allowed_tokens` from operator policy or task metadata.
+3. On `action: WARN`, consider narrowing scope, compressing context, or asking the operator before continuing.
+4. On `action: FORCE_TERMINATE`, **do not** call the main model again for this task. Return the skill payload to the dashboard or user.
+
+## Parameters
+
+| Field | Required | Notes |
+| :--- | :--- | :--- |
+| `task_id` | Yes | Stable task identifier |
+| `current_token_count` | Yes (check) | Cumulative tokens used so far |
+| `max_allowed_tokens` | Yes (check) | Hard ceiling |
+| `turn_id` | No | Use for idempotent retries of the same turn |
+| `model_id` | No | Enables indicative USD cost in the response |
+| `soft_threshold_pct` | No | Default 80; triggers WARN before hard limit |
+
+## ROI scaffold (v2, not enforced)
+
+Optional fields `roi_value_usd`, `expected_outcome`, and `outcome_delivered` are accepted for future ROI logic. **v1 never terminates on ROI alone.** Token limits are the only termination trigger today.
+
+## Interpreting the response
+
+- `CONTINUE`: Under the soft threshold. Proceed with the next turn.
+- `WARN`: Approaching the limit. Tighten scope or warn the operator.
+- `FORCE_TERMINATE`: Hard limit reached. Stop the loop and surface `reason`.
+- `RESET`: Administrative action clearing cached turn results for a `task_id`.
+
+Cost figures in `cost.incurred_usd` are **indicative** estimates from bundled list prices, not invoice amounts.

--- a/skills/monitoring/token_limiter/manifest.yaml
+++ b/skills/monitoring/token_limiter/manifest.yaml
@@ -1,0 +1,74 @@
+name: "monitoring/token_limiter"
+version: "1.0.0"
+description: "Deterministic token budget gate for autonomous agent loops. Returns CONTINUE, WARN, or FORCE_TERMINATE so the host loop can stop runaway tasks before they exhaust context or budget."
+short_description: "Token budget gate: CONTINUE, WARN, or FORCE_TERMINATE for agent loops."
+issuer:
+  name: Ross Peili
+  email: vpeilivanidis@gmail.com
+  github: rosspeili
+  org: ARPAHLS
+category: "monitoring"
+requirements: []
+parameters:
+  type: object
+  properties:
+    action:
+      type: string
+      description: "Workflow action: check (default) evaluates the budget; reset clears cached turn results for task_id."
+      enum:
+        - check
+        - reset
+    task_id:
+      type: string
+      description: "Stable identifier for the autonomous task or agent session."
+    current_token_count:
+      type: integer
+      description: "Cumulative token count for the task so far. The host loop must track and pass the running total."
+    max_allowed_tokens:
+      type: integer
+      description: "Hard token ceiling for the task. At or above this value the skill returns FORCE_TERMINATE."
+    soft_threshold_pct:
+      type: number
+      description: "Optional warning threshold as a percentage of max_allowed_tokens. Default 80."
+    turn_id:
+      type: string
+      description: "Optional turn identifier for idempotent retries. Same task_id, turn_id, and counts return the cached decision."
+    model_id:
+      type: string
+      description: "Optional model name for indicative USD cost estimates (for example gpt-4o, gemini-2.5-flash)."
+    input_tokens:
+      type: integer
+      description: "Optional input tokens for this turn or cumulative split when estimating cost."
+    output_tokens:
+      type: integer
+      description: "Optional output tokens for this turn or cumulative split when estimating cost."
+    roi_value_usd:
+      type: number
+      description: "Optional scaffold for future ROI checks. Not enforced in v1."
+    expected_outcome:
+      type: string
+      description: "Optional scaffold describing the deliverable expected from the task (v2 ROI)."
+    outcome_delivered:
+      type: boolean
+      description: "Optional scaffold indicating whether the expected outcome was delivered (v2 ROI)."
+  required: []
+outputs:
+  status:
+    type: string
+    description: "ready or error."
+  action:
+    type: string
+    description: "CONTINUE, WARN, FORCE_TERMINATE, or RESET."
+  reason:
+    type: string
+    description: "Human-readable explanation of the decision."
+constitution: |
+  1. INFORMATIONAL ONLY: Output is a budget signal, not billing authority or legal clearance.
+  2. HOST RESPONSIBILITY: The calling loop must stop when action is FORCE_TERMINATE.
+  3. DETERMINISM: Same inputs produce the same decision (except timestamp).
+  4. PRIVACY: Do not accept or store prompt content; only metrics and task identifiers.
+  5. TOKEN FIRST: v1 terminates only on token hard limits. ROI fields are scaffold-only.
+  6. NO SIDE EFFECTS: Do not spawn background tasks, network calls, or process kills.
+presentation:
+  icon: "activity"
+  color: "#E67E22"

--- a/skills/monitoring/token_limiter/skill.py
+++ b/skills/monitoring/token_limiter/skill.py
@@ -1,0 +1,60 @@
+import importlib.util
+import os
+from typing import Any, Dict, Optional
+
+from skillware.core.base_skill import BaseSkill
+
+
+def _import_budget():
+    try:
+        from . import budget as budget_module  # type: ignore[import-not-found]
+    except ImportError:
+        budget_path = os.path.join(os.path.dirname(__file__), "budget.py")
+        spec = importlib.util.spec_from_file_location(
+            "token_limiter_budget", budget_path
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load budget module from {budget_path}")
+        budget_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(budget_module)
+    return budget_module
+
+
+_budget = _import_budget()
+evaluate_budget = _budget.evaluate_budget
+load_pricing = _budget.load_pricing
+SCHEMA_VERSION = _budget.SCHEMA_VERSION
+
+
+class TokenLimiterSkill(BaseSkill):
+    """
+    Deterministic token budget gate for autonomous agent loops.
+
+    The skill does not terminate host processes or provider sessions itself.
+    It returns CONTINUE, WARN, or FORCE_TERMINATE and the host loop must act.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        super().__init__(config)
+        self._data_dir = os.path.join(os.path.dirname(__file__), "data")
+        self._pricing = load_pricing(self._data_dir)
+        self._turn_cache: Dict[str, Dict[str, Any]] = {}
+
+    @property
+    def manifest(self) -> Dict[str, Any]:
+        manifest_path = os.path.join(os.path.dirname(__file__), "manifest.yaml")
+        if os.path.exists(manifest_path):
+            import yaml
+
+            with open(manifest_path, "r", encoding="utf-8") as handle:
+                return yaml.safe_load(handle)
+        return {}
+
+    def execute(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return evaluate_budget(params, self._pricing, self._turn_cache)
+        except Exception as exc:
+            return {
+                "status": "error",
+                "message": f"Token budget evaluation failed: {exc}",
+            }

--- a/skills/monitoring/token_limiter/test_skill.py
+++ b/skills/monitoring/token_limiter/test_skill.py
@@ -1,0 +1,174 @@
+import json
+import os
+
+import pytest
+import yaml
+
+from .skill import TokenLimiterSkill, SCHEMA_VERSION
+
+
+@pytest.fixture
+def skill():
+    return TokenLimiterSkill()
+
+
+@pytest.fixture
+def manifest():
+    manifest_path = os.path.join(os.path.dirname(__file__), "manifest.yaml")
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+@pytest.fixture
+def card():
+    card_path = os.path.join(os.path.dirname(__file__), "card.json")
+    with open(card_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_manifest_name(skill, manifest):
+    assert skill.manifest["name"] == manifest["name"]
+    assert manifest["name"] == "monitoring/token_limiter"
+
+
+def test_manifest_version(skill, manifest):
+    assert skill.manifest["version"] == manifest["version"]
+
+
+def test_manifest_has_real_issuer(manifest):
+    issuer = manifest.get("issuer", {})
+    assert issuer.get("name")
+    assert issuer.get("email")
+    assert issuer["name"].lower() != "your name"
+    assert issuer["email"].lower() != "you@example.com"
+
+
+def test_card_issuer_matches_manifest(manifest, card):
+    m_issuer = manifest.get("issuer", {})
+    c_issuer = card.get("issuer", {})
+    assert c_issuer.get("name") == m_issuer.get("name")
+    assert c_issuer.get("email") == m_issuer.get("email")
+
+
+def test_missing_task_id_returns_error(skill):
+    result = skill.execute({"current_token_count": 10, "max_allowed_tokens": 100})
+    assert result["status"] == "error"
+    assert "task_id" in result["message"].lower()
+
+
+def test_continue_under_soft_threshold(skill):
+    result = skill.execute(
+        {
+            "task_id": "task-1",
+            "current_token_count": 50_000,
+            "max_allowed_tokens": 100_000,
+        }
+    )
+    assert result["status"] == "ready"
+    assert result["action"] == "CONTINUE"
+    assert result["schema_version"] == SCHEMA_VERSION
+
+
+def test_warn_at_soft_threshold(skill):
+    result = skill.execute(
+        {
+            "task_id": "task-warn",
+            "current_token_count": 80_000,
+            "max_allowed_tokens": 100_000,
+            "soft_threshold_pct": 80,
+        }
+    )
+    assert result["action"] == "WARN"
+    assert result["budget"]["utilization_pct"] == 80.0
+
+
+def test_force_terminate_over_limit(skill):
+    result = skill.execute(
+        {
+            "task_id": "scrape_amazon_listings_101",
+            "current_token_count": 125_000,
+            "max_allowed_tokens": 100_000,
+            "model_id": "gpt-4o",
+            "roi_value_usd": 2.50,
+        }
+    )
+    assert result["action"] == "FORCE_TERMINATE"
+    assert result["budget"]["tokens_over_budget"] == 25_000
+    assert "25" in result["reason"]
+    assert result["cost"]["incurred_usd"] is not None
+    assert result["roi"]["status"] == "scaffold_only"
+    assert result["roi"]["enabled"] is True
+
+
+def test_roi_scaffold_does_not_terminate_below_limit(skill):
+    result = skill.execute(
+        {
+            "task_id": "task-roi",
+            "current_token_count": 10_000,
+            "max_allowed_tokens": 100_000,
+            "roi_value_usd": 1.0,
+            "expected_outcome": "Deliver JSON summary of 10 listings",
+            "outcome_delivered": False,
+        }
+    )
+    assert result["action"] == "CONTINUE"
+    assert result["roi"]["enabled"] is True
+    assert result["roi"]["status"] == "scaffold_only"
+
+
+def test_unknown_model_uses_fallback_pricing(skill):
+    result = skill.execute(
+        {
+            "task_id": "task-unknown-model",
+            "current_token_count": 1_000_000,
+            "max_allowed_tokens": 2_000_000,
+            "model_id": "unknown-model-9000",
+        }
+    )
+    assert result["status"] == "ready"
+    assert any("Unknown model_id" in w for w in result["metadata"]["warnings"])
+    assert result["cost"]["incurred_usd"] == 5.0
+
+
+def test_turn_id_cache_is_idempotent(skill):
+    params = {
+        "task_id": "task-cache",
+        "turn_id": "turn-3",
+        "current_token_count": 90_000,
+        "max_allowed_tokens": 100_000,
+    }
+    first = skill.execute(params)
+    second = skill.execute(params)
+    assert first["action"] == second["action"]
+    assert second["metadata"]["cache_hit"] is True
+
+
+def test_reset_clears_turn_cache(skill):
+    params = {
+        "task_id": "task-reset",
+        "turn_id": "turn-1",
+        "current_token_count": 90_000,
+        "max_allowed_tokens": 100_000,
+    }
+    skill.execute(params)
+    reset = skill.execute({"action": "reset", "task_id": "task-reset"})
+    assert reset["status"] == "ready"
+    assert reset["action"] == "RESET"
+    again = skill.execute(params)
+    assert again["metadata"]["cache_hit"] is False
+
+
+def test_invalid_action(skill):
+    result = skill.execute({"action": "fly", "task_id": "x"})
+    assert result["status"] == "error"
+
+
+def test_result_is_json_serializable(skill):
+    result = skill.execute(
+        {
+            "task_id": "json-task",
+            "current_token_count": 1,
+            "max_allowed_tokens": 100,
+        }
+    )
+    json.dumps(result)

--- a/tests/skills/monitoring/__init__.py
+++ b/tests/skills/monitoring/__init__.py
@@ -1,0 +1,1 @@
+# Maintainer tests for monitoring skills.

--- a/tests/skills/monitoring/test_token_limiter.py
+++ b/tests/skills/monitoring/test_token_limiter.py
@@ -1,0 +1,53 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from skillware.core.loader import SkillLoader
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+
+def _load_example_module(filename: str):
+    path = EXAMPLES_DIR / filename
+    spec = importlib.util.spec_from_file_location(filename.replace(".py", ""), path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_loader_loads_token_limiter():
+    bundle = SkillLoader.load_skill("monitoring/token_limiter")
+    assert bundle["manifest"]["name"] == "monitoring/token_limiter"
+    skill = bundle["module"].TokenLimiterSkill()
+    result = skill.execute(
+        {
+            "task_id": "loader-smoke",
+            "current_token_count": 10,
+            "max_allowed_tokens": 100,
+        }
+    )
+    assert result["status"] == "ready"
+    assert result["action"] == "CONTINUE"
+
+
+def test_local_loop_example_smoke():
+    module = _load_example_module("token_limiter_loop.py")
+    module.run_demo()
+
+
+@patch("google.genai.Client")
+def test_gemini_example_smoke(mock_client_cls):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    module = _load_example_module("gemini_token_limiter.py")
+    module.run_demo(live_gemini=False)
+
+
+@patch("anthropic.Anthropic")
+def test_claude_example_smoke(mock_client_cls):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    module = _load_example_module("claude_token_limiter.py")
+    module.run_demo(live_claude=False)


### PR DESCRIPTION
Add `monitoring/token_limiter`: a deterministic budget gate for autonomous agent loops. The host passes cumulative token usage after each turn; the skill returns `CONTINUE`, `WARN`, or `FORCE_TERMINATE`. Includes bundled model pricing (indicative USD), ROI scaffold fields for v2 (not enforced), catalog docs, local + Gemini/Claude loop examples, and bundle/maintainer tests.

**Note:** Issue #23 proposed `monitoring/token_hard_limit`; shipped skill ID is `monitoring/token_limiter`.

Fixes #23

---

## Description

Introduces the first skill under a new **`monitoring/`** category. `TokenLimiterSkill` evaluates token budgets in pure Python (no network calls). The host loop must stop when `action` is `FORCE_TERMINATE` — the skill returns a structured decision only.

### Type of Change

- [x] **Skill Proposal**: New Skill
- [ ] Bug Report Fix
- [ ] Doc Fix
- [ ] Framework Feature / RFC Updates

## Checklist (all PRs)

- [x] Follows the **Agent Code of Conduct**
- [x] Ran `flake8`, `pytest skills/`, and targeted `pytest tests/` locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `examples/README.md` updated

## New or updated skill

### Bundle & metadata

- [x] `skills/monitoring/token_limiter/`
- [x] `manifest.yaml` — name, version, description, parameters, constitution
- [x] Real issuer (Ross Peili)
- [x] `short_description` present
- [x] No external `requirements` or `env_vars` (host supplies token counts)

### Logic, cognition, and UI

- [x] Deterministic `skill.py` + `budget.py`
- [x] `instructions.md` — when to call, host must stop on `FORCE_TERMINATE`
- [x] `card.json` issuer matches manifest

### Tests & loader

- [x] `test_skill.py` — continue, warn, terminate, ROI scaffold, cache, reset
- [x] `SkillLoader.load_skill("monitoring/token_limiter")` works
- [x] Maintainer smoke tests for local + mocked Gemini/Claude examples

### Documentation & catalog

- [x] `docs/skills/token_limiter.md` (all five provider snippets)
- [x] `docs/skills/README.md` — new Monitoring section
- [x] `docs/usage/agent_loops.md` row
- [x] `CONTRIBUTING.md` + `ai_native_workflow.md` — `monitoring` category

## Constitution & Safety

Informational budget gate only — not billing authority. No prompt content stored. v1 terminates **only** on token hard limits; ROI fields are scaffold-only. Host loop owns loop termination.

## Test plan

- [x] `pytest skills/monitoring/token_limiter/test_skill.py`
- [x] `pytest tests/skills/monitoring/test_token_limiter.py`
- [x] `pytest tests/test_skill_issuer.py`
- [x] `pytest tests/test_registry_docs.py`
- [ ] CI green on PR

## Related Issues

Fixes #23