### PR TITLE
fix: ship examples README in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ include = ["skillware*", "skills*"]
 # and this wildcard. No per-skill entries needed when adding registry skills.
 [tool.setuptools.package-data]
 skills = ["**/*"]
+skillware = ["examples/README.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "skills"]

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -77,11 +77,13 @@ def _example_github_url(script: str) -> str:
 
 
 def _examples_readme_path() -> Optional[Path]:
-    """Resolve a local examples/README.md from checkout or cwd walk."""
+    """Resolve examples/README.md from installed package, checkout, or cwd walk."""
     candidates: List[Path] = []
 
-    package_root = Path(__file__).resolve().parent.parent
-    candidates.append(package_root.parent / _EXAMPLES_README_REL)
+    package_dir = Path(__file__).resolve().parent
+    project_root = package_dir.parent
+    candidates.append(package_dir / _EXAMPLES_README_REL)
+    candidates.append(project_root / _EXAMPLES_README_REL)
 
     cwd = Path.cwd()
     for directory in [cwd, *list(cwd.parents)[:_PARENT_WALK_LIMIT]]:

--- a/skillware/examples/README.md
+++ b/skillware/examples/README.md
@@ -1,0 +1,68 @@
+# Skillware Examples Index
+
+> **These are usage examples, not tests.** Runnable provider demos live here; automated tests live in `skills/**/test_skill.py` (bundle) and `tests/` (framework and optional maintainer depth). See [TESTING.md](../docs/TESTING.md).
+
+Runnable examples in this directory show how to load Skillware skills, adapt
+them for a provider, execute local skill logic, and return tool results to an
+agent loop. After `pip install skillware`, run `skillware examples` or
+`skillware list --examples` from any directory to browse the index in the
+terminal; when no local `examples/README.md` is present, the index is fetched
+from GitHub (network required); see
+[CLI reference](../docs/usage/cli.md). Provider setup details live in the usage guides:
+
+- [API keys for skills](../docs/usage/api_keys.md)
+- [Gemini](../docs/usage/gemini.md)
+- [Claude](../docs/usage/claude.md)
+- [OpenAI](../docs/usage/openai.md)
+- [DeepSeek](../docs/usage/deepseek.md)
+- [Ollama](../docs/usage/ollama.md)
+- [Agent loops](../docs/usage/agent_loops.md)
+
+Use the package extra shown below when installing from PyPI:
+`pip install "skillware[gemini]"`. For local development, use the same extra
+with editable install: `pip install -e ".[gemini]"`.
+
+## Runnable Scripts
+
+| Script | Skill ID | Provider | Required extra | Required env vars | Description |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `mental_coach_demo.py` | `wellness/mental_coach` | Local execute | base install only | None | Demonstrates coaching, crisis escalation, and blocked clinical paths locally. |
+| `build_dataset_demo.py` | `data_engineering/synthetic_generator` | Local execute (Gemini backend) | `[gemini]` | `GOOGLE_API_KEY` | Generates a JSONL synthetic dataset with the synthetic generator skill. |
+| `claude_pdf_form_filler.py` | `office/pdf_form_filler` | Claude | `[claude]`, `[office]` | `ANTHROPIC_API_KEY` | Uses Claude with the PDF form filler skill to map instructions to fields. |
+| `claude_tos_evaluator.py` | `compliance/tos_evaluator` | Claude | `[claude]` | `ANTHROPIC_API_KEY` | Runs a Claude tool loop for website automation policy review. |
+| `claude_issue_resolver.py` | `dev_tools/issue_resolver` | Claude | `[claude]` | `ANTHROPIC_API_KEY`; optional `GITHUB_TOKEN` | Claude loop for GitHub issue analysis; fetches issue data after `prepare` (sample: issue #123). |
+| `claude_wallet_check.py` | `finance/wallet_screening` | Claude | `[claude]` | `ANTHROPIC_API_KEY`, `ETHERSCAN_API_KEY` | Screens an Ethereum wallet and returns the result through a Claude tool loop. |
+| `deepseek_tos_evaluator.py` | `compliance/tos_evaluator` | DeepSeek | `[openai]` | `DEEPSEEK_API_KEY` | Uses the OpenAI-compatible DeepSeek API for terms-of-service evaluation. |
+| `gemini_pdf_form_filler.py` | `office/pdf_form_filler` | Gemini | `[gemini]`, `[office]` | `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY` | Uses Gemini as the agent while the PDF skill calls Anthropic for form filling. |
+| `gemini_tos_evaluator.py` | `compliance/tos_evaluator` | Gemini | `[gemini]` | `GOOGLE_API_KEY` | Runs the terms-of-service evaluator with a Gemini function-calling loop. |
+| `gemini_wallet_check.py` | `finance/wallet_screening` | Gemini | `[gemini]` | `GOOGLE_API_KEY`, `ETHERSCAN_API_KEY` | Screens an Ethereum wallet with Gemini orchestration and Etherscan data. |
+| `gemini_evm_tx_handler.py` | `defi/evm_tx_handler` | Gemini | `[gemini]` | `GOOGLE_API_KEY`; for live swaps also `AGENT_WALLET_PRIVATE_KEY`, `BASE_RPC_URL` or `ETHEREUM_RPC_URL`. Set `EVM_TX_HANDLER_EXAMPLE_DEMO=1` for mocked flow without keys. | Resolve → quote → preview → execute buy flow via Gemini tool loop (or demo mode). |
+| `claude_evm_tx_handler.py` | `defi/evm_tx_handler` | Claude | `[claude]` | `ANTHROPIC_API_KEY`; for live swaps also `AGENT_WALLET_PRIVATE_KEY`, RPC URLs. Demo: `EVM_TX_HANDLER_EXAMPLE_DEMO=1`. | Claude tool loop for structured DeFi intent and optional execute after confirmation. |
+| `mica_claude_flow.py` | `compliance/mica_module` | Claude | `[claude]` | `ANTHROPIC_API_KEY` | Runs a MiCA compliance agent loop through Claude. |
+| `mica_ollama_flow.py` | `compliance/mica_module` | Ollama | No Skillware extra; install `ollama` separately | None | Runs a local Ollama MiCA flow with prompt-mode tool calling. |
+| `mica_rag_flow.py` | `compliance/mica_module` | Gemini | `[gemini]` | `GOOGLE_API_KEY` | Runs the MiCA RAG flow with Gemini. |
+| `ollama_skills_test.py` | `finance/wallet_screening`, `office/pdf_form_filler`, `optimization/prompt_rewriter` | Ollama | `[office]`; install `ollama` separately | `ETHERSCAN_API_KEY`, `ANTHROPIC_API_KEY` | Loads multiple skills and tests prompt-mode tool calling with Ollama. |
+| `ollama_tos_evaluator.py` | `compliance/tos_evaluator` | Ollama | No Skillware extra; install `ollama` separately | None | Runs the terms-of-service evaluator with local Ollama prompt-mode calls. |
+| `openai_tos_evaluator.py` | `compliance/tos_evaluator` | OpenAI | `[openai]` | `OPENAI_API_KEY` | Runs the terms-of-service evaluator with OpenAI function calling. |
+| `pii_guardrail_flow.py` | `compliance/pii_masker` | Local execute | base install only | None | Demonstrates local PII masking before passing text to an external agent. |
+| `prompt_compression_demo.py` | `optimization/prompt_rewriter` | Local execute | base install only | None | Demonstrates prompt compression without a provider loop. |
+| `novelty_extractor_demo.py` | `data_engineering/novelty_extractor` | Local execute | `pip install fastembed numpy` | None | Demonstrates multi-turn corpus distillation using local embeddings with no API key. |
+| `gemini_novelty_extractor.py` | `data_engineering/novelty_extractor` | Gemini | `[gemini]`, `pip install fastembed numpy` | `GOOGLE_API_KEY` | Runs the novelty extractor with a Gemini function-calling loop. |
+| `ollama_novelty_extractor.py` | `data_engineering/novelty_extractor` | Ollama | `pip install fastembed numpy`; install `ollama` separately | None | Runs the novelty extractor with local Ollama prompt-mode calls. |
+| `gemini_issue_resolver.py` | `dev_tools/issue_resolver` | Gemini | `[gemini]` | `GOOGLE_API_KEY`; optional `GITHUB_TOKEN` | Gemini loop for GitHub issue analysis; fetches issue data after `prepare` (sample: issue #123). |
+| `ollama_issue_resolver.py` | `dev_tools/issue_resolver` | Ollama | No Skillware extra; install `ollama` separately | optional `GITHUB_TOKEN`; `OLLAMA_MODEL` (default `gemma4:e2b`) | Ollama prompt-mode loop for GitHub issue analysis (sample: issue #123). |
+| `token_limiter_loop.py` | `monitoring/token_limiter` | Local execute | base install only | None | Simulates a runaway task hitting a token ceiling with deterministic budget checks. |
+| `gemini_token_limiter.py` | `monitoring/token_limiter` | Gemini | `[gemini]` | Optional `GOOGLE_API_KEY` for Phase 2 live loop | Local budget simulation plus optional Gemini tool loop. |
+| `claude_token_limiter.py` | `monitoring/token_limiter` | Claude | `[claude]` | Optional `ANTHROPIC_API_KEY` for Phase 2 live loop | Local budget simulation plus optional Claude tool loop. |
+| `gemini_uk_companies_house_handler.py` | `finance/uk_companies_house_handler` | Gemini | `[gemini]` | `GOOGLE_API_KEY`, `COMPANIES_HOUSE_API_KEY` | Resolve company, officers, filings via Gemini tool loop. |
+| `uk_companies_house_handler_demo.py` | `finance/uk_companies_house_handler` | Local execute | base install only | None | Runs a scripted sequence (resolve, profile, officers, pscs, filings) with mocked HTTP responses (no API keys needed). |
+
+## Notes
+
+- Agent-side model keys such as `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, and `DEEPSEEK_API_KEY` are documented in the provider
+  guides.
+- Skill runtime keys such as `ETHERSCAN_API_KEY` are documented in each skill
+  manifest and on the skill catalog pages.
+- Ollama examples require the Python `ollama` package, a local Ollama server,
+  and the model named in the script, but no cloud API key.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from skillware.cli import (
     _resolve_pytest_targets,
     _parse_examples_index,
     _load_examples_index,
+    _examples_readme_path,
     _example_counts_by_skill,
     _example_github_url,
     cmd_list,
@@ -588,6 +589,12 @@ def test_load_examples_index_prefers_local_readme(examples_readme):
     rows, source = _load_examples_index()
     assert len(rows) == 2
     assert source == examples_readme
+
+
+def test_examples_readme_path_includes_packaged_index():
+    path = _examples_readme_path()
+    assert path is not None
+    assert path.as_posix().endswith("skillware/examples/README.md")
 
 
 def test_load_examples_index_github_fallback(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes ARPAHLS/skillware#226 (Phase A): ship the examples index with the wheel so `skillware examples` and `skillware list --examples` can work for pip-only installs without relying on GitHub raw access.

## Changes

- Add `skillware/examples/README.md` as the packaged copy of the examples index.
- Include it as `skillware` package data in `pyproject.toml`.
- Update `_examples_readme_path()` to check the installed package copy before checkout/cwd discovery and GitHub fallback.
- Add a regression test that verifies the packaged index path is discoverable.

## Verification

- `pytest tests/test_cli.py -q`
  - `43 passed in 0.42s`
- `python -m build --wheel`
- Verified the built wheel contains `skillware/examples/README.md`.
- Installed the built wheel into a fresh venv from `/tmp` and verified `_load_examples_index()` loads the installed packaged copy with 30 rows.

## Notes

This keeps the existing GitHub raw fallback for old wheels, editable/dev layouts, and other edge cases.