### PR TITLE
docs: compact architecture Mermaid diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation**: Compact architecture Mermaid diagrams — shorter README labels, model-agnostic adapter nodes in introduction, horizontal agent-loop layout with role table (#210 follow-up).
+
 ## [0.4.1] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Browse capabilities by category in the [Skill library](docs/skills/README.md) or
 
 ```mermaid
 flowchart LR
-    Registry[(Registry / Disk)] -->|Load| Skillware[Skillware Loader]
-    Skillware -->|Adapt| Host[Host App]
-    Host -->|Prompt + Tools| Model([AI Model])
-    Model -->|Tool Call| Host
+    Registry[(Registry)] -->|Load| Loader[Loader]
+    Loader -->|Adapt| Host[Host]
+    Host -->|Prompt + Tools| LogicalSystems([Logical Systems])
+    LogicalSystems -->|Tool Call| Host
 ```
 
 Install the registry once. Skillware loads a bundle and adapts it to your model's tool format — you run the loop. For details on how the loader turns the manifest into a tool, see the [Introduction](docs/introduction.md).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -55,7 +55,6 @@ flowchart TD
         Manifest[manifest.yaml]
         Instructions[instructions.md]
         SkillPy[skill.py]
-        CardJson["card.json (optional)"]
     end
 
     Loader[SkillLoader] -->|Loads| Bundle
@@ -63,10 +62,8 @@ flowchart TD
 
     subgraph Adapters["Model adapters"]
         direction LR
-        G[Gemini]
-        C[Claude]
-        O[OpenAI]
-        OL[Ollama]
+        API[API models]
+        Local[Local models]
     end
 
     Host[Host App] -.->|Directly calls execute| SkillPy

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -1,29 +1,21 @@
 # Agent loops with Skillware
 
-Every integration follows the same execution pattern:
+Every integration follows the same execution pattern. **Skillware** loads the bundle and adapts it to your runtime's tool format; **your host app** calls `execute()` and passes JSON back to the model. The diagram below is the loop you implement in code — for bundle contents, see the [Introduction](../introduction.md).
 
 ```mermaid
-flowchart TD
-    subgraph Skillware
-        Load((1. Load)) --> Adapt((2. Wire / Adapt))
-    end
-
-    subgraph Model
-        Prompt((3. Prompt))
-        Return((5. Return))
-    end
-
-    subgraph Host ["Host App"]
-        Execute((4. Execute))
-    end
-
-    Adapt -->|Inject tools/instructions| Prompt
-    Prompt -->|Tool call request| Execute
-    Execute -->|Tool result JSON| Return
-    Return -->|Loop next iteration| Prompt
+flowchart LR
+    Load[load] --> Wire[wire]
+    Wire --> Prompt[prompt]
+    Prompt --> Execute[execute]
+    Execute --> Return[return]
+    Return --> Prompt
 ```
 
-Your loop always looks like this. Skillware handles load and tool translation; you call execute and pass JSON back. To see what files a skill contains, see the [Introduction](../introduction.md).
+| Role | Steps |
+| :--- | :--- |
+| **Skillware** | load, wire |
+| **Model** | prompt, return |
+| **Host** | execute |
 
 1. `bundle = SkillLoader.load_skill("<category>/<skill_name>")`
 2. `skill = bundle["class"]()` — or `SkillLoader.get_skill_class(bundle)()`; `bundle["module"]` remains available for backward compatibility.


### PR DESCRIPTION
## Description

Follow-up polish on the #210 architecture diagrams: shorter README labels, a tighter introduction diagram (three-file bundle + model-agnostic adapters), and a compact horizontal agent-loop layout with intro prose and a role table. Docs only — no loader or skill behavior changes.

### Type of Change

- [x] **Doc Fix**: Documentation Update

## Checklist

- [x] My code follows the **Agent Code of Conduct**.
- [x] Relevant checks not required (documentation-only; no Python changes).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] `examples/README.md` unchanged (no example script changes).

## Related Issues

Refs #210 (diagram follow-up after #217).