### PR TITLE
feat(wallet_screening): paginate Etherscan txlist and surface warnings (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
-- **`finance/wallet_screening`**: Paginate Etherscan `txlist` (up to 10k normal txs) and surface `metadata.warnings` when history is truncated or unavailable (#214, parent #115).
+- **`finance/wallet_screening`**: Paginate Etherscan `txlist` (up to 10k normal txs) and surface `metadata.warnings` when history is truncated or unavailable; bump skill version `1.0.0` → `1.0.1` (#214, parent #115).
 - **Skills (finance/uk_companies_house_handler):** Completed Phase v2a upgrade (#220). Added `context` parameter to carry forward session state (`company_number`, `company_name`, `officer_filter`, etc.). Added `partial` envelope status and optional `pipeline` state to support paused multi-step pipelines (noted as v2b prep in instructions). Updated `_get_officers` to fallback to `company_name` from context and added tests for fallback logic. Updated `examples/gemini_uk_companies_house_handler.py` into a fully interactive chat loop.
 - **Documentation:** CONTRIBUTING and contributor workflow checklists — update `card.json` and output fixtures together when changing `execute()` output (#199).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **`finance/wallet_screening`**: Paginate Etherscan `txlist` (up to 10k normal txs) and surface `metadata.warnings` when history is truncated or unavailable (#214, parent #115).
 - **Skills (finance/uk_companies_house_handler):** Completed Phase v2a upgrade (#220). Added `context` parameter to carry forward session state (`company_number`, `company_name`, `officer_filter`, etc.). Added `partial` envelope status and optional `pipeline` state to support paused multi-step pipelines (noted as v2b prep in instructions). Updated `_get_officers` to fallback to `company_name` from context and added tests for fallback logic. Updated `examples/gemini_uk_companies_house_handler.py` into a fully interactive chat loop.
 - **Documentation:** CONTRIBUTING and contributor workflow checklists — update `card.json` and output fixtures together when changing `execute()` output (#199).
 

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -237,7 +237,7 @@ The skill returns a rich forensic report. Agents act on this data.
 ## Limitations
 
 - **Ethereum only**: The skill screens Ethereum (EVM) addresses exclusively. Bitcoin, Solana, or other chain addresses are not supported and will fail address validation.
-- **Etherscan transaction cap**: Etherscan's `txlist` endpoint returns a maximum of 10,000 transactions per address. Wallets with very high transaction volume will have their older history silently truncated, which may affect PnL and counterparty calculations.
+- **Etherscan transaction cap**: Normal ETH history is fetched via paginated `txlist` (1,000 txs per page, max 10 pages → **10,000 txs**). When that cap is hit, or Etherscan fails, the report includes `metadata.warnings` with codes such as `etherscan_txlist_truncated`, `etherscan_txlist_unavailable`, or `etherscan_txlist_partial`. Treat PnL and counterparty stats as incomplete when warnings are present.
 - **Point-in-time sanctions data**: The bundled JSON lists (`entities.ftm.json`, `malicious_scs_2025.json`, and the normalized lists) reflect the state at the time of the last `maintenance/` run. They must be refreshed periodically to stay current.
 - **No ERC-20 or internal transaction coverage**: Only standard ETH transfers from the Etherscan `txlist` action are analyzed. ERC-20 token transfers, internal transactions, and NFT transfers are not included in financial flow calculations.
 - **Not legal advice**: Risk flags are derived from open-source sanctions data and pattern heuristics. A clean result does not constitute legal clearance.

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -190,14 +190,15 @@ Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "finance/
 
 ## Data Schema
 
-The skill returns a rich forensic report. Agents act on this data.
+The skill returns a rich forensic report. Agents act on this data. `metadata.warnings` is optional — present when Etherscan history is truncated or partially unavailable (see Limitations).
 
 ```json
 {
   "metadata": {
     "screening_time": "2025-01-01T00:00:00",
     "wallet_address": "0xd8dA...",
-    "data_sources_count": 3
+    "data_sources_count": 3,
+    "warnings": ["etherscan_txlist_truncated"]
   },
   "summary": {
     "risk_flag": true,

--- a/skills/finance/wallet_screening/instructions.md
+++ b/skills/finance/wallet_screening/instructions.md
@@ -17,6 +17,7 @@ The tool returns a JSON object. You should summarize this for the user in a prof
 2.  **`summary.malicious_interaction_count` (Integer)**: If > 0, the wallet has touched bad actors. List the `risk_details.malicious_interactions`.
 3.  **`financial_analysis.pnl_eth` / `pnl_usd`**: Profit and Loss. Useful for determining if it's a profitable trader or a victim.
 4.  **`network_analysis.top_10_counterparties`**: Who are they sending money to?
+5.  **`metadata.warnings` (Array, optional)**: If present, tell the user the on-chain history may be **incomplete** — e.g. `etherscan_txlist_truncated` (wallet exceeded the fetch cap), `etherscan_txlist_unavailable`, or `etherscan_txlist_partial`. Do not present PnL or interaction counts as exhaustive when warnings are set.
 
 ## Safety Protocol
 *   If a wallet is **Sanctioned**: severe warning. "⚠️ WARNING: This wallet appears on the following sanctions lists..."

--- a/skills/finance/wallet_screening/manifest.yaml
+++ b/skills/finance/wallet_screening/manifest.yaml
@@ -1,5 +1,5 @@
 name: finance/wallet_screening
-version: 1.0.0
+version: 1.0.1
 description: |
   A comprehensive crypto wallet screening tool. Checks Ethereum addresses against sanctions lists (OFAC, FBI, etc.) and known malicious contracts (Mixers, Scams). analyze transaction history for risk.
 short_description: "Screens Ethereum wallets against OFAC sanctions and mixer lists."

--- a/skills/finance/wallet_screening/skill.py
+++ b/skills/finance/wallet_screening/skill.py
@@ -4,7 +4,7 @@ import re
 import requests
 import glob
 import yaml
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime
 from skillware.core.base_skill import BaseSkill
 
@@ -17,6 +17,10 @@ class WalletScreeningSkill(BaseSkill):
     A specific implementation of a compliance skill that screens Ethereum wallets
     against sanctions lists and malicious contract databases.
     """
+
+    # Etherscan account.txlist pagination (see api.etherscan.io docs).
+    ETHERSCAN_TX_PAGE_OFFSET = 1000
+    ETHERSCAN_TX_MAX_PAGES = 10  # cap: 10_000 normal txs per screen
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         super().__init__(config)
@@ -60,7 +64,7 @@ class WalletScreeningSkill(BaseSkill):
             return {"error": "Missing ETHERSCAN_API_KEY environment variable."}
 
         # 1. Fetch Data
-        txs = self._get_eth_transactions(address)
+        txs, fetch_warnings = self._get_eth_transactions(address)
         eth_balance = self._get_eth_balance(address)
         eth_usd = self._get_price(self.coingecko_url_usd, "usd")
         eth_eur = self._get_price(self.coingecko_url_eur, "eur")
@@ -80,6 +84,7 @@ class WalletScreeningSkill(BaseSkill):
             eth_usd=eth_usd,
             eth_eur=eth_eur,
             txs_count=len(txs),
+            warnings=fetch_warnings,
         )
 
     # --- Loader Helpers ---
@@ -274,25 +279,61 @@ class WalletScreeningSkill(BaseSkill):
         except Exception:
             return 0.0
 
-    def _get_eth_transactions(self, address: str) -> List[Dict]:
+    def _get_eth_transactions(self, address: str) -> Tuple[List[Dict], List[str]]:
+        """Fetch normal ETH txs from Etherscan with pagination and warning codes."""
         url = "https://api.etherscan.io/api"
-        params = {
-            "module": "account",
-            "action": "txlist",
-            "address": address,
-            "startblock": 0,
-            "endblock": 99999999,
-            "sort": "asc",
-            "apikey": self.etherscan_api_key,
-        }
-        try:
-            resp = requests.get(url, params=params, timeout=15)
-            data = resp.json()
-            if data.get("status") == "1":
-                return data["result"]
-        except Exception:
-            pass
-        return []
+        warnings: List[str] = []
+        all_txs: List[Dict] = []
+        page = 1
+
+        while page <= self.ETHERSCAN_TX_MAX_PAGES:
+            params = {
+                "module": "account",
+                "action": "txlist",
+                "address": address,
+                "startblock": 0,
+                "endblock": 99999999,
+                "page": page,
+                "offset": self.ETHERSCAN_TX_PAGE_OFFSET,
+                "sort": "asc",
+                "apikey": self.etherscan_api_key,
+            }
+            try:
+                resp = requests.get(url, params=params, timeout=15)
+                data = resp.json()
+            except Exception:
+                warnings.append(
+                    "etherscan_txlist_unavailable"
+                    if page == 1
+                    else "etherscan_txlist_partial"
+                )
+                break
+
+            if data.get("status") != "1":
+                message = str(data.get("message", "")).lower()
+                if page == 1 and "no transactions found" in message:
+                    return [], warnings
+                warnings.append(
+                    "etherscan_txlist_unavailable"
+                    if page == 1
+                    else "etherscan_txlist_partial"
+                )
+                break
+
+            batch = data.get("result")
+            if not isinstance(batch, list):
+                warnings.append("etherscan_txlist_unavailable")
+                break
+
+            all_txs.extend(batch)
+            if len(batch) < self.ETHERSCAN_TX_PAGE_OFFSET:
+                break
+            if page >= self.ETHERSCAN_TX_MAX_PAGES:
+                warnings.append("etherscan_txlist_truncated")
+                break
+            page += 1
+
+        return all_txs, warnings
 
     def _get_eth_balance(self, address: str) -> float:
         url = "https://api.etherscan.io/api"
@@ -445,7 +486,9 @@ class WalletScreeningSkill(BaseSkill):
         eth_usd,
         eth_eur,
         txs_count,
+        warnings=None,
     ):
+        warnings = warnings or []
         pnl = analysis["value_out"] - analysis["value_in"] - analysis["gas_paid"]
         pnl_pct = (
             ((pnl) / analysis["value_in"] * 100) if analysis["value_in"] > 0 else 0.0
@@ -460,12 +503,16 @@ class WalletScreeningSkill(BaseSkill):
             key=lambda x: -x[1],
         )[:10]
 
+        metadata: Dict[str, Any] = {
+            "screening_time": datetime.now().isoformat(),
+            "wallet_address": address,
+            "data_sources_count": len(self.additional_datasets) + 2,
+        }
+        if warnings:
+            metadata["warnings"] = warnings
+
         return {
-            "metadata": {
-                "screening_time": datetime.now().isoformat(),
-                "wallet_address": address,
-                "data_sources_count": len(self.additional_datasets) + 2,
-            },
+            "metadata": metadata,
             "summary": {
                 "risk_flag": bool(sanctions_hits)
                 or bool(analysis["malicious_interactions"]),

--- a/skills/finance/wallet_screening/test_skill.py
+++ b/skills/finance/wallet_screening/test_skill.py
@@ -82,3 +82,138 @@ def test_execute_success(mock_get, skill):
     assert "summary" in result
     assert result["summary"]["balance_eth"] == 1.0
     assert result["summary"]["balance_usd"] == 2000.0
+
+
+def _sample_tx(index: int = 0) -> dict:
+    return {
+        "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".lower(),
+        "to": "0x123",
+        "value": "500000000000000000",
+        "isError": "0",
+        "gasUsed": "21000",
+        "gasPrice": "1000000000",
+        "hash": f"0x{'a' * 62}{index:02x}",
+    }
+
+
+def _mock_price_and_balance_side_effect():
+    mock_eth_balance = MagicMock()
+    mock_eth_balance.json.return_value = {
+        "status": "1",
+        "result": "1000000000000000000",
+    }
+    mock_price = MagicMock()
+    mock_price.json.return_value = {"ethereum": {"usd": 2000.0, "eur": 1800.0}}
+
+    def side_effect(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if params.get("action") == "balance":
+            return mock_eth_balance
+        return mock_price
+
+    return side_effect
+
+
+@patch("skills.finance.wallet_screening.skill.requests.get")
+def test_txlist_pagination_merges_pages(mock_get, skill, monkeypatch):
+    skill.etherscan_api_key = "dummy_key"
+    monkeypatch.setattr(skill, "ETHERSCAN_TX_PAGE_OFFSET", 2)
+    monkeypatch.setattr(skill, "ETHERSCAN_TX_MAX_PAGES", 5)
+
+    get_side_effect = _mock_price_and_balance_side_effect()
+
+    def tx_side_effect(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if params.get("action") == "txlist":
+            page = int(params.get("page", 1))
+            if page == 1:
+                return MagicMock(
+                    json=lambda: {
+                        "status": "1",
+                        "result": [_sample_tx(1), _sample_tx(2)],
+                    }
+                )
+            if page == 2:
+                return MagicMock(
+                    json=lambda: {"status": "1", "result": [_sample_tx(3)]}
+                )
+            raise AssertionError(f"unexpected page {page}")
+        return get_side_effect(url, **kwargs)
+
+    mock_get.side_effect = tx_side_effect
+
+    result = skill.execute({"address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"})
+
+    assert "error" not in result
+    assert result["summary"]["total_transactions"] == 3
+    assert "warnings" not in result["metadata"]
+
+
+@patch("skills.finance.wallet_screening.skill.requests.get")
+def test_txlist_truncation_warning(mock_get, skill, monkeypatch):
+    skill.etherscan_api_key = "dummy_key"
+    monkeypatch.setattr(skill, "ETHERSCAN_TX_PAGE_OFFSET", 1)
+    monkeypatch.setattr(skill, "ETHERSCAN_TX_MAX_PAGES", 2)
+
+    get_side_effect = _mock_price_and_balance_side_effect()
+
+    def tx_side_effect(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if params.get("action") == "txlist":
+            return MagicMock(json=lambda: {"status": "1", "result": [_sample_tx()]})
+        return get_side_effect(url, **kwargs)
+
+    mock_get.side_effect = tx_side_effect
+
+    result = skill.execute({"address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"})
+
+    assert result["metadata"]["warnings"] == ["etherscan_txlist_truncated"]
+    assert result["summary"]["total_transactions"] == 2
+
+
+@patch("skills.finance.wallet_screening.skill.requests.get")
+def test_txlist_unavailable_warning(mock_get, skill):
+    skill.etherscan_api_key = "dummy_key"
+
+    get_side_effect = _mock_price_and_balance_side_effect()
+
+    def tx_side_effect(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if params.get("action") == "txlist":
+            return MagicMock(
+                json=lambda: {"status": "0", "message": "NOTOK", "result": []}
+            )
+        return get_side_effect(url, **kwargs)
+
+    mock_get.side_effect = tx_side_effect
+
+    result = skill.execute({"address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"})
+
+    assert result["metadata"]["warnings"] == ["etherscan_txlist_unavailable"]
+    assert result["summary"]["total_transactions"] == 0
+
+
+@patch("skills.finance.wallet_screening.skill.requests.get")
+def test_txlist_no_transactions_no_warning(mock_get, skill):
+    skill.etherscan_api_key = "dummy_key"
+
+    get_side_effect = _mock_price_and_balance_side_effect()
+
+    def tx_side_effect(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if params.get("action") == "txlist":
+            return MagicMock(
+                json=lambda: {
+                    "status": "0",
+                    "message": "No transactions found",
+                    "result": [],
+                }
+            )
+        return get_side_effect(url, **kwargs)
+
+    mock_get.side_effect = tx_side_effect
+
+    result = skill.execute({"address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"})
+
+    assert "warnings" not in result["metadata"]
+    assert result["summary"]["total_transactions"] == 0


### PR DESCRIPTION
## Summary
- Paginate Etherscan `account.txlist` (1k per page, cap 10k txs)
- Add `metadata.warnings` when history is truncated or unavailable
- Update agent `instructions.md` and bundle tests (mocked only)

Fixes #214 · Part of #115

## Test plan
- [x] `pytest skills/finance/wallet_screening/test_skill.py tests/skills/finance/test_wallet_screening.py -q` (18 passed)
- [x] `flake8` + `black` on changed files