### PR TITLE
docs: add minimal architecture flow diagrams to README, introduction,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation**: Add minimal Mermaid architecture flow diagrams to README, introduction, and agent loops; add cross-links and direct-path footnotes (#210).
+
 ### Changed
 
 - **Loader**: `SkillLoader.load_skill()` auto-discovers the single `BaseSkill` subclass in each `skill.py` and exposes it as `bundle["class"]`; `get_skill_class()` helper added. Existing `bundle["module"]` usage is unchanged (#89).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 <div align="center">
   <a href="#mission">Mission</a> •
+  <a href="#how-it-works">How it works</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#documentation">Documentation</a> •
@@ -47,6 +48,18 @@ A **Skill** in this framework provides everything an Agent needs to master a dom
 ### Skill library
 
 Browse capabilities by category in the [Skill library](docs/skills/README.md) or on our <a href="https://skillware.site/skills" target="_blank" rel="noopener noreferrer">site&nbsp;↗</a>.
+
+## How it works
+
+```mermaid
+flowchart LR
+    Registry[(Registry / Disk)] -->|Load| Skillware[Skillware Loader]
+    Skillware -->|Adapt| Host[Host App]
+    Host -->|Prompt + Tools| Model([AI Model])
+    Model -->|Tool Call| Host
+```
+
+Install the registry once. Skillware loads a bundle and adapts it to your model's tool format — you run the loop. For details on how the loader turns the manifest into a tool, see the [Introduction](docs/introduction.md).
 
 ## Architecture
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -49,6 +49,23 @@ Skillware/
         └── loader.py               # The engine that bridges the skill to the LLM
 ```
 
+```mermaid
+flowchart TD
+    subgraph Bundle["Skill Bundle Folder"]
+        Manifest[manifest.yaml]
+        Instructions[instructions.md]
+        SkillPy[skill.py]
+    end
+
+    Loader[SkillLoader] -->|Loads| Bundle
+    Loader -->|Adapts manifest| Adapters[Model Tool Schemas]
+    Host[Host App] -.->|Directly calls execute| SkillPy
+
+    style Host stroke-width:2px,stroke-dasharray: 5 5
+```
+
+A skill is a folder on disk. The loader turns the manifest into whatever tool schema your runtime expects. For the code loop that hooks these adapters up, see [Agent Loops](usage/agent_loops.md).
+
 When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestration happens behind the scenes:
 
 ### Step 1: Discovery & Loading

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -55,17 +55,26 @@ flowchart TD
         Manifest[manifest.yaml]
         Instructions[instructions.md]
         SkillPy[skill.py]
-        CardJson[card.json]
+        CardJson["card.json (optional)"]
     end
 
     Loader[SkillLoader] -->|Loads| Bundle
-    Loader -->|Adapts manifest| Adapters[Model Tool Schemas]
+    Loader --> Adapters
+
+    subgraph Adapters["Model adapters"]
+        direction LR
+        G[Gemini]
+        C[Claude]
+        O[OpenAI]
+        OL[Ollama]
+    end
+
     Host[Host App] -.->|Directly calls execute| SkillPy
 
     style Host stroke-width:2px,stroke-dasharray: 5 5
 ```
 
-A skill is a folder on disk. The loader turns the manifest into whatever tool schema your runtime expects. For the code loop that hooks these adapters up, see [Agent Loops](usage/agent_loops.md).
+A skill is a folder on disk. The loader turns the manifest into whatever tool schema your runtime expects. For the high-level picture, see [How it works](../README.md#how-it-works); for the code loop that hooks these adapters up, see [Agent Loops](usage/agent_loops.md).
 
 When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestration happens behind the scenes:
 
@@ -73,7 +82,14 @@ When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestr
 The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
 *   It dynamically imports the `skill.py` module and auto-discovers the single `BaseSkill` subclass as `bundle["class"]` (no hardcoded class names required).
 *   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Gemini and Claude use as the tool name; OpenAI and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
-*   It reads `instructions.md` and `card.json`.
+*   It reads `instructions.md` and, when present, optional `card.json`.
+
+```mermaid
+flowchart LR
+    ID[category/name] --> FIND[resolve]
+    FIND --> PACK[bundle]
+    PACK --> ADAPT[adapt]
+```
 
 For how skills are resolved on disk, the provenance tiers, and what to check before loading skills you did not write, see [Skill trust model & operator security](security/skill-trust-model.md).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -55,6 +55,7 @@ flowchart TD
         Manifest[manifest.yaml]
         Instructions[instructions.md]
         SkillPy[skill.py]
+        CardJson[card.json]
     end
 
     Loader[SkillLoader] -->|Loads| Bundle

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -39,12 +39,14 @@ Your loop always looks like this. Skillware handles load and tool translation; y
 | **execute** | `bundle["class"]().execute(args)` |
 | **return** | Tool result &rarr; model |
 
-> **Direct path (no model)**: You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON.
->
-> ```mermaid
-> flowchart LR
->     Load((1. Load)) --> Execute((2. Execute)) --> JSON((3. JSON))
-> ```
+### Direct path (no model)
+
+You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON.
+
+```mermaid
+flowchart LR
+    Load((1. Load)) --> Execute((2. Execute)) --> JSON((3. JSON))
+```
 
 Provider guides contain full API details. Skill pages contain copy-paste examples with skill-specific paths and sample user messages.
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -4,11 +4,23 @@ Every integration follows the same execution pattern:
 
 ```mermaid
 flowchart TD
-    subgraph HostLoop ["Host-Centric Loop"]
-        direction TB
-        Load((1. Load)) --> Wire((2. Wire)) --> Prompt((3. Prompt))
-        Prompt --> Execute((4. Execute)) --> Return((5. Return)) --> Prompt
+    subgraph Skillware
+        Load((1. Load)) --> Adapt((2. Wire / Adapt))
     end
+
+    subgraph Model
+        Prompt((3. Prompt))
+        Return((5. Return))
+    end
+
+    subgraph Host ["Host App"]
+        Execute((4. Execute))
+    end
+
+    Adapt -->|Inject tools/instructions| Prompt
+    Prompt -->|Tool call request| Execute
+    Execute -->|Tool result JSON| Return
+    Return -->|Loop next iteration| Prompt
 ```
 
 Your loop always looks like this. Skillware handles load and tool translation; you call execute and pass JSON back. To see what files a skill contains, see the [Introduction](../introduction.md).
@@ -24,10 +36,15 @@ Your loop always looks like this. Skillware handles load and tool translation; y
 | **load** | `SkillLoader.load_skill(id)` |
 | **wire** | `to_*_tool(bundle)` + `bundle["instructions"]` &rarr; model |
 | **prompt** | User query &rarr; model |
-| **execute** | `SkillClass().execute(args)` |
+| **execute** | `bundle["class"]().execute(args)` |
 | **return** | Tool result &rarr; model |
 
 > **Direct path (no model)**: You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON.
+>
+> ```mermaid
+> flowchart LR
+>     Load((1. Load)) --> Execute((2. Execute)) --> JSON((3. JSON))
+> ```
 
 Provider guides contain full API details. Skill pages contain copy-paste examples with skill-specific paths and sample user messages.
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -2,11 +2,32 @@
 
 Every integration follows the same execution pattern:
 
+```mermaid
+flowchart TD
+    subgraph HostLoop ["Host-Centric Loop"]
+        direction TB
+        Load((1. Load)) --> Wire((2. Wire)) --> Prompt((3. Prompt))
+        Prompt --> Execute((4. Execute)) --> Return((5. Return)) --> Prompt
+    end
+```
+
+Your loop always looks like this. Skillware handles load and tool translation; you call execute and pass JSON back. To see what files a skill contains, see the [Introduction](../introduction.md).
+
 1. `bundle = SkillLoader.load_skill("<category>/<skill_name>")`
 2. `skill = bundle["class"]()` — or `SkillLoader.get_skill_class(bundle)()`; `bundle["module"]` remains available for backward compatibility.
 3. Adapt `bundle` for the model (`to_gemini_tool`, `to_claude_tool`, etc.).
 4. Pass `bundle["instructions"]` as system context.
 5. On tool call, `result = skill.execute(arguments)` and return JSON to the model.
+
+| Step | Call |
+| :--- | :--- |
+| **load** | `SkillLoader.load_skill(id)` |
+| **wire** | `to_*_tool(bundle)` + `bundle["instructions"]` &rarr; model |
+| **prompt** | User query &rarr; model |
+| **execute** | `SkillClass().execute(args)` |
+| **return** | Tool result &rarr; model |
+
+> **Direct path (no model)**: You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON.
 
 Provider guides contain full API details. Skill pages contain copy-paste examples with skill-specific paths and sample user messages.
 


### PR DESCRIPTION
## Description

This PR implements the following updates to the documentation as requested in the review comments:

1. **Agent Loops Diagram & Table Updates (`docs/usage/agent_loops.md`)**:
   - Refactored the core agent loops flowchart to explicitly show the division of responsibilities: **Skillware** (loading & adaptation), **Host App** (local execution), and the **AI Model** (prompting, cognition, and return/synthesis).
   - Fixed the step table in `agent_loops.md` to use the correct `bundle["class"]().execute(args)` format instead of the outdated `SkillClass().execute(args)` to match step 2.
   - Added a mini Mermaid flowchart representing the direct execution path (Load ➔ Execute ➔ JSON) for direct integrations without an LLM.

2. **Introduction Flowchart Updates (`docs/introduction.md`)**:
   - Updated the "Skill Bundle Folder" flowchart subgraph to include `card.json` as an optional bundle file alongside `manifest.yaml`, `instructions.md`, and `skill.py`.

### Type of Change (Matches Issue Templates)

- [ ] **Skill Proposal**: New Skill (Contains `manifest.yaml`, `skill.py`, and `instructions.md`)
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update (Changes to `base_skill.py`, `loader.py`, etc.)

## Checklist (all PRs)

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `python -m flake8 .`, `pytest skills/` (or `skillware test`), and `pytest tests/` locally (or the subset relevant to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]` if this PR changes user-visible behavior.
- [x] `examples/README.md` is updated if this PR adds, renames, or removes a runnable script under `examples/`.

## Related Issues
Fixes #210
