### PR TITLE
Document skill trust model and operator security warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **Version policy**: Raise security support floor to `>= 0.3.5`, legacy band `0.3.0`–`0.3.4` (silent CLI), unsupported advisory for installs below `0.3.0` (#192).
 - **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).
 - **Documentation**: Clarify skill ID vs manifest `name` vs provider tool names in `docs/usage/cli.md`, `docs/usage/agent_loops.md`, and `docs/introduction.md`; require full registry IDs in CONTRIBUTING manifest standard (#201).
+- **Documentation**: Add `docs/security/skill-trust-model.md` documenting the skill execution model, on-disk resolution order and shadowing, provenance tiers (Bundled / Project / External), and operator security guidance; wire links from SECURITY, usage, CONTRIBUTING, and CODE_OF_CONDUCT (#109).
+
 
 ## [0.4.0] - 2026-06-30
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ Examples of behavior that contributes to creating a positive environment for AI 
 
 *   **Deterministic Outputs**: Writing skills that produce predictable, schema-compliant JSON outputs.
 *   **Token Efficiency**: Minimizing unnecessary token expenditure by relying on underlying Python execution rather than LLM reasoning where possible.
-*   **Safety First**: Strictly adhering to the `constitution` defined in skill manifests and respecting all sandboxing rules.
+*   **Safety First**: Strictly adhering to the `constitution` defined in skill manifests and following the project's [security and trust guidelines](docs/security/skill-trust-model.md).
 *   **Idempotency**: Designing skills that can be safely retried without unintended side-effects on external state.
 *   **Clear Interface**: Documenting inputs cleanly in `manifest.yaml` so other agents do not hallucinate parameters.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,6 +356,7 @@ Skill IDs follow `category/skill_name` and should match the path under `skills/`
 - Sanitize inputs in `skill.py` before external calls.
 - Respect the skill `constitution` in both code and documentation.
 - Malicious or deceptive contributions may be rejected and blocked from the project.
+- **Registry review is not runtime isolation.** Passing maintainer review means a skill's *origin* is trusted; it does not sandbox the skill. All skills run in the host process regardless of tier. See the [skill trust model](docs/security/skill-trust-model.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,10 @@ Thresholds are defined in `skillware/version_policy.py` (`MIN_SECURITY_SUPPORTED
 
 **Note:** PyPI releases are immutable. Users on very old wheels will not see the CLI advisory until they upgrade to a release that includes this logic at least once. That is expected for OSS packaging.
 
+## Skill execution model
+
+Loading a skill runs its `skill.py` in your host process, with full filesystem and environment access. Skillware does not sandbox skills; trust is based on provenance (where a skill came from and who reviewed it), not runtime isolation. Before loading skills you did not write, review the [skill trust model](docs/security/skill-trust-model.md).
+
 ## Reporting a Vulnerability
 
 We take security seriously. If you discover a vulnerability in Skillware (e.g., standard library skills leaking data, or loader bypasses):

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -57,6 +57,8 @@ The loader resolves `category/skill_name` to a skill directory by checking, in o
 *   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
 *   It reads `instructions.md` and `card.json`.
 
+For how skills are resolved on disk, the provenance tiers, and what to check before loading skills you did not write, see [Skill trust model & operator security](security/skill-trust-model.md).
+
 ### Step 2: Adaptation (The "Babel Fish")
 This is Skillware's superpower. Every model (Gemini, Claude, GPT) speaks a different "Tool Language".
 *   **Gemini** wants `FunctionDeclaration` with Protobuf types (UPPERCASE).

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,5 @@
+# Security
+
+Documentation on Skillware's security posture and operator guidance.
+
+- [Skill trust model & operator security](skill-trust-model.md) — how skills are resolved and executed, provenance tiers, and what to check before loading skills you did not write.

--- a/docs/security/skill-trust-model.md
+++ b/docs/security/skill-trust-model.md
@@ -1,0 +1,90 @@
+# Skill Trust Model & Operator Security
+
+This page explains how Skillware resolves and executes skills on disk, and how you should reason about trusting them.
+
+**None of these tiers are sandboxed today.** Loading a skill runs its Python in your host process. Trust in Skillware is based on provenance — where a skill came from and who reviewed it — not on runtime isolation. Nothing described below prevents a skill from doing anything your own process can do. Read this page before loading skills you did not write.
+
+## 1. Executive summary
+
+When you load a skill, Skillware executes that skill's skill.py in your host process. Import runs the module's top-level code immediately, and from that point the skill's code has the same reach your process has: the full filesystem and every environment variable in os.environ, including secrets and API keys.
+
+There is no isolation, no permission boundary, and no capability restriction around this execution. SkillLoader checks that a skill's declared requirements are importable, but it does not inspect, restrict, or sandbox what the code does. So the real decision each time you load a skill is: am I willing to hand this code my machine and my secrets?
+
+The trust tiers in this document describe how much you should trust a skill's origin. They are not isolation levels. To be explicit: none of them are sandboxed today.
+
+## 2. How skills are resolved on disk
+
+When you pass a registry id (for example finance/wallet_screening) rather than a path that already exists, the loader searches a fixed set of roots and uses the first match it finds, in this order:
+
+1. SKILLWARE_SKILL_PATH — one or more roots, separated by your OS path separator.
+2. ./skills/ in the current working directory, and its parent directories — the loader walks up to six levels of parents looking for a skills/ directory.
+3. Bundled skills shipped inside the installed skillware package (for example under site-packages/skills/).
+
+If you pass a path that already points at a skill directory (absolute or relative to the current directory), the loader uses it directly and skips the search entirely.
+
+### Shadowing
+
+Because the search stops at the first matching id, a skill earlier in the order shadows any skill with the same id later in the order. If a finance/wallet_screening exists under SKILLWARE_SKILL_PATH or in a local ./skills/, it is loaded instead of the bundled, maintainer-reviewed copy of the same id — and the bundled copy never runs.
+
+The practical consequence: placing a skill with the same id as an official one, anywhere earlier in the search order, silently replaces the official skill. Shadowing is a normal feature of the resolution order, but it means the id you ask for does not by itself tell you which code will run — the location does.
+
+## 3. Provenance tiers
+
+A skill's tier describes where it came from and who reviewed it, which is the basis for how much you should trust it. It does not describe runtime isolation. All tiers execute the same way, in your host process.
+
+| Tier | Where it comes from | Reviewed by | Basis for trust | Sandboxed? |
+| :--- | :--- | :--- | :--- | :--- |
+| A — Bundled registry | Shipped in the skillware wheel (site-packages/skills/) | Maintainers, via pull-request review | Public review before it ships | No |
+| B — Project-local | ./skills/ in your project (cwd or a parent) | You / your team | You put it there | No |
+| C — External | SKILLWARE_SKILL_PATH or an absolute path | No one, until you review it | Treat as untrusted until read | No |
+
+**Tier A — Bundled registry.** These ship inside the package and go through maintainer pull-request review before release. This is the most trustworthy origin, but review is not isolation: a bundled skill still runs unsandboxed in your process.
+
+**Tier B — Project-local.** Skills in your project's ./skills/ (or a parent's). Trust here is simply trust in you and your team — you are responsible for the code you place there.
+
+**Tier C — External.** Skills loaded from SKILLWARE_SKILL_PATH or an absolute path. This is third-party code you did not write and no one has reviewed for you. Treat it as untrusted until you have read it yourself.
+
+## 4. constitution is guidance, not isolation
+
+A skill's manifest.yaml can declare a constitution — a set of natural-language rules such as "use a dedicated wallet only," "never pass private keys in tool arguments," or "fail closed on missing confirmation." For example, defi/evm_tx_handler declares a constitution covering dedicated wallets, secret handling, and fail-closed behavior.
+
+A constitution guides the agent (the LLM calling the skill). It does not constrain skill.py. Nothing in the loader enforces a constitution at the Python level — code that ignores every rule in the constitution loads and runs exactly the same. The constitution is a prompt-level norm, not a process-level boundary.
+
+The same distinction applies to other manifest fields. Declaring env_vars documents which variables a skill expects; it does not limit what the code can read. The loader's requirements check confirms that declared packages are importable; it does not inspect what the code does with them. In short:
+
+| constitution / manifest does | It does not |
+| :--- | :--- |
+| Tell the agent how the skill should be used | Sandbox or restrict skill.py |
+| Document expected env vars and dependencies | Limit which env vars or files the code can access |
+| Set norms reviewers and agents can rely on | Enforce those norms at runtime |
+
+## 5. Concrete flows
+
+Three common setups and what to watch for in each.
+
+**pip-only agent.** You pip install skillware and use only bundled skills (Tier A). Origin trust is highest here — the skills were reviewed before shipping — but execution is still unsandboxed: a bundled skill runs in your process with full access like any other. The risk is lower because of review, not because of isolation.
+
+**Development with ./skills/.** You keep project skills in ./skills/ (Tier B). Two things to keep in mind: trust rests on whoever on your team wrote the code, and shadowing applies — a local skill with the same id as a bundled one replaces it. Check that you are not unintentionally overriding an official skill with a local id.
+
+**External path.** You point SKILLWARE_SKILL_PATH at a third-party skills directory (Tier C). This is the highest-risk case: unreviewed code runs in your process with access to your entire os.environ. Because a skill can read environment variables and make network calls, a malicious or careless external skill could read your API keys or secrets and send them elsewhere — nothing in the loader prevents this. Only load external skills you have read.
+
+## 6. Operator checklist
+
+Because there is no default isolation, these precautions are on you, the operator — the loader does not do them for you:
+
+- Read external (Tier C) skills before you load them. Do not run third-party skill code you have not looked at.
+- Use dedicated, least-privilege API keys for agent work. Any loaded skill can read every variable in os.environ, so do not expose production or personal full-access keys.
+- Do not run untrusted skills on a machine that holds production secrets.
+- Watch for shadowing: confirm a local ./skills/ id is not unintentionally overriding a bundled skill.
+- When running skills you do not fully trust, run them in a minimal or containerized environment. This is your own isolation, outside Skillware — the loader provides none.
+
+## 7. Where this is going
+
+This document describes the current state (Phase 0): an honest account of how loading works today, with no isolation. Isolation and trust controls are being discussed in follow-up work:
+
+- #110 — Phase 1: operator warnings and a trust flag for remote/external code.
+- #111 and #39 — scoped secrets, so skills see only the environment they need.
+- #112–#114 — research into stronger isolation (for example WASM or container-based sandboxing).
+- #17 — the parent Security Sandboxing RFC, which remains the decision record for this area.
+
+Until those land, treat every tier as unsandboxed and trust skills by their provenance.

--- a/docs/security/skill-trust-model.md
+++ b/docs/security/skill-trust-model.md
@@ -28,21 +28,25 @@ Because the search stops at the first matching id, a skill earlier in the order 
 
 The practical consequence: placing a skill with the same id as an official one, anywhere earlier in the search order, silently replaces the official skill. Shadowing is a normal feature of the resolution order, but it means the id you ask for does not by itself tell you which code will run — the location does.
 
+### Flat vs registry layout
+
+A private, local skill can live either in registry layout (`<skill_root>/<category>/<skill_name>/`) or in a flat layout (`<skill_root>/<skill_name>/`). Both load. One practical wrinkle: `skillware list` only discovers the two-level registry layout, so a flat skill loads fine but does not appear in `list`. If a local skill loads but is missing from `list`, a flat layout is usually why.
+
 ## 3. Provenance tiers
 
 A skill's tier describes where it came from and who reviewed it, which is the basis for how much you should trust it. It does not describe runtime isolation. All tiers execute the same way, in your host process.
 
 | Tier | Where it comes from | Reviewed by | Basis for trust | Sandboxed? |
 | :--- | :--- | :--- | :--- | :--- |
-| A — Bundled registry | Shipped in the skillware wheel (site-packages/skills/) | Maintainers, via pull-request review | Public review before it ships | No |
-| B — Project-local | ./skills/ in your project (cwd or a parent) | You / your team | You put it there | No |
-| C — External | SKILLWARE_SKILL_PATH or an absolute path | No one, until you review it | Treat as untrusted until read | No |
+| **Bundled registry** | Shipped in the skillware wheel (site-packages/skills/) | Maintainers, via pull-request review | Public review before it ships | No |
+| **Project-local** | ./skills/ in your project (cwd or a parent) | You / your team | You put it there | No |
+| **External** | SKILLWARE_SKILL_PATH or an absolute path | No one, until you review it | Treat as untrusted until read | No |
 
-**Tier A — Bundled registry.** These ship inside the package and go through maintainer pull-request review before release. This is the most trustworthy origin, but review is not isolation: a bundled skill still runs unsandboxed in your process.
+**Bundled registry.** These ship inside the package and go through maintainer pull-request review before release. This is the most trustworthy origin, but review is not isolation: a bundled skill still runs unsandboxed in your process.
 
-**Tier B — Project-local.** Skills in your project's ./skills/ (or a parent's). Trust here is simply trust in you and your team — you are responsible for the code you place there.
+**Project-local.** Skills in your project's ./skills/ (or a parent's). Trust here is simply trust in you and your team — you are responsible for the code you place there.
 
-**Tier C — External.** Skills loaded from SKILLWARE_SKILL_PATH or an absolute path. This is third-party code you did not write and no one has reviewed for you. Treat it as untrusted until you have read it yourself.
+**External.** Skills loaded from SKILLWARE_SKILL_PATH or an absolute path. This is third-party code you did not write and no one has reviewed for you. Treat it as untrusted until you have read it yourself.
 
 ## 4. constitution is guidance, not isolation
 
@@ -62,17 +66,17 @@ The same distinction applies to other manifest fields. Declaring env_vars docume
 
 Three common setups and what to watch for in each.
 
-**pip-only agent.** You pip install skillware and use only bundled skills (Tier A). Origin trust is highest here — the skills were reviewed before shipping — but execution is still unsandboxed: a bundled skill runs in your process with full access like any other. The risk is lower because of review, not because of isolation.
+**pip-only agent.** You pip install skillware and use only bundled skills (Bundled). Origin trust is highest here — the skills were reviewed before shipping — but execution is still unsandboxed: a bundled skill runs in your process with full access like any other. The risk is lower because of review, not because of isolation.
 
-**Development with ./skills/.** You keep project skills in ./skills/ (Tier B). Two things to keep in mind: trust rests on whoever on your team wrote the code, and shadowing applies — a local skill with the same id as a bundled one replaces it. Check that you are not unintentionally overriding an official skill with a local id.
+**Development with ./skills/.** You keep project skills in ./skills/ (Project). Two things to keep in mind: trust rests on whoever on your team wrote the code, and shadowing applies — a local skill with the same id as a bundled one replaces it. Check that you are not unintentionally overriding an official skill with a local id.
 
-**External path.** You point SKILLWARE_SKILL_PATH at a third-party skills directory (Tier C). This is the highest-risk case: unreviewed code runs in your process with access to your entire os.environ. Because a skill can read environment variables and make network calls, a malicious or careless external skill could read your API keys or secrets and send them elsewhere — nothing in the loader prevents this. Only load external skills you have read.
+**External path.** You point SKILLWARE_SKILL_PATH at a third-party skills directory (External). This is the highest-risk case: unreviewed code runs in your process with access to your entire os.environ. Because a skill can read environment variables and make network calls, a malicious or careless external skill could read your API keys or secrets and send them elsewhere — nothing in the loader prevents this. Only load external skills you have read.
 
 ## 6. Operator checklist
 
 Because there is no default isolation, these precautions are on you, the operator — the loader does not do them for you:
 
-- Read external (Tier C) skills before you load them. Do not run third-party skill code you have not looked at.
+- Read external (External) skills before you load them. Do not run third-party skill code you have not looked at.
 - Use dedicated, least-privilege API keys for agent work. Any loaded skill can read every variable in os.environ, so do not expose production or personal full-access keys.
 - Do not run untrusted skills on a machine that holds production secrets.
 - Watch for shadowing: confirm a local ./skills/ id is not unintentionally overriding a bundled skill.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -12,6 +12,8 @@ How to load Skillware skills and connect them to language models. Each guide cov
 
 For pip-installed apps, keep project skills in `./skills/<category>/<name>/` or set `SKILLWARE_SKILL_PATH` to your skills root.
 
+> **Security:** Loading a skill executes its `skill.py` in your process — there is no sandbox, and the first matching id in the search order wins (a local skill can shadow a bundled one). Only load skills you trust, and see the [skill trust model](../security/skill-trust-model.md) before loading external skills.
+
 To list locally available skills or run bundle tests from the terminal, see the [CLI reference](cli.md).
 
 | Provider | Adapter | Guide | Agent API key (typical) |


### PR DESCRIPTION
## Summary

Resolves #109 (Phase 0 — docs only). Adds an operator-facing document explaining Skillware's skill trust model, and wires links to it from the security-relevant files.

This is documentation only. It does not change `SkillLoader`, add flags, or implement sandboxing (those remain in #110–#114). It documents the current state honestly.

Fixes #109

## What's included

- **New:** `docs/security/skill-trust-model.md` — the operator mental model:
  1. Executive summary — loading a skill runs its `skill.py` in the host process with full filesystem + `os.environ` access.
  2. On-disk resolution order (`SKILLWARE_SKILL_PATH` → cwd `./skills/` and parents → bundled) and shadowing.
  3. Provenance tiers (A/B/C — Bundled / Project / External), with an explicit "Sandboxed? No" for every tier.
  4. `constitution` is agent guidance, not Python isolation (with the `defi/evm_tx_handler` example).
  5. Concrete flows (pip-only, dev with `./skills/`, external path) and what can go wrong.
  6. Operator checklist.
  7. Roadmap pointer (#110, #111 + #39, #112–#114, parent #17).
- **New:** `docs/security/README.md` — index for the new folder.
- **Wiring:** `SECURITY.md` (skill execution model section), `docs/usage/README.md` (security note on "Finding skills on disk"), `CONTRIBUTING.md` (registry review ≠ runtime isolation), `CODE_OF_CONDUCT.md` (replaced the undefined "sandboxing rules" reference with a link to the trust doc), `CHANGELOG.md` (`[Unreleased]` Documentation entry).

## Acceptance bar

The doc leads with "None of these tiers are sandboxed today," and a new operator comes away understanding: no default sandbox, where code came from matters, and constitution ≠ isolation. No claim that sandboxing exists today.

## Naming

The provenance tiers are labeled A/B/C in the doc, but Bundled / Project / External may read more clearly. Happy to rename to whichever you prefer before merge — flagged here rather than in the doc body so the page stays clean.

Made with [Cursor](https://cursor.com)