### PR TITLE
docs: sweep vision, bundle class usage, and README Mermaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Documentation**: Docs sweep — README Mermaid Registry alignment; `vision.md` pinned to v0.4.x; skill catalog and usage guides prefer `bundle["class"]()` with explicit `bundle["module"].ClassName()` noted as still supported.
 - **CLI**: Interactive splash — correct SKILLWARE ASCII logo, Rich 3-stop gradient on logo and tagline (`#D4E4F1` → `#79B6D8` → `#EBD8DC`), shared `_package_version_str()` for splash and `--version`, tagline `Skillware v{version} — Skill Management Framework` (#222).
 - **Documentation**: Compact architecture Mermaid diagrams — shorter README labels, model-agnostic adapter nodes in introduction, horizontal agent-loop layout with role table (#210 follow-up).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Browse capabilities by category in the [Skill library](docs/skills/README.md) or
 
 ```mermaid
 flowchart LR
-    Registry[(Registry)] -->|Load| Loader[Loader]
+    Registry[Registry] -->|Load| Loader[Loader]
     Loader -->|Adapt| Host[Host]
     Host -->|Prompt + Tools| LogicalSystems([Logical Systems])
     LogicalSystems -->|Tool Call| Host
@@ -167,9 +167,10 @@ load_env_file()
 # 1. Load the Skill from the Registry
 # The loader reads the code, manifest, and instructions automatically
 skill_bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = skill_bundle["module"].WalletScreeningSkill(
+skill = skill_bundle["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
+# Or: skill = skill_bundle["module"].WalletScreeningSkill(config={...})
 
 # 2. Client & Tool Setup
 client = genai.Client()

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -81,7 +81,9 @@ Registry skills live under `skills/<category>/<skill_name>/` in the repository a
 from skillware.core.loader import SkillLoader
 
 # Load by registry ID (category/skill_name)
-skill = SkillLoader.load_skill("finance/wallet_screening")
+bundle = SkillLoader.load_skill("finance/wallet_screening")
+skill = bundle["class"]()
+# Or: skill = bundle["module"].WalletScreeningSkill()
 ```
 
 ---

--- a/docs/skills/evm_tx_handler.md
+++ b/docs/skills/evm_tx_handler.md
@@ -56,6 +56,9 @@ Copy `skills/defi/evm_tx_handler/config.yaml.example` to `config.yaml` in the sa
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *“Buy 10 DEGEN on Base with USDC”* → `resolve` → `quote` → `preview` → user confirms → `execute` with `confirmed: true`.
 
 ### Runnable examples
@@ -80,7 +83,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("defi/evm_tx_handler")
-skill = bundle["module"].EvmTxHandlerSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 
@@ -116,7 +119,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("defi/evm_tx_handler")
-skill = bundle["module"].EvmTxHandlerSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 
@@ -136,7 +139,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("defi/evm_tx_handler")
-skill = bundle["module"].EvmTxHandlerSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name to openai_tool["function"]["name"] (defi_evm_tx_handler)
@@ -152,7 +155,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("defi/evm_tx_handler")
-skill = bundle["module"].EvmTxHandlerSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -57,6 +57,9 @@ Configure per [API keys for skills](../usage/api_keys.md). The token can also be
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Analyse issue #56 in ARPAHLS/skillware and produce a resolution plan.*
 
 ### Runnable examples
@@ -77,7 +80,7 @@ See [examples/README.md](../../examples/README.md) and [Agent loops](../usage/ag
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
-skill = bundle["module"].IssueResolverSkill()
+skill = bundle["class"]()
 result = skill.execute({
     "issue_url": "https://github.com/owner/repo/issues/42",
     "extra_instructions": "Follow PEP 8. Do not bump the package version.",
@@ -99,7 +102,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
-skill = bundle["module"].IssueResolverSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool_decl = SkillLoader.to_gemini_tool(bundle)
 tool_decl["name"] = SkillLoader._sanitize_function_tool_name("dev_tools/issue_resolver")
@@ -144,7 +147,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
-skill = bundle["module"].IssueResolverSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 response = client.messages.create(
@@ -170,7 +173,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
-skill = bundle["module"].IssueResolverSkill()
+skill = bundle["class"]()
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 openai_tool = SkillLoader.to_openai_tool(bundle)
 response = client.chat.completions.create(
@@ -194,7 +197,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("dev_tools/issue_resolver")
-skill = bundle["module"].IssueResolverSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/mental_coach.md
+++ b/docs/skills/mental_coach.md
@@ -44,7 +44,7 @@ Configure values per [API keys for skills](../usage/api_keys.md). Core crisis an
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("wellness/mental_coach")
-skill = bundle["module"].MentalCoachSkill()
+skill = bundle["class"]()
 
 result = skill.execute(
     {
@@ -68,6 +68,9 @@ See [examples/mental_coach_demo.py](../../examples/mental_coach_demo.py) for loc
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md) (optional `GOOGLE_API_KEY` for evaluator).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *I feel stressed at work and need coping strategies.*
 
 ### Gemini
@@ -80,7 +83,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("wellness/mental_coach")
-skill = bundle["module"].MentalCoachSkill()
+skill = bundle["class"]()
 tool = SkillLoader.to_gemini_tool(bundle)
 client = genai.Client()
 response = client.models.generate_content(
@@ -106,7 +109,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("wellness/mental_coach")
-skill = bundle["module"].MentalCoachSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic()
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use (name wellness/mental_coach): skill.execute(tool_use.input)
@@ -121,7 +124,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("wellness/mental_coach")
-skill = bundle["module"].MentalCoachSkill()
+skill = bundle["class"]()
 client = OpenAI()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 # Match tool_call.function.name (wellness_mental_coach)
@@ -137,7 +140,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("wellness/mental_coach")
-skill = bundle["module"].MentalCoachSkill()
+skill = bundle["class"]()
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),
     base_url="https://api.deepseek.com",

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -48,6 +48,9 @@ Configure values per [API keys for skills](../usage/api_keys.md).
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 ### Runnable examples
 
 See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The runnable scripts currently checked in for this skill are `examples/mica_rag_flow.py`, `examples/mica_claude_flow.py`, and `examples/mica_ollama_flow.py`.
@@ -66,7 +69,7 @@ Sample user message: *Can I issue a stablecoin backed by physical art under an e
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("compliance/mica_module")
-skill = bundle["module"].MiCAModuleSkill()
+skill = bundle["class"]()
 result = skill.execute({
     "user_prompt": "Can I issue a stablecoin backed by physical art under an e-money license?",
     "run_evaluator": True,
@@ -86,7 +89,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
-skill = bundle["module"].MiCAModuleSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -129,7 +132,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
-skill = bundle["module"].MiCAModuleSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # See examples/mica_claude_flow.py for the full loop
@@ -145,7 +148,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
-skill = bundle["module"].MiCAModuleSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name (compliance_mica_module)
@@ -161,7 +164,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/mica_module")
-skill = bundle["module"].MiCAModuleSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/novelty_extractor.md
+++ b/docs/skills/novelty_extractor.md
@@ -61,6 +61,9 @@ This skill requires no API keys or environment variables.
 
 Guides: [Usage index](../usage/README.md) - [Agent loops](../usage/agent_loops.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Filter this dataset and keep only the chunks that contain new information.*
 
 ### Direct execute
@@ -69,7 +72,7 @@ Sample user message: *Filter this dataset and keep only the chunks that contain 
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 
 result = skill.execute({
     "dataset_chunk": "Bitcoin is going to rise.\n\nBitcoin will increase.\n\nThe sky is blue.",
@@ -86,7 +89,7 @@ print(result["redundant_chunks_dropped"])
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 
 result1 = skill.execute({
     "dataset_chunk": "first batch of text...",
@@ -112,7 +115,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -138,7 +141,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 client = anthropic.Anthropic()
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use (name data_engineering/novelty_extractor): skill.execute(tool_use.input)
@@ -153,7 +156,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 client = OpenAI()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 # Match tool_call.function.name (data_engineering_novelty_extractor)
@@ -169,7 +172,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
-skill = bundle["module"].NoveltyExtractor()
+skill = bundle["class"]()
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),
     base_url="https://api.deepseek.com",

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -44,6 +44,9 @@ Configure values per [API keys for skills](../usage/api_keys.md).
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 ### Runnable examples
 
 See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable scripts today are `examples/gemini_pdf_form_filler.py` and `examples/claude_pdf_form_filler.py`. The OpenAI, DeepSeek, and Ollama sections below are catalog snippets only unless separate runnable examples are added later.
@@ -59,7 +62,7 @@ See [examples/README.md](../../examples/README.md) for the current runnable-scri
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
-filler = bundle["module"].PDFFormFillerSkill()
+filler = bundle["class"]()
 result = filler.execute({
     "pdf_path": "/absolute/path/to/form.pdf",
     "instructions": "Name: John Doe. Check the terms of service box.",
@@ -78,7 +81,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
-skill = bundle["module"].PDFFormFillerSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 tool_name = bundle["manifest"]["name"]
@@ -122,7 +125,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
-skill = bundle["module"].PDFFormFillerSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use, match name against bundle["manifest"]["name"] (office/pdf_form_filler):
@@ -139,7 +142,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
-skill = bundle["module"].PDFFormFillerSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name to openai_tool["function"]["name"] (office_pdf_form_filler)
@@ -155,7 +158,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("office/pdf_form_filler")
-skill = bundle["module"].PDFFormFillerSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -61,6 +61,9 @@ The `micro-f1-mask` model detects a variety of entities, including but not limit
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). Skill execution uses local Ollama (`arpacorp/micro-f1-mask`); no cloud agent key required for the masker itself.
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 ### Runnable examples
 
 See [examples/README.md](../../examples/README.md) for the current runnable-script inventory. The dedicated runnable example for this skill is `examples/pii_guardrail_flow.py`, which demonstrates the local execute path rather than a full provider loop.
@@ -73,7 +76,7 @@ Sample user message: *Mask PII in: "Hello John Doe, your wallet 0xabc123 has bee
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("compliance/pii_masker")
-skill = bundle["module"].PIIMaskerSkill()
+skill = bundle["class"]()
 result = skill.execute({
     "text": "Hello John Doe, your wallet 0xabc123 has been verified.",
     "mode": "mask",
@@ -92,7 +95,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
-skill = bundle["module"].PIIMaskerSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -135,7 +138,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
-skill = bundle["module"].PIIMaskerSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use (name compliance/pii_masker): skill.execute(tool_use.input)
@@ -151,7 +154,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
-skill = bundle["module"].PIIMaskerSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name (compliance_pii_masker)
@@ -167,7 +170,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/pii_masker")
-skill = bundle["module"].PIIMaskerSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -26,6 +26,9 @@ This is critical for complex agents facing strict token constraints or high LLM 
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). No skill-specific API keys.
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Compress this prompt before the main model call: "Hello, could you please make sure to read this documentation..."*
 
 ### Runnable examples
@@ -38,7 +41,7 @@ See [examples/README.md](../../examples/README.md) for the current runnable-scri
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-rewriter = bundle["module"].PromptRewriter()
+rewriter = bundle["class"]()
 result = rewriter.execute({
     "raw_text": "Hello, could you please make sure to read this documentation...",
     "compression_aggression": "high",
@@ -57,7 +60,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-skill = bundle["module"].PromptRewriter()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -100,7 +103,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-skill = bundle["module"].PromptRewriter()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use (name optimization/prompt_rewriter): skill.execute(tool_use.input)
@@ -116,7 +119,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-skill = bundle["module"].PromptRewriter()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name to openai_tool["function"]["name"] (optimization_prompt_rewriter)
@@ -132,7 +135,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
-skill = bundle["module"].PromptRewriter()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -42,6 +42,9 @@ Configure values per [API keys for skills](../usage/api_keys.md). Internal gener
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Generate five high-entropy medical coding dispute samples with dual-insurance edge cases.*
 
 ### Runnable examples
@@ -54,7 +57,7 @@ See [examples/README.md](../../examples/README.md) for the current runnable-scri
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-skill = bundle["module"].SyntheticGeneratorSkill()
+skill = bundle["class"]()
 result = skill.execute({
     "domain": "medical_coding_disputes",
     "num_samples": 5,
@@ -76,7 +79,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-skill = bundle["module"].SyntheticGeneratorSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool = SkillLoader.to_gemini_tool(bundle)
 response = client.models.generate_content(
@@ -119,7 +122,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-skill = bundle["module"].SyntheticGeneratorSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # On tool_use (name data_engineering/synthetic_generator): skill.execute(tool_use.input)
@@ -135,7 +138,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-skill = bundle["module"].SyntheticGeneratorSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Match tool_call.function.name (data_engineering_synthetic_generator)
@@ -151,7 +154,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("data_engineering/synthetic_generator")
-skill = bundle["module"].SyntheticGeneratorSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/token_limiter.md
+++ b/docs/skills/token_limiter.md
@@ -64,6 +64,9 @@ Indicative USD rates live in `skills/monitoring/token_limiter/data/model_pricing
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md). No skill-specific API keys.
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Check whether task `scrape_amazon_listings_101` should continue; it has used 125000 tokens with a 100000 limit.*
 
 ### Runnable examples
@@ -84,7 +87,7 @@ See [examples/README.md](../../examples/README.md) and [Agent loops](../usage/ag
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 result = skill.execute({
     "task_id": "scrape_amazon_listings_101",
     "current_token_count": 125_000,
@@ -106,7 +109,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 client = genai.Client()
 tool_decl = SkillLoader.to_gemini_tool(bundle)
 tool_decl["name"] = SkillLoader._sanitize_function_tool_name("monitoring/token_limiter")
@@ -137,7 +140,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 response = client.messages.create(
@@ -168,7 +171,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 tool = SkillLoader.to_openai_tool(bundle)
 response = client.chat.completions.create(
@@ -202,7 +205,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),
     base_url="https://api.deepseek.com",
@@ -236,7 +239,7 @@ import json
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("monitoring/token_limiter")
-skill = bundle["module"].TokenLimiterSkill()
+skill = bundle["class"]()
 prompt = (
     "You may call tools as JSON blocks.\n"
     f"Tool: {bundle['manifest']['name']}\n"

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -59,8 +59,8 @@ Configure values per [API keys for skills](../usage/api_keys.md). The core polic
 from skillware.core.loader import SkillLoader
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-TOSEvaluatorSkill = bundle["module"].TOSEvaluatorSkill
-skill = TOSEvaluatorSkill()
+skill = bundle["class"]()
+# Or: skill = bundle["module"].TOSEvaluatorSkill()
 
 result = skill.execute(
     {
@@ -79,6 +79,9 @@ print(result["reason"])
 ## Usage Examples
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md) (optional `GOOGLE_API_KEY` for the LLM evaluator path).
+
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
 
 Sample user message: *Before crawling https://example.com/docs, check if automated indexing is allowed.*
 
@@ -105,7 +108,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-skill = bundle["module"].TOSEvaluatorSkill()
+skill = bundle["class"]()
 tool = SkillLoader.to_gemini_tool(bundle)
 client = genai.Client()
 response = client.models.generate_content(
@@ -148,7 +151,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-skill = bundle["module"].TOSEvaluatorSkill()
+skill = bundle["class"]()
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 tools = [SkillLoader.to_claude_tool(bundle)]
 # messages.create(..., system=bundle["instructions"], tools=tools)
@@ -165,7 +168,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-skill = bundle["module"].TOSEvaluatorSkill()
+skill = bundle["class"]()
 openai_tool = SkillLoader.to_openai_tool(bundle)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # chat.completions.create(model="gpt-4o", tools=[openai_tool], ...)
@@ -182,7 +185,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-skill = bundle["module"].TOSEvaluatorSkill()
+skill = bundle["class"]()
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 client = OpenAI(
     api_key=os.environ.get("DEEPSEEK_API_KEY"),

--- a/docs/skills/uk_companies_house_handler.md
+++ b/docs/skills/uk_companies_house_handler.md
@@ -54,6 +54,9 @@ Agent loops also need a provider API key (for example `GOOGLE_API_KEY` with Gemi
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Who is the CEO of BP?*
 
 ### Gemini
@@ -67,7 +70,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/uk_companies_house_handler")
-skill = bundle["module"].UkCompaniesHouseHandlerSkill(
+skill = bundle["class"](
     config={"COMPANIES_HOUSE_API_KEY": os.environ.get("COMPANIES_HOUSE_API_KEY")}
 )
 client = genai.Client()
@@ -115,7 +118,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/uk_companies_house_handler")
-skill = bundle["module"].UkCompaniesHouseHandlerSkill(
+skill = bundle["class"](
     config={"COMPANIES_HOUSE_API_KEY": os.environ.get("COMPANIES_HOUSE_API_KEY")}
 )
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
@@ -135,7 +138,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/uk_companies_house_handler")
-skill = bundle["module"].UkCompaniesHouseHandlerSkill(
+skill = bundle["class"](
     config={"COMPANIES_HOUSE_API_KEY": os.environ.get("COMPANIES_HOUSE_API_KEY")}
 )
 openai_tool = SkillLoader.to_openai_tool(bundle)
@@ -154,7 +157,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/uk_companies_house_handler")
-skill = bundle["module"].UkCompaniesHouseHandlerSkill(
+skill = bundle["class"](
     config={"COMPANIES_HOUSE_API_KEY": os.environ.get("COMPANIES_HOUSE_API_KEY")}
 )
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -61,6 +61,9 @@ Agent loops also need a provider API key (for example `GOOGLE_API_KEY` with Gemi
 
 Guides: [Usage index](../usage/README.md) · [Agent loops](../usage/agent_loops.md) · [API keys](../usage/api_keys.md).
 
+
+Use `bundle["class"]()` in the snippets below; explicit `bundle["module"].ClassName()` also works.
+
 Sample user message: *Screen wallet `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` for sanctions and malicious contract interactions.*
 
 ### Runnable examples
@@ -84,7 +87,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = bundle["module"].WalletScreeningSkill(
+skill = bundle["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 client = genai.Client()
@@ -131,7 +134,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = bundle["module"].WalletScreeningSkill(
+skill = bundle["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
@@ -150,7 +153,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = bundle["module"].WalletScreeningSkill(
+skill = bundle["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 openai_tool = SkillLoader.to_openai_tool(bundle)
@@ -168,7 +171,7 @@ from skillware.core.loader import SkillLoader
 
 load_env_file()
 bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = bundle["module"].WalletScreeningSkill(
+skill = bundle["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -28,7 +28,7 @@ To list locally available skills or run bundle tests from the terminal, see the 
 Skill-specific **Usage Examples** (sample prompts and execute payloads) live on each [skill catalog page](../skills/README.md).
 
 Shared patterns (load bundle, run `execute`, return tool results):
-[agent_loops.md](agent_loops.md). Runnable script inventory:
+[agent_loops.md](agent_loops.md). After `load_skill`, prefer `bundle["class"]()` to instantiate the skill; explicit `bundle["module"].ClassName()` also works. Runnable script inventory:
 [examples/README.md](../../examples/README.md).
 
 Contributors adding **Usage Examples** to skill catalog pages: [skill_usage_template.md](skill_usage_template.md).

--- a/docs/usage/deepseek.md
+++ b/docs/usage/deepseek.md
@@ -83,7 +83,8 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-skill = bundle["module"].TOSEvaluatorSkill()
+skill = bundle["class"]()
+# Or: skill = bundle["module"].TOSEvaluatorSkill()
 
 deepseek_tool = SkillLoader.to_deepseek_tool(bundle)
 tool_name = deepseek_tool["function"]["name"]

--- a/docs/usage/gemini.md
+++ b/docs/usage/gemini.md
@@ -20,9 +20,10 @@ from google.genai import types
 
 # Load & Convert
 skill = SkillLoader.load_skill("finance/wallet_screening")
-skill_instance = skill["module"].WalletScreeningSkill(
+skill_instance = skill["class"](
     config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
 )
+# Or: skill_instance = skill["module"].WalletScreeningSkill(config={...})
 tool = SkillLoader.to_gemini_tool(skill)
 
 # Initialize the google-genai client
@@ -125,10 +126,11 @@ rewriter = SkillLoader.load_skill("optimization/prompt_rewriter")
 sys_prompt = "You are a very helpful assistant serving a bank..."
 
 # Use python logic offline before starting the chat session
-optimized_ctx_result = rewriter['module'].PromptRewriter().execute({
+optimized_ctx_result = rewriter["class"]().execute({
     "raw_text": sys_prompt,
     "compression_aggression": "high"
 })
+# Or: rewriter["module"].PromptRewriter().execute({...})
 
 response = client.models.generate_content(
     model='gemini-2.5-flash',

--- a/docs/usage/ollama.md
+++ b/docs/usage/ollama.md
@@ -32,8 +32,8 @@ load_env_file()
 # 1. Load the Skill dynamically
 SKILL_PATH = "finance/wallet_screening"
 skill_bundle = SkillLoader.load_skill(SKILL_PATH)
-WalletScreeningSkill = getattr(skill_bundle["module"], "WalletScreeningSkill")
-wallet_skill = WalletScreeningSkill()
+wallet_skill = skill_bundle["class"]()
+# Or: WalletScreeningSkill = getattr(skill_bundle["module"], "WalletScreeningSkill"); wallet_skill = WalletScreeningSkill()
 
 print(f"Loaded Skill: {skill_bundle['manifest']['name']}")
 

--- a/docs/usage/openai.md
+++ b/docs/usage/openai.md
@@ -80,8 +80,8 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-SkillClass = bundle["module"].TOSEvaluatorSkill
-skill = SkillClass()
+skill = bundle["class"]()
+# Or: SkillClass = bundle["module"].TOSEvaluatorSkill; skill = SkillClass()
 
 openai_tool = SkillLoader.to_openai_tool(bundle)
 tool_name = openai_tool["function"]["name"]

--- a/docs/usage/skill_usage_template.md
+++ b/docs/usage/skill_usage_template.md
@@ -1,6 +1,6 @@
 # Skill usage example template (contributors)
 
-When adding **Usage Examples** to `docs/skills/<skill>.md`, include subsections for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). Each block should be runnable: imports, `load_env_file()`, `load_skill`, adapter, system instructions, sample user message, and `execute` on tool call.
+When adding **Usage Examples** to `docs/skills/<skill>.md`, include subsections for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). Each block should be runnable: imports, `load_env_file()`, `load_skill`, `bundle["class"]()` (or explicit `bundle["module"].ClassName()`), adapter, system instructions, sample user message, and `execute` on tool call.
 
 Link to [agent_loops.md](agent_loops.md) and [README.md](README.md). List skill-specific env vars in an **Environment** table; link to [api_keys.md](api_keys.md) for setup.
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -64,7 +64,7 @@ Skillware follows one thread: modular capability you can install, trust, and ext
 
 **Self-contained, deterministic skills for any LLM or agent**
 
-**In short:** A public registry, a stable loader, model adapters, tests, and docs. Install a skill and call it from any major LLM runtime. **You are here** (v0.3.x).
+**In short:** A public registry, a stable loader, model adapters, tests, and docs. Install a skill and call it from any major LLM runtime. **You are here** (v0.4.x).
 
 **Example:** Your agent runs `pip install skillware`, loads a Terms-of-Service evaluator skill, then visits a site or ingests a document. It follows the skill's constitution and logic immediately: what to extract, what to flag, what never to scrape or store. No extra prompt engineering, no one-off tools, no separate subscription stack. The capability ships as one bundle.
 
@@ -102,12 +102,12 @@ Skillware follows one thread: modular capability you can install, trust, and ext
 
 ## Where we are today
 
-Honest snapshot for **v0** (current v0.3.x line):
+Honest snapshot for **v0** (current v0.4.x line):
 
 - **Registry**: Skills under `skills/` with docs in [docs/skills/](skills/README.md).
-- **Loader**: Dynamic import, dependency checks, and adapters for major LLM tool formats.
+- **Loader**: Dynamic import, auto-discovered `bundle["class"]`, dependency checks, and adapters for major LLM tool formats.
 - **CLI**: `skillware list`, `skillware test`, and an interactive menu, included with `pip install skillware`. Use `skillware list --examples` and `skillware examples` to browse the runnable script index from the terminal.
-- **Active work**: Wallet screening enhancements ([RFC #115](https://github.com/ARPAHLS/skillware/issues/115)), CLI polish, contributor docs, and good first issues across docs and framework.
+- **Active work**: Wallet screening enhancements ([RFC #115](https://github.com/ARPAHLS/skillware/issues/115)), contributor docs, and good first issues across docs and framework.
 
 Browse [open good first issues](https://github.com/ARPAHLS/skillware/issues?q=is%3Aopen+label%3A%22good+first+issue%22) if you want a low-risk entry point.
 


### PR DESCRIPTION
## Description

Documentation sweep — no code or skill changes.

- **README**: Fix Mermaid Registry node alignment (`Registry[Registry]` instead of cylinder syntax)
- **vision.md**: Pin to v0.4.x; remove stale “CLI polish” active-work item; note `bundle["class"]` in loader snapshot
- **Skill catalog + usage guides**: Prefer `bundle["class"]()` in snippets; keep `bundle["module"].ClassName()` as an optional `# Or:` / note (still supported, not deprecated)
- **CHANGELOG**: `[Unreleased]` entry for the sweep

### Type of Change

- [ ] **Skill Proposal**: New Skill
- [ ] **Bug Report Fix**: Non-breaking change which fixes an execution error or framework bug
- [x] **Doc Fix**: Documentation Update
- [ ] **Framework Feature / RFC Updates**: Core Framework Update

## Checklist

- [x] My code follows the **Agent Code of Conduct**.
- [x] `pytest tests/test_registry_docs.py` passed locally (doc-drift guards).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [ ] `examples/README.md` — N/A (no example changes)

## New or updated skill

N/A — documentation only.

## Constitution & Safety

N/A — no skill or runtime changes.

## Related Issues

N/A - just polishing docs.