### PR TITLE
fix: align pdf_form_filler and evm_tx_handler manifest names with reg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Changed
 
 - **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).
+- **Documentation**: Clarify skill ID vs manifest `name` vs provider tool names in `docs/usage/cli.md`, `docs/usage/agent_loops.md`, and `docs/introduction.md`; require full registry IDs in CONTRIBUTING manifest standard (#201).
 
 ## [0.4.0] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Changed
+
+- **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).
+
 ## [0.4.0] - 2026-06-30
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,8 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 
 **Required fields and sections:**
 
-- `name`, `version`, `description`
+- `name` — registry skill ID in `category/skill_name` form; **must match** the folder path under `skills/` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). Do not use a short name alone (for example `pdf_form_filler` without the `office/` prefix).
+- `version`, `description`
 - `issuer` — see [Issuer attribution](#issuer-attribution); `name` and `email` required, `github` and `org` optional
 - `short_description` — optional one-line summary (~80 chars) shown in `skillware list` when present
 - `parameters` — valid JSON Schema for LLM tool calling
@@ -222,7 +223,7 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 **Example:**
 
 ```yaml
-name: generic_hello
+name: category/generic_hello
 version: 1.0.0
 description: A friendly greeting skill.
 issuer:
@@ -334,7 +335,7 @@ Place each skill under one top-level directory under `skills/`. Use an existing 
 | `monitoring` | Agent loop observability, budget gates, task control | `token_limiter` |
 | `wellness` | Coaching guardrails, mental health support | `mental_coach` |
 
-Skill IDs follow `category/skill_name` and should match the path under `skills/`. For the live registry, see [Skill Library](docs/skills/README.md). Propose new top-level categories in an issue before adding a folder.
+Skill IDs follow `category/skill_name` and should match the path under `skills/` and the `name` field in `manifest.yaml`. For the live registry, see [Skill Library](docs/skills/README.md). Propose new top-level categories in an issue before adding a folder.
 
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -54,7 +54,7 @@ When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestr
 ### Step 1: Discovery & Loading
 The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
 *   It dynamically imports the `skill.py` module.
-*   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields).
+*   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores).
 *   It reads `instructions.md` and `card.json`.
 
 ### Step 2: Adaptation (The "Babel Fish")

--- a/docs/skills/evm_tx_handler.md
+++ b/docs/skills/evm_tx_handler.md
@@ -126,6 +126,45 @@ tools = [SkillLoader.to_claude_tool(bundle)]
 # skill.execute({"action": "execute", "intent": intent, "confirmed": True})
 ```
 
+### OpenAI
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("defi/evm_tx_handler")
+skill = bundle["module"].EvmTxHandlerSkill()
+openai_tool = SkillLoader.to_openai_tool(bundle)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Match tool_call.function.name to openai_tool["function"]["name"] (defi_evm_tx_handler)
+```
+
+### DeepSeek
+
+```python
+import os
+from openai import OpenAI
+from skillware.core.env import load_env_file
+from skillware.core.loader import SkillLoader
+
+load_env_file()
+bundle = SkillLoader.load_skill("defi/evm_tx_handler")
+skill = bundle["module"].EvmTxHandlerSkill()
+deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+# Match tool_call.function.name to deepseek_tool["function"]["name"] (defi_evm_tx_handler)
+```
+
+### Ollama
+
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "defi/evm_tx_handler"`. See [Ollama usage](../usage/ollama.md).
+
 ## Limitations
 
 - Uniswap V2 only; Ethereum + Base.  

--- a/docs/skills/evm_tx_handler.md
+++ b/docs/skills/evm_tx_handler.md
@@ -101,7 +101,8 @@ response = client.models.generate_content(
         system_instruction=bundle["instructions"],
     ),
 )
-# On function_call (evm_tx_handler): skill.execute({"action": ..., "intent": ...})
+# On function_call, match bundle["manifest"]["name"] (defi/evm_tx_handler):
+# skill.execute({"action": ..., "intent": ...})
 # After preview + user approval: skill.execute({"action": "execute", "intent": intent, "confirmed": True})
 ```
 
@@ -119,7 +120,8 @@ skill = bundle["module"].EvmTxHandlerSkill()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 
-# On tool_use (evm_tx_handler): skill.execute(tool_use.input)
+# On tool_use, match name against bundle["manifest"]["name"] (defi/evm_tx_handler):
+# skill.execute(tool_use.input)
 # execute example:
 # skill.execute({"action": "execute", "intent": intent, "confirmed": True})
 ```

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -80,8 +80,8 @@ load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
 client = genai.Client()
-# User: "Fill /path/to/form.pdf — name John Doe, check the terms box."
 tool = SkillLoader.to_gemini_tool(bundle)
+tool_name = bundle["manifest"]["name"]
 response = client.models.generate_content(
     model="gemini-2.5-flash",
     contents="Fill /path/to/form.pdf — name John Doe, check the terms box.",
@@ -91,7 +91,7 @@ response = client.models.generate_content(
     ),
 )
 for part in response.candidates[0].content.parts:
-    if part.function_call:
+    if part.function_call and part.function_call.name == tool_name:
         result = skill.execute(dict(part.function_call.args))
         follow_up = client.models.generate_content(
             model="gemini-2.5-flash",
@@ -161,6 +161,7 @@ client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),
     base_url="https://api.deepseek.com",
 )
+# Match tool_call.function.name to deepseek_tool["function"]["name"] (office_pdf_form_filler)
 ```
 
 ### Ollama

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -125,7 +125,8 @@ bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
-# On tool_use (name pdf_form_filler): skill.execute(tool_use.input), return tool_result
+# On tool_use, match name against bundle["manifest"]["name"] (office/pdf_form_filler):
+# skill.execute(tool_use.input), return tool_result
 ```
 
 ### OpenAI
@@ -141,7 +142,7 @@ bundle = SkillLoader.load_skill("office/pdf_form_filler")
 skill = bundle["module"].PDFFormFillerSkill()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-# Match tool_call.function.name to openai_tool["function"]["name"] (pdf_form_filler)
+# Match tool_call.function.name to openai_tool["function"]["name"] (office_pdf_form_filler)
 ```
 
 ### DeepSeek
@@ -164,7 +165,7 @@ client = OpenAI(
 
 ### Ollama
 
-`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "pdf_form_filler"`. See [Ollama usage](../usage/ollama.md).
+`SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "office/pdf_form_filler"`. See [Ollama usage](../usage/ollama.md).
 
 ## Data Schema
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -20,9 +20,9 @@ Provider guides contain full API details. Skill pages contain copy-paste example
 | Claude | `manifest["name"]` |
 | OpenAI | `to_openai_tool(bundle)["function"]["name"]` (sanitized, e.g. `compliance_tos_evaluator`) |
 | DeepSeek | `to_deepseek_tool(bundle)["function"]["name"]` (same sanitization rules) |
-| Ollama (prompt) | `"tool"` field in the JSON block the model emits |
+| Ollama (prompt) | `"tool"` field in the JSON block the model emits (same as `manifest["name"]` when the manifest uses the full registry ID) |
 
----
+**Registry manifest names:** Every bundled skill uses `manifest["name"]` = `category/skill_name` (for example `office/pdf_form_filler`, `defi/evm_tx_handler`). Match tool calls with `bundle["manifest"]["name"]` on Gemini and Claude, or derive sanitized names from the adapter on OpenAI and DeepSeek (`office_pdf_form_filler`, `defi_evm_tx_handler`). Do not hardcode legacy short names in examples.
 
 ## Minimal execute (no LLM)
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -185,6 +185,18 @@ To point the CLI at a persistent custom root, set the environment variable:
 Only skills with both `manifest.yaml` and `skill.py` present are shown —
 the same condition `SkillLoader` requires to load a skill successfully.
 
+### Skill ID vs manifest `name` vs LLM tool name
+
+| Concept | Source | Example (`office/pdf_form_filler`) |
+| :--- | :--- | :--- |
+| **CLI / loader ID** | Folder path `category/skill_name` | `office/pdf_form_filler` |
+| **`manifest.yaml` `name`** | Should match the registry ID | `office/pdf_form_filler` |
+| **Gemini / Claude tool name** | `manifest["name"]` via adapter | `office/pdf_form_filler` |
+| **OpenAI / DeepSeek tool name** | Sanitized adapter name | `office_pdf_form_filler` |
+| **Ollama prompt `"tool"`** | Same as manifest when using full IDs | `office/pdf_form_filler` |
+
+`skillware list` always shows the **path-derived ID**; it does not read `manifest["name"]` for the ID column. Keep manifest `name` aligned with that ID so agent loops and `SkillLoader.to_*_tool()` stay consistent. See [Agent loops](agent_loops.md#tool-name-matching).
+
 ## Color theme
 
 The CLI uses a pastel color palette consistent with the project's visual identity:

--- a/examples/claude_pdf_form_filler.py
+++ b/examples/claude_pdf_form_filler.py
@@ -21,6 +21,7 @@ client = anthropic.Anthropic(
 )
 
 tools = [SkillLoader.to_claude_tool(skill_bundle)]
+TOOL_NAME = skill_bundle["manifest"]["name"]
 
 # 4. Run Agent Loop
 pdf_path = os.path.abspath("test_form.pdf")
@@ -44,7 +45,7 @@ if message.stop_reason == "tool_use":
     print(f"\nClaude requested tool: {tool_name}")
     print(f"Input: {tool_input}")
 
-    if tool_name == "pdf_form_filler":
+    if tool_name == TOOL_NAME:
         # Check file
         if not os.path.exists(tool_input.get("pdf_path", "")):
             print(

--- a/examples/gemini_pdf_form_filler.py
+++ b/examples/gemini_pdf_form_filler.py
@@ -19,6 +19,7 @@ pdf_skill = PDFFormFillerSkill()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(skill_bundle)
 system_instruction = skill_bundle["instructions"]
+TOOL_NAME = skill_bundle["manifest"]["name"]
 
 pdf_path = os.path.abspath("test_form.pdf")
 user_query = (
@@ -47,7 +48,7 @@ while response.candidates and response.candidates[0].content.parts:
         print(f"Agent wants to call: {fn_name}")
         print(f"   Args: {fn_args}")
 
-        if fn_name == "pdf_form_filler":
+        if fn_name == TOOL_NAME:
             try:
                 if not os.path.exists(fn_args.get("pdf_path", "")):
                     print(f"Error: PDF file not found at {fn_args.get('pdf_path')}")

--- a/skills/defi/evm_tx_handler/instructions.md
+++ b/skills/defi/evm_tx_handler/instructions.md
@@ -1,6 +1,6 @@
 # EVM Transaction Handler
 
-You are equipped with **`evm_tx_handler`**: a deterministic EVM tool for a **dedicated agent wallet** on Ethereum and Base.
+You are equipped with **`defi/evm_tx_handler`**: a deterministic EVM tool for a **dedicated agent wallet** on Ethereum and Base.
 
 ## Your job vs the skill's job
 

--- a/skills/defi/evm_tx_handler/manifest.yaml
+++ b/skills/defi/evm_tx_handler/manifest.yaml
@@ -1,4 +1,4 @@
-name: evm_tx_handler
+name: defi/evm_tx_handler
 version: 0.2.0
 description: |
   Operates a dedicated EVM agent wallet for structured buy/sell on Ethereum and Base:

--- a/skills/defi/evm_tx_handler/test_skill.py
+++ b/skills/defi/evm_tx_handler/test_skill.py
@@ -81,12 +81,13 @@ def manifest():
 
 def test_manifest_consistency(skill, manifest):
     assert skill.manifest["name"] == manifest["name"]
+    assert manifest["name"] == "defi/evm_tx_handler"
 
 
 def test_loader_loads_skill(monkeypatch):
     monkeypatch.setenv("AGENT_WALLET_PRIVATE_KEY", TEST_KEY)
     bundle = SkillLoader.load_skill("defi/evm_tx_handler")
-    assert bundle["manifest"]["name"] == "evm_tx_handler"
+    assert bundle["manifest"]["name"] == "defi/evm_tx_handler"
     cls = bundle["module"].EvmTxHandlerSkill
     instance = cls()
     assert (

--- a/skills/office/pdf_form_filler/manifest.yaml
+++ b/skills/office/pdf_form_filler/manifest.yaml
@@ -1,4 +1,4 @@
-name: pdf_form_filler
+name: office/pdf_form_filler
 version: 0.1.0
 description: Fills PDF forms based on natural language instructions.
 short_description: "Fills PDF forms from natural language instructions using Claude."

--- a/skills/office/pdf_form_filler/test_skill.py
+++ b/skills/office/pdf_form_filler/test_skill.py
@@ -23,6 +23,7 @@ def manifest():
 def test_skill_manifest_consistency(skill, manifest):
     skill_manifest = skill.manifest
     assert skill_manifest["name"] == manifest["name"]
+    assert manifest["name"] == "office/pdf_form_filler"
     assert skill_manifest["version"] == manifest["version"]
 
 

--- a/tests/skills/office/test_pdf_form_filler.py
+++ b/tests/skills/office/test_pdf_form_filler.py
@@ -12,6 +12,17 @@ from skills.office.pdf_form_filler.utils import (
     FieldEdit,
 )
 
+from skillware.core.loader import SkillLoader
+
+
+def test_pdf_form_filler_manifest():
+    bundle = SkillLoader.load_skill("office/pdf_form_filler")
+    skill = bundle["module"].PDFFormFillerSkill()
+    manifest = bundle["manifest"]
+    assert skill.manifest["name"] == manifest["name"]
+    assert manifest["name"] == "office/pdf_form_filler"
+
+
 # --- Utils Tests ---
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_discover_skills_returns_skills(tmp_path):
 
     manifest = skill_dir / "manifest.yaml"
     manifest.write_text(
-        "name: pdf_form_filler\n"
+        "name: office/pdf_form_filler\n"
         "version: 0.1.0\n"
         "description: Fills PDF forms.\n"
         "requirements:\n"
@@ -94,7 +94,7 @@ def test_discover_skills_includes_issuer(tmp_path):
 
     manifest = skill_dir / "manifest.yaml"
     manifest.write_text(
-        "name: pdf_form_filler\n"
+        "name: office/pdf_form_filler\n"
         "version: 0.1.0\n"
         "description: Fills PDF forms.\n"
         "issuer:\n"
@@ -115,7 +115,7 @@ def test_discover_skills_issuer_falls_back_to_name(tmp_path):
 
     manifest = skill_dir / "manifest.yaml"
     manifest.write_text(
-        "name: pdf_form_filler\n"
+        "name: office/pdf_form_filler\n"
         "version: 0.1.0\n"
         "description: Fills PDF forms.\n"
         "issuer:\n"
@@ -140,7 +140,7 @@ def test_cmd_list_filter_by_category(tmp_path):
         skill_dir.mkdir(parents=True)
         (skill_dir / "skill.py").touch()
         (skill_dir / "manifest.yaml").write_text(
-            f"name: {name}\nversion: 0.1.0\ndescription: Test.\n"
+            f"name: {category}/{name}\nversion: 0.1.0\ndescription: Test.\n"
         )
 
     buf = io.StringIO()
@@ -294,7 +294,7 @@ def _make_bundle(tmp_path, category, name, with_test=True):
     skill_dir.mkdir(parents=True)
     (skill_dir / "skill.py").touch()
     (skill_dir / "manifest.yaml").write_text(
-        f"name: {name}\nversion: 0.1.0\ndescription: Test.\n"
+        f"name: {category}/{name}\nversion: 0.1.0\ndescription: Test.\n"
     )
     if with_test:
         (skill_dir / "test_skill.py").touch()


### PR DESCRIPTION
## Summary

Aligns the last two legacy short manifest names with registry paths ([#101](https://github.com/ARPAHLS/skillware/issues/101) Option A):

- `office/pdf_form_filler` — was `pdf_form_filler`
- `defi/evm_tx_handler` — was `evm_tx_handler`

Gemini/Claude tool names now use the full ID (e.g. `office/pdf_form_filler`). OpenAI/DeepSeek use sanitized names (`office_pdf_form_filler`, `defi_evm_tx_handler`).

**Fixes #201**

## Changes

- **Manifests** — `name` set to `category/skill_name` for both skills
- **Examples** — PDF scripts dispatch via `bundle["manifest"]["name"]` (evm examples already did)
- **Tests** — bundle + maintainer manifest assertions; CLI fixtures use full IDs
- **Docs** — skill catalog pages, `CONTRIBUTING`, `cli.md`, `agent_loops.md`, `introduction.md`
- **CHANGELOG** — `[Unreleased]` entry

## Out of scope

- Loader strict validation ([#201](https://github.com/ARPAHLS/skillware/issues/201) follow-up)
- Category moves ([#53](https://github.com/ARPAHLS/skillware/issues/53))

## Type of change

- [x] **Bug Report Fix** — manifest / tool-name identity drift
- [x] **Doc Fix** — naming and dispatch guidance

## Checklist

- [x] Agent Code of Conduct
- [x] `pytest skills/office/pdf_form_filler/test_skill.py skills/defi/evm_tx_handler/test_skill.py`
- [x] `pytest tests/test_cli.py tests/test_registry_docs.py tests/skills/office/test_pdf_form_filler.py`
- [x] `skillware list` / `skillware test` for both skills
- [x] `CHANGELOG.md` updated

## New or updated skill

Manifest metadata + docs/examples only — no new skills, no logic changes.

- [x] `manifest.yaml` `name` matches folder path
- [x] Examples use manifest-derived tool dispatch
- [x] `test_skill.py` + catalog docs updated
- [x] `SkillLoader.load_skill(...)` unchanged (path-based)

## Related

Fixes #201 · Related #101, #178