### PR TITLE
feat(loader): validate manifest name against registry path (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Loader**: `SkillLoader.load_skill()` validates that `manifest.yaml` `name` matches the path-derived registry ID for `category/skill_name` layouts; emits `SkillwareIdentityWarning` on mismatch (warn-only v1). Flat private skills under a skill root are unchanged. Bundles now include optional `registry_id` (#200).
 - **Version policy**: Raise security support floor to `>= 0.3.5`, legacy band `0.3.0`–`0.3.4` (silent CLI), unsupported advisory for installs below `0.3.0` (#192).
 - **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).
 - **Documentation**: Clarify skill ID vs manifest `name` vs provider tool names in `docs/usage/cli.md`, `docs/usage/agent_loops.md`, and `docs/introduction.md`; require full registry IDs in CONTRIBUTING manifest standard (#201).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 
 **Required fields and sections:**
 
-- `name` — registry skill ID in `category/skill_name` form; **must match** the folder path under `skills/` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). Do not use a short name alone (for example `pdf_form_filler` without the `office/` prefix).
+- `name` — registry skill ID in `category/skill_name` form; **must match** the folder path under `skills/` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). Do not use a short name alone (for example `pdf_form_filler` without the `office/` prefix). The loader emits `SkillwareIdentityWarning` when a registry-layout skill (`<skill_root>/<category>/<skill_name>/`) has a missing or mismatched `name` (warn-only in v1; may become an error later). Flat private layouts (`<skill_root>/<skill_name>/`) skip this check.
 - `version`, `description`
 - `issuer` — see [Issuer attribution](#issuer-attribution); `name` and `email` required, `github` and `org` optional
 - `short_description` — optional one-line summary (~80 chars) shown in `skillware list` when present

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -233,6 +233,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 
 - Bundle: `manifest.yaml`, `skill.py`, `instructions.md`, `card.json`, `test_skill.py`, plus catalog docs
 - `manifest.yaml` is source of truth for schema, constitution, `requirements`, `env_vars`, and `issuer`
+- `manifest.yaml` `name` must equal `category/skill_name` (matches folder path); loader warns on mismatch for registry layout
 - `issuer.name` and `issuer.email` required; `github` and `org` optional; no template placeholders in registry paths
 - `card.json` issuer must match manifest `name` and `email` when present
 - Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
@@ -268,7 +269,7 @@ Complete the checklist that matches your issue during Stage 5.
 ### New or updated skill
 
 - [ ] `skills/<category>/<skill_name>/` exists with full bundle
-- [ ] `manifest.yaml`: `name`, `version`, `description`, `parameters`, `constitution`, real `issuer`
+- [ ] `manifest.yaml`: `name` (`category/skill_name`, matches folder), `version`, `description`, `parameters`, `constitution`, real `issuer`
 - [ ] Optional: `short_description` field (~80 chars) for a concise one-line summary in `skillware list`
 - [ ] `skill.py`: deterministic, JSON-serializable returns, safe error handling
 - [ ] `instructions.md`: when to use, how to interpret output, limitations
@@ -300,6 +301,7 @@ Complete the checklist that matches your issue during Stage 5.
 
 - [ ] Framework issue approved
 - [ ] Changes in `skillware/` and relevant `tests/`
+- [ ] Loader or API docs updated when behavior changes (e.g. `registry_id`, identity warnings)
 - [ ] `pytest tests/` passes
 - [ ] Usage docs updated if API changed
 - [ ] No undeclared breaking changes

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -54,7 +54,7 @@ When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestr
 ### Step 1: Discovery & Loading
 The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
 *   It dynamically imports the `skill.py` module.
-*   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores).
+*   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
 *   It reads `instructions.md` and `card.json`.
 
 ### Step 2: Adaptation (The "Babel Fish")

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -22,7 +22,7 @@ Provider guides contain full API details. Skill pages contain copy-paste example
 | DeepSeek | `to_deepseek_tool(bundle)["function"]["name"]` (same sanitization rules) |
 | Ollama (prompt) | `"tool"` field in the JSON block the model emits (same as `manifest["name"]` when the manifest uses the full registry ID) |
 
-**Registry manifest names:** Every bundled skill uses `manifest["name"]` = `category/skill_name` (for example `office/pdf_form_filler`, `defi/evm_tx_handler`). Match tool calls with `bundle["manifest"]["name"]` on Gemini and Claude, or derive sanitized names from the adapter on OpenAI and DeepSeek (`office_pdf_form_filler`, `defi_evm_tx_handler`). Do not hardcode legacy short names in examples.
+**Registry manifest names:** Every bundled skill uses `manifest["name"]` = `category/skill_name` (for example `office/pdf_form_filler`, `defi/evm_tx_handler`). Match tool calls with `bundle["manifest"]["name"]` on Gemini and Claude, or derive sanitized names from the adapter on OpenAI and DeepSeek (`office_pdf_form_filler`, `defi_evm_tx_handler`). Do not hardcode legacy short names in examples. `SkillLoader.load_skill()` warns when `name` diverges from the folder path for registry-layout skills; use `bundle.get("registry_id")` for the path-derived ID when present.
 
 ## Minimal execute (no LLM)
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -196,7 +196,7 @@ the same condition `SkillLoader` requires to load a skill successfully.
 | **OpenAI / DeepSeek tool name** | Sanitized adapter name | `office_pdf_form_filler` |
 | **Ollama prompt `"tool"`** | Same as manifest when using full IDs | `office/pdf_form_filler` |
 
-`skillware list` always shows the **path-derived ID**; it does not read `manifest["name"]` for the ID column. Keep manifest `name` aligned with that ID so agent loops and `SkillLoader.to_*_tool()` stay consistent. See [Agent loops](agent_loops.md#tool-name-matching).
+`skillware list` always shows the **path-derived ID**; it does not read `manifest["name"]` for the ID column. Keep manifest `name` aligned with that ID so agent loops and `SkillLoader.to_*_tool()` stay consistent. `SkillLoader.load_skill()` warns via `SkillwareIdentityWarning` when a registry-layout skill has a missing or mismatched `name` (flat private skills under `<skill_root>/<skill_name>/` are not checked). See [Agent loops](agent_loops.md#tool-name-matching).
 
 ## Color theme
 

--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -1,10 +1,16 @@
 import os
 import re
+import warnings
 import yaml
 import json
 import importlib.util
 from pathlib import Path
 from typing import Dict, Any, List, Optional
+
+
+class SkillwareIdentityWarning(UserWarning):
+    """Emitted when manifest.name does not match the registry folder path (warn-only in v1)."""
+
 
 SKILLWARE_SKILL_PATH_ENV = "SKILLWARE_SKILL_PATH"
 _MAX_PARENT_WALK = 6
@@ -48,6 +54,74 @@ class SkillLoader:
             for entry in raw.split(os.pathsep)
             if entry.strip()
         ]
+
+    @staticmethod
+    def _all_skill_roots() -> List[Path]:
+        roots: List[Path] = []
+        seen: set[str] = set()
+        for root in (
+            SkillLoader._env_skill_roots()
+            + SkillLoader._cwd_skill_roots()
+            + [SkillLoader._bundled_skills_root()]
+        ):
+            resolved = root.resolve()
+            key = str(resolved)
+            if key not in seen:
+                seen.add(key)
+                roots.append(resolved)
+        return roots
+
+    @staticmethod
+    def _expected_registry_id(skill_dir: Path) -> Optional[str]:
+        """
+        Return category/skill_name when the skill directory uses registry layout
+        ({skill_root}/{category}/{skill_name}/). Flat layouts ({skill_root}/{skill_name}/)
+        and arbitrary absolute paths outside skill roots return None.
+        """
+        resolved = skill_dir.resolve()
+        parent = resolved.parent
+        for root in SkillLoader._all_skill_roots():
+            try:
+                relative_parent = parent.relative_to(root)
+            except ValueError:
+                continue
+            if len(relative_parent.parts) == 1:
+                return f"{relative_parent.parts[0]}/{resolved.name}"
+        return None
+
+    @staticmethod
+    def _validate_manifest_identity(
+        skill_dir: Path, manifest: Dict[str, Any]
+    ) -> Optional[str]:
+        """
+        Warn when manifest.name diverges from the path-derived registry ID.
+        Returns the expected registry ID for registry-layout skills, else None.
+        """
+        expected = SkillLoader._expected_registry_id(skill_dir)
+        if expected is None:
+            return None
+
+        manifest_name = manifest.get("name")
+        if not manifest_name or not str(manifest_name).strip():
+            warnings.warn(
+                f"Skill at {skill_dir}: manifest.yaml is missing 'name'; "
+                f"expected {expected!r} for registry layout (category/skill_name).",
+                SkillwareIdentityWarning,
+                stacklevel=4,
+            )
+            return expected
+
+        manifest_name = str(manifest_name).strip()
+        if manifest_name != expected:
+            warnings.warn(
+                f"Skill at {skill_dir}: manifest.yaml name {manifest_name!r} does not "
+                f"match registry path {expected!r}. Set name to the full ID "
+                f"(category/skill_name) or use a flat layout (<skill_root>/<skill_name>/) "
+                f"for private local skills. See CONTRIBUTING.md.",
+                SkillwareIdentityWarning,
+                stacklevel=4,
+            )
+        return expected
 
     @staticmethod
     def _cwd_skill_roots() -> List[Path]:
@@ -129,7 +203,9 @@ class SkillLoader:
         manifest_path = os.path.join(skill_path, "manifest.yaml")
         if os.path.exists(manifest_path):
             with open(manifest_path, "r", encoding="utf-8") as f:
-                manifest = yaml.safe_load(f)
+                manifest = yaml.safe_load(f) or {}
+
+        registry_id = SkillLoader._validate_manifest_identity(resolved_path, manifest)
 
         # Check Dependencies
         if "requirements" in manifest:
@@ -174,6 +250,7 @@ class SkillLoader:
                 "manifest": manifest,
                 "instructions": instructions,
                 "card": card,
+                "registry_id": registry_id,
             }
         return {}
 

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -6,7 +6,7 @@ Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from 
 
 1. **Rename** the folder to match your skill ID (e.g. `skills/finance/my_skill`).
 2. **Packaging**: Add empty `__init__.py` files in `skills/<category>/` (new categories only) and in your skill folder so PyPI wheels include the full bundle. No `pyproject.toml` changes per skill.
-3. **`manifest.yaml`**: Set real `name`, `version`, `description`, `short_description`, `parameters`, `constitution`, and `issuer` (`name` + `email` required; `github` / `org` optional).
+3. **`manifest.yaml`**: Set real `name` to the full registry ID (`category/skill_name`, matching the folder path), `version`, `description`, `short_description`, `parameters`, `constitution`, and `issuer` (`name` + `email` required; `github` / `org` optional). `SkillLoader.load_skill()` warns when `name` diverges from the path under registry layout; flat private layouts (`skills/<skill_name>/`) are not validated.
 4. **`skill.py`**: Implement deterministic logic; no LLM-generated code in the skill body.
 5. **`instructions.md`**: Tell the agent when and how to use the tool.
 6. **`card.json`**: Mirror `issuer` from the manifest; customize UI fields.

--- a/templates/python_skill/manifest.yaml
+++ b/templates/python_skill/manifest.yaml
@@ -1,4 +1,4 @@
-name: "my-awesome-skill"
+name: "category/my-awesome-skill"
 version: "0.1.0"
 description: "A short description of what this skill does."
 short_description: "One-line summary for skillware list (~80 chars)."

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,11 +1,16 @@
 import subprocess
 import sys
+import warnings
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from skillware.core.loader import SKILLWARE_SKILL_PATH_ENV, SkillLoader
+from skillware.core.loader import (
+    SKILLWARE_SKILL_PATH_ENV,
+    SkillLoader,
+    SkillwareIdentityWarning,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -18,6 +23,102 @@ def test_load_skill_not_found():
 def test_load_skill_registry_has_manifest():
     bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
     assert bundle["manifest"].get("name") == "optimization/prompt_rewriter"
+    assert bundle["registry_id"] == "optimization/prompt_rewriter"
+
+
+def test_load_skill_registry_id_matches_bundled_skills():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SkillwareIdentityWarning)
+        bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+    assert bundle["registry_id"] == "compliance/tos_evaluator"
+
+
+def test_flat_skill_skips_identity_validation(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "my_flat_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "name: different_from_path\nversion: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class FlatSkill(BaseSkill):\n"
+        "    def execute(self, **kwargs):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SkillwareIdentityWarning)
+        bundle = SkillLoader.load_skill("my_flat_skill")
+    assert bundle["registry_id"] is None
+
+
+def test_registry_layout_mismatch_warns(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "finance" / "bad_manifest"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "name: finance/wrong_name\nversion: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class BadManifestSkill(BaseSkill):\n"
+        "    def execute(self, **kwargs):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.warns(SkillwareIdentityWarning, match="does not match registry path"):
+        bundle = SkillLoader.load_skill("finance/bad_manifest")
+    assert bundle["registry_id"] == "finance/bad_manifest"
+
+
+def test_registry_layout_missing_name_warns(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "office" / "no_name"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "version: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class NoNameSkill(BaseSkill):\n"
+        "    def execute(self, **kwargs):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.warns(SkillwareIdentityWarning, match="missing 'name'"):
+        bundle = SkillLoader.load_skill("office/no_name")
+    assert bundle["registry_id"] == "office/no_name"
+
+
+def test_env_root_registry_layout_validates(tmp_path, monkeypatch):
+    root = tmp_path / "custom_skills"
+    skill_dir = root / "monitoring" / "env_registry_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "name: monitoring/env_registry_skill\nversion: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class EnvRegistrySkill(BaseSkill):\n"
+        "    def execute(self, **kwargs):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, str(root))
+    monkeypatch.chdir(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SkillwareIdentityWarning)
+        bundle = SkillLoader.load_skill("monitoring/env_registry_skill")
+    assert bundle["registry_id"] == "monitoring/env_registry_skill"
 
 
 def test_resolve_skill_from_project_skills_dir(tmp_path, monkeypatch):
@@ -38,6 +139,7 @@ def test_resolve_skill_from_project_skills_dir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     bundle = SkillLoader.load_skill("local_skill")
     assert bundle["manifest"]["name"] == "local_skill"
+    assert bundle["registry_id"] is None
 
 
 def test_resolve_skill_from_env_path(tmp_path, monkeypatch):
@@ -60,6 +162,7 @@ def test_resolve_skill_from_env_path(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     bundle = SkillLoader.load_skill("env_skill")
     assert bundle["manifest"]["name"] == "env_skill"
+    assert bundle["registry_id"] is None
 
 
 def test_resolve_skill_prefers_env_over_cwd(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

Implements **#200** (manifest identity validation, warn-only v1).

`SkillLoader.load_skill()` now checks that `manifest.yaml` `name` matches the path-derived registry ID for `category/skill_name` layouts. On mismatch or missing `name`, it emits `SkillwareIdentityWarning` — load still succeeds. Flat private skills (`<skill_root>/<skill_name>/`) are unchanged and skip validation.

Loaded bundles include `registry_id` when the check applies. Docs, skill template, and loader tests are aligned.

Depends on **#201** (bundled manifest names already aligned).

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .`, `pytest skills/` (or `skillware test`), and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip — framework-only PR; no registry skill changes.

## Constitution & Safety (if adding or modifying a skill)

N/A — loader validation only; no skill execution logic changed.

## Related Issues

Fixes #200  
Refs #101