### PR TITLE
feat(cli): fix splash logo and add Rich gradient branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **CLI**: Interactive splash — correct SKILLWARE ASCII logo, Rich 3-stop gradient on logo and tagline (`#D4E4F1` → `#79B6D8` → `#EBD8DC`), shared `_package_version_str()` for splash and `--version`, tagline `Skillware v{version} — Skill Management Framework` (#222).
 - **Documentation**: Compact architecture Mermaid diagrams — shorter README labels, model-agnostic adapter nodes in introduction, horizontal agent-loop layout with role table (#210 follow-up).
 
 ## [0.4.1] - 2026-07-08

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -70,7 +70,9 @@ interactive numbered menu:
 
     skillware
 
-The splash displays the current version and links to the project site and
+The splash shows a gradient-styled **SKILLWARE** ASCII logo, a tagline in the
+form `Skillware v{version} — Skill Management Framework` (same version string
+as `skillware --version`), and dim footer links to the project site and
 repository. The menu accepts both number input (`1`) and command name (`list`).
 After each command completes, the menu re-prints automatically. Press `q` or
 `Ctrl+C` to exit.
@@ -207,7 +209,8 @@ The CLI uses a pastel color palette consistent with the project's visual identit
 | Table headers and borders | Lavender | `#C7CEEA` |
 | Category column | Peach | `#FFDAC1` |
 | Skill ID column | Mint | `#B5EAD7` |
-| Splash screen | Lavender | `#C7CEEA` |
+| Splash logo and tagline | Gradient (ice → sky → blush) | `#D4E4F1` → `#79B6D8` → `#EBD8DC` |
+| Splash footer links | Lavender | `#C7CEEA` |
 | Interactive menu | Peach | `#FFDAC1` |
 
 ## short_description field

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -27,6 +27,19 @@ BORDER_STYLE = "#C7CEEA"  # lavender  - table border
 SPLASH_STYLE = "#C7CEEA"  # lavender  - skillware splash color
 MENU_STYLE = "#FFDAC1"  # peach     - menu category
 
+SPLASH_GRADIENT_START = (0xD4, 0xE4, 0xF1)
+SPLASH_GRADIENT_MID = (0x79, 0xB6, 0xD8)
+SPLASH_GRADIENT_END = (0xEB, 0xD8, 0xDC)
+
+_SPLASH_LOGO_LINES = (
+    "  ███████╗██╗  ██╗██╗██╗     ██╗     ██╗    ██╗ █████╗ ██████╗ ███████╗",
+    "  ██╔════╝██║ ██╔╝██║██║     ██║     ██║    ██║██╔══██╗██╔══██╗██╔════╝",
+    "  ███████╗█████╔╝ ██║██║     ██║     ██║ █╗ ██║███████║██████╔╝█████╗",
+    "  ╚════██║██╔═██╗ ██║██║     ██║     ██║███╗██║██╔══██║██╔══██╗██╔══╝",
+    "  ███████║██║  ██╗██║███████╗███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗",
+    "  ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝",
+)
+
 _EXAMPLES_README_REL = Path("examples") / "README.md"
 _PARENT_WALK_LIMIT = 6
 _SKILL_ID_PATTERN = re.compile(r"`([\w-]+/[\w-]+)`")
@@ -549,29 +562,67 @@ def cmd_help(console=None) -> None:
     )
 
 
+def _rgb_to_hex(rgb: Tuple[int, int, int]) -> str:
+    r, g, b = rgb
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _lerp_rgb(
+    start: Tuple[int, int, int], end: Tuple[int, int, int], t: float
+) -> Tuple[int, int, int]:
+    return tuple(int(start[i] + (end[i] - start[i]) * t) for i in range(3))
+
+
+def _splash_gradient_color(column: int, width: int) -> str:
+    if width <= 1:
+        return _rgb_to_hex(SPLASH_GRADIENT_START)
+    t = column / (width - 1)
+    if t <= 0.5:
+        rgb = _lerp_rgb(SPLASH_GRADIENT_START, SPLASH_GRADIENT_MID, t / 0.5)
+    else:
+        rgb = _lerp_rgb(SPLASH_GRADIENT_MID, SPLASH_GRADIENT_END, (t - 0.5) / 0.5)
+    return _rgb_to_hex(rgb)
+
+
+def _gradient_text_line(line: str, width: int) -> Text:
+    text = Text()
+    for column, char in enumerate(line):
+        text.append(char, style=_splash_gradient_color(column, width))
+    return text
+
+
+def _gradient_splash_text(logo_lines: Tuple[str, ...]) -> Text:
+    width = max(len(line) for line in logo_lines)
+    text = Text()
+    for line in logo_lines:
+        text.append(_gradient_text_line(line, width))
+        text.append("\n")
+    return text
+
+
+def _package_version_str() -> str:
+    installed = get_installed_version()
+    if installed is not None:
+        return str(installed)
+    try:
+        return importlib.metadata.version("skillware")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
 def cmd_interactive(console=None, parser=None) -> None:
     """Launch ASCII splash screen and interactive menu."""
     if console is None:
         console = Console()
 
-    try:
-        version = importlib.metadata.version("skillware")
-    except importlib.metadata.PackageNotFoundError:
-        version = "dev"
+    version = _package_version_str()
+    logo_width = max(len(line) for line in _SPLASH_LOGO_LINES)
 
-    splash = r"""
-  ███████╗██╗  ██╗██╗██╗     ██╗    ██╗ █████╗ ██████╗ ███████╗
-  ██╔════╝██║ ██╔╝██║██║     ██║    ██║██╔══██╗██╔══██╗██╔════╝
-  ███████╗█████╔╝ ██║██║     ██║ █╗ ██║███████║██████╔╝█████╗
-  ╚════██║██╔═██╗ ██║██║     ██║███╗██║██╔══██║██╔══██╗██╔══╝
-  ███████║██║  ██╗██║███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗
-  ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝"""
-
-    console.print(Text(splash, style=SPLASH_STYLE))
+    console.print(_gradient_splash_text(_SPLASH_LOGO_LINES))
     console.print(
-        Text(
-            f"  Skill Management Framework — v{version}",
-            style=f"dim {SPLASH_STYLE}",
+        _gradient_text_line(
+            f"  Skillware v{version} — Skill Management Framework",
+            logo_width,
         )
     )
 
@@ -653,8 +704,7 @@ def main() -> None:
         help="Show this help message and exit.",
     )
 
-    _ver = get_installed_version()
-    _version_str = str(_ver) if _ver else "dev"
+    _version_str = _package_version_str()
 
     parser.add_argument(
         "--version",


### PR DESCRIPTION
## Description

Polishes the interactive CLI splash (`skillware` with no subcommand):

- Fixes the ASCII logo so it correctly spells **SKILLWARE** (was missing the second **L**)
- Applies a 3-stop Rich gradient (`#D4E4F1` → `#79B6D8` → `#EBD8DC`) to the logo and tagline
- Adds `_package_version_str()` so the splash and `--version` share the same version resolution
- Updates tagline copy to `Skillware v{version} — Skill Management Framework`

Footer links and menu behavior are unchanged.

Also updates `CHANGELOG.md` and `docs/usage/cli.md` for this user-visible CLI change.

### Type of Change

- [ ] **Skill Proposal**: New Skill
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [ ] **Doc Fix**: Documentation Update
- [x] **Framework Feature / RFC Updates**: Core Framework Update

## Checklist

- [x] My code follows the **Agent Code of Conduct**.
- [x] I have run `pytest tests/test_cli.py` locally (42 passed).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] `docs/usage/cli.md` updated (splash branding and tagline format).
- [ ] `examples/README.md` — N/A (no example changes)

## New or updated skill

N/A — framework-only PR.

## Constitution & Safety

N/A — no skill execution changes.

## Related Issues

Fixes #222