### PR TITLE
Docs/gemini dispatch doc hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,12 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
-### Documentation
-
-- **CONTRIBUTING**: Category selection guidance for contributors; issue-first policy for new top-level folders (#204).
-- **Usage docs**: Align `agent_loops.md` and `cli.md` with Gemini sanitized tool-name dispatch after #229 (#230 follow-up).
-
 ### Added
 
 - **Framework:** Added `_sanitize_gemini_tool_name()` to `skillware/core/loader.py` to explicitly map provider tool naming constraints.
 - **Tests:** Added `test_sanitize_gemini_tool_name()` to `tests/test_loader.py` to verify safe translation and `test_skill_docs_gemini_anti_patterns()` to `tests/test_registry_docs.py` to enforce documentation hygiene by preventing manual tool wrapping and mutation anti-patterns in skill catalog pages.
 - **Documentation:** Added canonical dispatch guidelines to `docs/usage/gemini.md` and `docs/usage/skill_usage_template.md`.
+- **Documentation:** Category selection guidance for contributors; issue-first policy for new top-level folders in `CONTRIBUTING.md` (#204).
 
 ### Changed
 
@@ -25,6 +21,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **Framework:** `SkillLoader.to_gemini_tool()` now returns a `google.genai.types.Tool` object instead of a raw dictionary, ensuring compatibility with the `google-genai` SDK when passing tools to `GenerateContentConfig`.
 - **Tests:** Updated `tests/test_loader.py` to assert against the properties of the `google.genai.types.Tool` object for `to_gemini_tool()`.
 - **Documentation:** Updated Gemini integration snippets across all skill catalog pages and `introduction.md` to reflect the `to_gemini_tool()` API change and correct tool name sanitization.
+- **Documentation:** Aligned `agent_loops.md` and `cli.md` with Gemini sanitized tool-name dispatch after #229 (#230 follow-up).
 - **Examples:** Removed manual `types.Tool` wrapping, and consistently utilize `SkillLoader._sanitize_gemini_tool_name()` for derived tool names in gemini examples.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Documentation
 
 - **CONTRIBUTING**: Category selection guidance for contributors; issue-first policy for new top-level folders (#204).
+- **Usage docs**: Align `agent_loops.md` and `cli.md` with Gemini sanitized tool-name dispatch after #229 (#230 follow-up).
 
 ### Added
 

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -48,13 +48,13 @@ Provider guides contain full API details. Skill pages contain copy-paste example
 
 | Adapter | Match tool calls using |
 | :--- | :--- |
-| Gemini | `manifest["name"]` (may include slashes, e.g. `compliance/tos_evaluator`) |
-| Claude | `manifest["name"]` |
+| Gemini | `SkillLoader._sanitize_gemini_tool_name(bundle["manifest"]["name"])` (e.g. `compliance_tos_evaluator`) |
+| Claude | `manifest["name"]` (may include slashes, e.g. `compliance/tos_evaluator`) |
 | OpenAI | `to_openai_tool(bundle)["function"]["name"]` (sanitized, e.g. `compliance_tos_evaluator`) |
 | DeepSeek | `to_deepseek_tool(bundle)["function"]["name"]` (same sanitization rules) |
 | Ollama (prompt) | `"tool"` field in the JSON block the model emits (same as `manifest["name"]` when the manifest uses the full registry ID) |
 
-**Registry manifest names:** Every bundled skill uses `manifest["name"]` = `category/skill_name` (for example `office/pdf_form_filler`, `defi/evm_tx_handler`). Match tool calls with `bundle["manifest"]["name"]` on Gemini and Claude, or derive sanitized names from the adapter on OpenAI and DeepSeek (`office_pdf_form_filler`, `defi_evm_tx_handler`). Do not hardcode legacy short names in examples. `SkillLoader.load_skill()` warns when `name` diverges from the folder path for registry-layout skills; use `bundle.get("registry_id")` for the path-derived ID when present.
+**Registry manifest names:** Every bundled skill uses `manifest["name"]` = `category/skill_name` (for example `office/pdf_form_filler`, `defi/evm_tx_handler`). Match tool calls with `bundle["manifest"]["name"]` on Claude, or derive sanitized names from the adapter on Gemini, OpenAI, and DeepSeek (`office_pdf_form_filler`, `defi_evm_tx_handler`). Do not hardcode legacy short names in examples. `SkillLoader.load_skill()` warns when `name` diverges from the folder path for registry-layout skills; use `bundle.get("registry_id")` for the path-derived ID when present.
 
 ## Minimal execute (no LLM)
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -214,7 +214,8 @@ the same condition `SkillLoader` requires to load a skill successfully.
 | :--- | :--- | :--- |
 | **CLI / loader ID** | Folder path `category/skill_name` | `office/pdf_form_filler` |
 | **`manifest.yaml` `name`** | Should match the registry ID | `office/pdf_form_filler` |
-| **Gemini / Claude tool name** | `manifest["name"]` via adapter | `office/pdf_form_filler` |
+| **Gemini tool name** | Sanitized via `to_gemini_tool()` / `_sanitize_gemini_tool_name()` | `office_pdf_form_filler` |
+| **Claude tool name** | `manifest["name"]` via adapter | `office/pdf_form_filler` |
 | **OpenAI / DeepSeek tool name** | Sanitized adapter name | `office_pdf_form_filler` |
 | **Ollama prompt `"tool"`** | Same as manifest when using full IDs | `office/pdf_form_filler` |
 


### PR DESCRIPTION
## Description

Follow-up to [#229](https://github.com/ARPAHLS/skillware/pull/229) / [#230](https://github.com/ARPAHLS/skillware/issues/230): the core Gemini fix landed in #229, but two usage docs still described Gemini tool names with slash-form registry IDs. This PR aligns them with the sanitized dispatch model (`SkillLoader._sanitize_gemini_tool_name()` / `to_gemini_tool()`).

**Changes**

| Acceptance criterion | File |
| --- | --- |
| Tool-name matching table: Gemini uses sanitized names | `docs/usage/agent_loops.md` |
| Registry manifest paragraph: Claude = slash ID; Gemini/OpenAI/DeepSeek = sanitized | `docs/usage/agent_loops.md` |
| CLI identity table: separate Gemini vs Claude tool-name rows | `docs/usage/cli.md` |
| Changelog entries under standard sections (no standalone `Documentation` heading) | `CHANGELOG.md` |

No framework, skill, or example code changes — docs and changelog only.

### Type of Change

- [ ] **New Skill** — new registry bundle under `skills/`
- [ ] **Skill Upgrade** — changes to an existing skill under `skills/`
- [ ] **Bug Fix** — incorrect runtime or framework behavior
- [x] **Documentation** — docs, README, CONTRIBUTING only
- [ ] **Framework Feature** — `skillware/core/` loader, env, adapters
- [x] **CLI** — `skillware/cli.py`, `docs/usage/cli.md`
- [ ] **Examples** — `examples/*.py`, agent loops, `examples/README.md`
- [ ] **Packaging** — PyPI wheel, `pyproject.toml`, `MANIFEST.in`
- [ ] **RFC / meta** — templates, labels, CI, or large design doc

## Checklist (all PRs)

- [x] Linked GitHub issue (`Fixes #…` or `Refs #…`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset)
- [x] `pytest skills/` and `pytest tests/` pass locally when relevant
- [x] `CHANGELOG.md` updated under `[Unreleased]` when user-visible behavior changes
- [x] `examples/README.md` updated if this PR adds, renames, or removes a runnable script *(N/A — no example changes)*
- [x] Ran `pytest tests/test_registry_docs.py` when skills, examples index, or agent-loops matrix changed

## New or updated skill

Skip — no changes under `skills/`.

## Constitution and safety (skills only)

N/A — documentation-only PR.

## Related Issues

Refs #230  
Follow-up to #223 / #229