### PR TITLE
feat(loader): auto-discover BaseSkill subclass in load_skill() (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Loader**: `SkillLoader.load_skill()` auto-discovers the single `BaseSkill` subclass in each `skill.py` and exposes it as `bundle["class"]`; `get_skill_class()` helper added. Existing `bundle["module"]` usage is unchanged (#89).
 - **Loader**: `SkillLoader.load_skill()` validates that `manifest.yaml` `name` matches the path-derived registry ID for `category/skill_name` layouts; emits `SkillwareIdentityWarning` on mismatch (warn-only v1). Flat private skills under a skill root are unchanged. Bundles now include optional `registry_id` (#200).
 - **Version policy**: Raise security support floor to `>= 0.3.5`, legacy band `0.3.0`–`0.3.4` (silent CLI), unsupported advisory for installs below `0.3.0` (#192).
 - **`office/pdf_form_filler`** and **`defi/evm_tx_handler`**: Align `manifest.yaml` `name` with registry paths (`office/pdf_form_filler`, `defi/evm_tx_handler`); update examples and docs to use manifest-derived tool dispatch (#201).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,8 @@ requirements:
 
 ### 2. `skill.py` (logic)
 
-- Implement deterministic Python logic (planned: inherit from `BaseSkill` where applicable).
+- Define **exactly one** concrete subclass of `BaseSkill` per skill file. `SkillLoader.load_skill()` discovers it automatically as `bundle["class"]` (see `SkillLoader.get_skill_class()`).
+- Implement deterministic Python logic; inherit from `BaseSkill`.
 - Accept a dictionary of inputs; return a JSON-serializable dictionary.
 - Catch internal errors and return a structured error report; do not crash the host agent.
 - Do **not** print to stdout or stderr for normal operation.

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -271,7 +271,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `skills/<category>/<skill_name>/` exists with full bundle
 - [ ] `manifest.yaml`: `name` (`category/skill_name`, matches folder), `version`, `description`, `parameters`, `constitution`, real `issuer`
 - [ ] Optional: `short_description` field (~80 chars) for a concise one-line summary in `skillware list`
-- [ ] `skill.py`: deterministic, JSON-serializable returns, safe error handling
+- [ ] `skill.py`: exactly one `BaseSkill` subclass (auto-discovered as `bundle["class"]`); deterministic, JSON-serializable returns, safe error handling
 - [ ] `instructions.md`: when to use, how to interpret output, limitations
 - [ ] `card.json`: `issuer` matches manifest
 - [ ] `test_skill.py` (bundle test) passes — `pytest skills/<category>/<skill_name>/test_skill.py` or `skillware test <category>/<skill_name>`

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -53,7 +53,7 @@ When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestr
 
 ### Step 1: Discovery & Loading
 The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
-*   It dynamically imports the `skill.py` module.
+*   It dynamically imports the `skill.py` module and auto-discovers the single `BaseSkill` subclass as `bundle["class"]` (no hardcoded class names required).
 *   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
 *   It reads `instructions.md` and `card.json`.
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -3,7 +3,7 @@
 Every integration follows the same execution pattern:
 
 1. `bundle = SkillLoader.load_skill("<category>/<skill_name>")`
-2. `skill = bundle["module"].<SkillClass>()`
+2. `skill = bundle["class"]()` — or `SkillLoader.get_skill_class(bundle)()`; `bundle["module"]` remains available for backward compatibility.
 3. Adapt `bundle` for the model (`to_gemini_tool`, `to_claude_tool`, etc.).
 4. Pass `bundle["instructions"]` as system context.
 5. On tool call, `result = skill.execute(arguments)` and return JSON to the model.
@@ -30,8 +30,7 @@ Provider guides contain full API details. Skill pages contain copy-paste example
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-SkillClass = bundle["module"].TOSEvaluatorSkill
-result = SkillClass().execute(
+result = bundle["class"]().execute(
     {
         "target_url": "https://example.com",
         "intended_action": "crawl documentation for research",

--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 import warnings
@@ -5,7 +6,7 @@ import yaml
 import json
 import importlib.util
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Type
 
 
 class SkillwareIdentityWarning(UserWarning):
@@ -187,13 +188,51 @@ class SkillLoader:
         )
 
     @staticmethod
+    def _discover_skill_class(module: Any, skill_file: str) -> Type[Any]:
+        """
+        Return the single BaseSkill subclass defined in the loaded skill module.
+        """
+        from skillware.core.base_skill import BaseSkill
+
+        skill_classes = [
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isclass)
+            if issubclass(obj, BaseSkill)
+            and obj is not BaseSkill
+            and obj.__module__ == module.__name__
+        ]
+        if len(skill_classes) == 1:
+            return skill_classes[0]
+        if not skill_classes:
+            raise ImportError(
+                f"Expected exactly one BaseSkill subclass in {skill_file}, found none."
+            )
+        names = [cls.__name__ for cls in skill_classes]
+        raise ImportError(
+            f"Expected exactly one BaseSkill subclass in {skill_file}, "
+            f"found: {names}"
+        )
+
+    @staticmethod
+    def get_skill_class(skill_bundle: Dict[str, Any]) -> Type[Any]:
+        """Return the BaseSkill subclass from a bundle produced by load_skill()."""
+        skill_class = skill_bundle.get("class")
+        if skill_class is None:
+            raise KeyError(
+                "Skill bundle has no 'class' key; load with SkillLoader.load_skill() first."
+            )
+        return skill_class
+
+    @staticmethod
     def load_skill(skill_path: str) -> Dict[str, Any]:
         """
         Loads a skill and returns a bundled object with:
-        - class: The Python class (uninstantiated)
+        - module: The loaded skill.py module
+        - class: The BaseSkill subclass (uninstantiated)
         - manifest: The YAML metadata
         - instructions: The system prompt content
         - card: The UI card definition
+        - registry_id: Path-derived registry ID when validation applies
         """
         resolved_path = SkillLoader._resolve_skill_path(skill_path)
         skill_path = str(resolved_path)
@@ -241,12 +280,10 @@ class SkillLoader:
         if spec and spec.loader:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-            # Find the class that inherits from BaseSkill?
-            # For now assume the user looks for the exported class or we inspect.
-            # We'll just return the module and let the user instantiate the known class name
-            # or we could enforce a naming convention.
+            skill_class = SkillLoader._discover_skill_class(module, skill_file)
             return {
                 "module": module,
+                "class": skill_class,
                 "manifest": manifest,
                 "instructions": instructions,
                 "card": card,

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -7,7 +7,7 @@ Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from 
 1. **Rename** the folder to match your skill ID (e.g. `skills/finance/my_skill`).
 2. **Packaging**: Add empty `__init__.py` files in `skills/<category>/` (new categories only) and in your skill folder so PyPI wheels include the full bundle. No `pyproject.toml` changes per skill.
 3. **`manifest.yaml`**: Set real `name` to the full registry ID (`category/skill_name`, matching the folder path), `version`, `description`, `short_description`, `parameters`, `constitution`, and `issuer` (`name` + `email` required; `github` / `org` optional). `SkillLoader.load_skill()` warns when `name` diverges from the path under registry layout; flat private layouts (`skills/<skill_name>/`) are not validated.
-4. **`skill.py`**: Implement deterministic logic; no LLM-generated code in the skill body.
+4. **`skill.py`**: Implement deterministic logic with exactly one `BaseSkill` subclass (loaded as `bundle["class"]`); no LLM-generated code in the skill body.
 5. **`instructions.md`**: Tell the agent when and how to use the tool.
 6. **`card.json`**: Mirror `issuer` from the manifest; customize UI fields.
 7. **`test_skill.py`**: Bundle test (required; enforced by `tests/test_skill_issuer.py`); offline, mock external services, including HTTP clients, LLM APIs, embedding/model loaders, and any first-run model downloads; run `pytest skills/<category>/<skill_name>/test_skill.py` or `skillware test <category>/<skill_name>`. See [TESTING.md](../../docs/TESTING.md).

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -24,6 +24,61 @@ def test_load_skill_registry_has_manifest():
     bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
     assert bundle["manifest"].get("name") == "optimization/prompt_rewriter"
     assert bundle["registry_id"] == "optimization/prompt_rewriter"
+    assert bundle["class"].__name__ == "PromptRewriter"
+    assert SkillLoader.get_skill_class(bundle) is bundle["class"]
+
+
+def test_load_skill_class_is_instantiable():
+    bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
+    skill = bundle["class"]()
+    result = skill.execute({"raw_text": "hello world"})
+    assert "error" not in result
+
+
+def test_discover_skill_class_requires_exactly_one_subclass(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "broken" / "no_class"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "name: broken/no_class\nversion: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ImportError, match="found none"):
+        SkillLoader.load_skill("broken/no_class")
+
+
+def test_discover_skill_class_rejects_multiple_subclasses(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "broken" / "two_classes"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "manifest.yaml").write_text(
+        "name: broken/two_classes\nversion: 0.1.0\ndescription: test\n"
+        "parameters:\n  type: object\n  properties: {}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class FirstSkill(BaseSkill):\n"
+        "    @property\n"
+        "    def manifest(self):\n"
+        "        return {}\n"
+        "    def execute(self, params):\n"
+        "        return {}\n"
+        "class SecondSkill(BaseSkill):\n"
+        "    @property\n"
+        "    def manifest(self):\n"
+        "        return {}\n"
+        "    def execute(self, params):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ImportError, match="found: \\['FirstSkill', 'SecondSkill'\\]"):
+        SkillLoader.load_skill("broken/two_classes")
 
 
 def test_load_skill_registry_id_matches_bundled_skills():


### PR DESCRIPTION
## Description

Implements **#89**: `SkillLoader.load_skill()` now inspects `skill.py` for exactly one `BaseSkill` subclass and exposes it as `bundle["class"]`. Adds `SkillLoader.get_skill_class()` for programmatic access.

**Non-breaking**, `bundle["module"]` and existing `bundle["module"].SomeSkill()` call sites are unchanged. Clear `ImportError` when zero or multiple subclasses are found.

Docs updated for the preferred pattern (`bundle["class"]()` in `agent_loops.md`, `CONTRIBUTING`, template README). Examples/catalog left as-is intentionally.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .`, `pytest skills/` (or `skillware test`), and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## New or updated skill (complete only if this PR adds or changes a skill under `skills/`)

Skip, framework-only PR, no registry skill changes.

## Constitution & Safety (if adding or modifying a skill)

N/A, loader discovery only, no skill execution logic changed.

## Related Issues

Fixes #89