### PR TITLE
chore: update supported-version policy thresholds (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Version policy**: Raise security support floor to `>= 0.3.5`, legacy band `0.3.0`–`0.3.4` (silent CLI), unsupported advisory for installs below `0.3.0` (#192).
 - **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).
 - **Documentation**: Clarify skill ID vs manifest `name` vs provider tool names in `docs/usage/cli.md`, `docs/usage/agent_loops.md`, and `docs/introduction.md`; require full registry IDs in CONTRIBUTING manifest standard (#201).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Use a current Skillware release to receive security fixes. We patch vulnerabilit
 
 | Installed version | Security support | CLI advisory |
 | :--- | :--- | :--- |
-| **>= 0.3.1** | Supported. Security reports accepted and patched here. | Silent |
-| **0.2.6 – 0.3.0** | No security fixes. Upgrade recommended. | Silent (no upgrade spam) |
-| **< 0.2.6** (e.g. 0.2.5) | Unsupported. | One dim stderr message at CLI startup (in releases that ship this check) |
+| **>= 0.3.5** | Supported. Security reports accepted and patched here. | Silent |
+| **0.3.0 – 0.3.4** | No security fixes. Upgrade recommended. | Silent |
+| **< 0.3.0** (e.g. 0.2.9, 0.2.6) | Unsupported. | One dim stderr message at CLI startup (in releases that ship this check) |
 
 Thresholds are defined in `skillware/version_policy.py` (`MIN_SECURITY_SUPPORTED`, `MIN_UNSUPPORTED`) and bumped by maintainers when support windows change.
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -50,9 +50,10 @@ system PATH, or use the `py` launcher:
 ## Version advisory
 
 On CLI startup, Skillware checks the installed package version **once per process**.
-If you are on an **unsupported** release (below `0.2.6`, for example `0.2.5`), a single
-dim message is printed to stderr suggesting an upgrade to `>= 0.3.1`. Current and
-recent installs (`0.2.6` and above) stay silent so normal use is not spammed.
+If you are on an **unsupported** release (below `0.3.0`, for example `0.2.9`), a single
+dim message is printed to stderr suggesting an upgrade to `>= 0.3.5`. Installs in the
+`0.3.0`–`0.3.4` band stay silent (no security backports, but no startup spam). Current
+supported installs (`0.3.5` and above) stay silent.
 
 Library use (`import skillware`, `SkillLoader`) never prints this message.
 

--- a/skillware/version_policy.py
+++ b/skillware/version_policy.py
@@ -10,9 +10,9 @@ from typing import Optional
 from packaging.version import Version
 
 PACKAGE_NAME = "skillware"
-MIN_SECURITY_SUPPORTED = Version("0.3.1")
-MIN_UNSUPPORTED = Version("0.2.6")
-UPGRADE_TARGET = "0.3.1"
+MIN_SECURITY_SUPPORTED = Version("0.3.5")
+MIN_UNSUPPORTED = Version("0.3.0")
+UPGRADE_TARGET = "0.3.5"
 
 
 def is_version_check_disabled() -> bool:
@@ -34,7 +34,7 @@ def get_installed_version() -> Optional[Version]:
 
 
 def should_emit_unsupported_advisory(installed: Version) -> bool:
-    """True only for installs below MIN_UNSUPPORTED (e.g. 0.2.5 and earlier)."""
+    """True only for installs below MIN_UNSUPPORTED (e.g. 0.2.9 and earlier)."""
     return installed < MIN_UNSUPPORTED
 
 

--- a/tests/test_version_policy.py
+++ b/tests/test_version_policy.py
@@ -28,43 +28,55 @@ def test_get_installed_version_dev_returns_none(monkeypatch):
 
 
 def test_should_emit_only_below_min_unsupported():
+    assert version_policy.should_emit_unsupported_advisory(Version("0.2.9")) is True
     assert version_policy.should_emit_unsupported_advisory(Version("0.2.5")) is True
-    assert version_policy.should_emit_unsupported_advisory(Version("0.2.6")) is False
     assert version_policy.should_emit_unsupported_advisory(Version("0.3.0")) is False
-    assert version_policy.should_emit_unsupported_advisory(Version("0.3.1")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.3.4")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.3.5")) is False
 
 
 def test_emit_advisory_silent_for_current_release(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.3.1",
+        lambda _name: "0.4.0",
+    )
+    version_policy.emit_upgrade_advisory()
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_advisory_silent_for_security_supported_floor(monkeypatch, capsys):
+    monkeypatch.setattr(
+        version_policy.metadata,
+        "version",
+        lambda _name: "0.3.5",
     )
     version_policy.emit_upgrade_advisory()
     assert capsys.readouterr().err == ""
 
 
 def test_emit_advisory_silent_for_outdated_but_supported_band(monkeypatch, capsys):
-    monkeypatch.setattr(
-        version_policy.metadata,
-        "version",
-        lambda _name: "0.3.0",
-    )
-    version_policy.emit_upgrade_advisory()
-    assert capsys.readouterr().err == ""
+    for version in ("0.3.0", "0.3.4"):
+        monkeypatch.setattr(
+            version_policy.metadata,
+            "version",
+            lambda _name, v=version: v,
+        )
+        version_policy.emit_upgrade_advisory()
+        assert capsys.readouterr().err == ""
 
 
 def test_emit_advisory_warns_for_unsupported(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.2.5",
+        lambda _name: "0.2.9",
     )
     version_policy.emit_upgrade_advisory()
     err = capsys.readouterr().err
-    assert "0.2.5" in err
+    assert "0.2.9" in err
     assert "unsupported" in err.lower()
-    assert ">=0.3.1" in err
+    assert ">=0.3.5" in err
 
 
 def test_emit_advisory_respects_opt_out(monkeypatch, capsys):
@@ -72,7 +84,7 @@ def test_emit_advisory_respects_opt_out(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.2.5",
+        lambda _name: "0.2.9",
     )
     version_policy.emit_upgrade_advisory()
     assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

Updates supported-version thresholds now that the project is on **0.4.0** while the policy still reflected the **#132** bands (`>= 0.3.1` supported, advisory below `0.2.6`).

**Fixes #192**

| Band | Security support | CLI |
|------|------------------|-----|
| **>= 0.3.5** | Patches accepted | Silent |
| **0.3.0 – 0.3.4** | No backports | Silent |
| **< 0.3.0** (e.g. 0.2.9) | Unsupported | One dim stderr advisory → `>= 0.3.5` |

## Changes

- **`skillware/version_policy.py`** — `MIN_SECURITY_SUPPORTED = 0.3.5`, `MIN_UNSUPPORTED = 0.3.0`, `UPGRADE_TARGET = 0.3.5`
- **`SECURITY.md`** — supported-versions table
- **`docs/usage/cli.md`** — Version advisory section
- **`tests/test_version_policy.py`** — thresholds, advisory message, legacy band silence
- **`CHANGELOG.md`** — `[Unreleased]` entry

No loader, skill, or runtime security model changes — policy constants and docs only.

## Type of change

- [x] **Framework Feature / RFC Updates** — `version_policy.py` thresholds
- [x] **Doc Fix** — `SECURITY.md`, CLI docs

## Checklist

- [x] Agent Code of Conduct
- [x] `python -m black --check .` and `python -m flake8 .`
- [x] `pytest tests/test_version_policy.py` (9 passed)
- [x] `CHANGELOG.md` updated
- [x] N/A — no `examples/` changes

## New or updated skill

N/A — skip.

## Related

Fixes #192 · Supersedes #132 policy bands