### PR TITLE
feat(cli): add skillware paths and shared discovery module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Added
+
+- **CLI:** `skillware paths` shows skill root resolution order (external → project → bundled), tier labels, shadowing summary, and operator tips; interactive menu option `4` wired (#81).
+- **Framework:** `skillware/core/discovery.py` — shared skill root discovery for `SkillLoader` and the CLI (tier labels, shadowing, registry ID listing; foundation for config-driven paths in #246).
+- **Framework:** Skill-not-found errors from `SkillLoader.load_skill()` include searched paths and a `skillware paths` tip (#81).
+
+### Changed
+
+- **Framework:** `SkillLoader` delegates root resolution to `discovery.get_skill_roots()` so load, list, test, and `paths` use the same order (#81).
+- **CLI:** Help and menu list `paths` as available (no longer “coming soon”) (#81).
+- **Documentation:** README — trim redundant Contributing cross-links, add `skillware paths` to install verification, and link the skill trust model in the docs table; cross-link `skillware paths` in `docs/introduction.md` and `docs/usage/README.md`.
+
 ## [0.4.3] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -120,13 +120,16 @@ For documentation-only work, `pip install -e ".[dev]"` is enough. Skill and fram
 
 ```bash
 skillware list
+skillware paths
 ```
 
 This prints a table of all locally available skills and confirms the install
-and path resolution are working. Running `skillware` with no arguments opens
-the interactive menu. As optional checks you can also run `skillware test` to
-execute bundle tests, and `skillware examples` to browse the runnable example
-index (fetched from GitHub when no local `examples/README.md` is present).
+and path resolution are working. `skillware paths` shows the same root order
+the loader uses (external → project → bundled), tier labels, and shadowing.
+Running `skillware` with no arguments opens the interactive menu. As optional
+checks you can also run `skillware test` to execute bundle tests, and
+`skillware examples` to browse the runnable example index (fetched from GitHub
+when no local `examples/README.md` is present).
 
 If `skillware` is not recognized, Python's `Scripts` directory may not be on
 your PATH — use `python -m skillware list` as a fallback. See
@@ -219,13 +222,14 @@ For other providers and shared integration patterns, see the [usage guides index
 | :--- | :--- |
 | **Introduction** | [Introduction](docs/introduction.md) · [Vision](docs/vision.md) · [Comparison](COMPARISON.md) |
 | **Usage guides** | [Skill Library](docs/skills/README.md) · [Usage Guide](docs/usage/README.md) · [Examples](examples/README.md) · [Agent Loops](docs/usage/agent_loops.md) · [API Keys](docs/usage/api_keys.md) · [CLI](docs/usage/cli.md) |
+| **Security** | [Skill trust model](docs/security/skill-trust-model.md) · [SECURITY.md](SECURITY.md) |
 | **Contributing** | [Contributing](CONTRIBUTING.md) · [Agent Native Workflow](docs/contributing/ai_native_workflow.md) · [Testing](docs/TESTING.md) · [Changelog](CHANGELOG.md) |
 
 ## Contributing
 
 We are building the "App Store" for Agents. Skills are the main contribution, but documentation, tests, and framework fixes are welcome too. Human operators and supervised agents follow the same standards: scoped PRs, deterministic behavior, and verified tests.
 
-See the **Contributing** row in [Documentation](#documentation) for the full path, [Contributing](CONTRIBUTING.md) (types, skill standard, PR process), [Agent Native Workflow](docs/contributing/ai_native_workflow.md) (for autonomous and semi-autonomous agents), [Testing](docs/TESTING.md) (Black, Flake8, framework and skill pytest, pre-PR checklist), and [Changelog](CHANGELOG.md) (user-facing entries under `[Unreleased]`).
+Start with [Contributing](CONTRIBUTING.md) (types, skill standard, PR process), [Agent Native Workflow](docs/contributing/ai_native_workflow.md) (for autonomous and semi-autonomous agents), [Testing](docs/TESTING.md) (Black, Flake8, framework and skill pytest, pre-PR checklist), and [Changelog](CHANGELOG.md) (user-facing entries under `[Unreleased]`).
 
 Also read the [Agent Code of Conduct](CODE_OF_CONDUCT.md). Open PRs with the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) and complete only the sections that apply.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -76,7 +76,7 @@ A skill is a folder on disk. The loader turns the manifest into whatever tool sc
 When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestration happens behind the scenes:
 
 ### Step 1: Discovery & Loading
-The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
+The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, roots in `SKILLWARE_SKILL_PATH`, a `skills/` folder in the current working directory (or its parents), then bundled skills installed with the package. Run `skillware paths` for a live view of resolved roots, tiers, and shadowing. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
 *   It dynamically imports the `skill.py` module and auto-discovers the single `BaseSkill` subclass as `bundle["class"]` (no hardcoded class names required).
 *   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Claude uses as the tool name; Gemini, OpenAI, and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
 *   It reads `instructions.md` and, when present, optional `card.json`.

--- a/docs/security/skill-trust-model.md
+++ b/docs/security/skill-trust-model.md
@@ -26,6 +26,8 @@ If you pass a path that already points at a skill directory (absolute or relativ
 
 Because the search stops at the first matching id, a skill earlier in the order shadows any skill with the same id later in the order. If a finance/wallet_screening exists under SKILLWARE_SKILL_PATH or in a local ./skills/, it is loaded instead of the bundled, maintainer-reviewed copy of the same id — and the bundled copy never runs.
 
+Run `skillware paths` to see which roots are active and which IDs shadow bundled registry skills.
+
 The practical consequence: placing a skill with the same id as an official one, anywhere earlier in the search order, silently replaces the official skill. Shadowing is a normal feature of the resolution order, but it means the id you ask for does not by itself tell you which code will run — the location does.
 
 ### Flat vs registry layout

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -14,7 +14,7 @@ For pip-installed apps, keep project skills in `./skills/<category>/<name>/` or 
 
 > **Security:** Loading a skill executes its `skill.py` in your process — there is no sandbox, and the first matching id in the search order wins (a local skill can shadow a bundled one). Only load skills you trust, and see the [skill trust model](../security/skill-trust-model.md) before loading external skills.
 
-To list locally available skills or run bundle tests from the terminal, see the [CLI reference](cli.md).
+To list locally available skills, inspect path resolution, or run bundle tests from the terminal, see the [CLI reference](cli.md) (`skillware list`, `skillware paths`, `skillware test`).
 
 | Provider | Adapter | Guide | Agent API key (typical) |
 | :--- | :--- | :--- | :--- |
@@ -23,7 +23,7 @@ To list locally available skills or run bundle tests from the terminal, see the 
 | OpenAI (ChatGPT) | `to_openai_tool()` | [openai.md](openai.md) | `OPENAI_API_KEY` |
 | DeepSeek | `to_deepseek_tool()` | [deepseek.md](deepseek.md) | `DEEPSEEK_API_KEY` |
 | Ollama (prompt mode) | `to_ollama_prompt()` | [ollama.md](ollama.md) | (local; no cloud key) |
-| CLI | `skillware list`, `skillware test`, `skillware examples` | [cli.md](cli.md) | pytest in `[dev]` for `test` |
+| CLI | `skillware list`, `skillware paths`, `skillware test`, `skillware examples` | [cli.md](cli.md) | pytest in `[dev]` for `test` |
 
 Skill-specific **Usage Examples** (sample prompts and execute payloads) live on each [skill catalog page](../skills/README.md).
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -104,7 +104,7 @@ Available commands:
 | `1` / `list` | List all locally installed skills | Available |
 | `2` / `examples` | Browse runnable example scripts (index from `examples/README.md`, or from GitHub when no local copy exists) | Available |
 | `3` / `test` | Run bundle tests (`test_skill.py`) for one or all skills | Available |
-| `4` / `paths` | Show and repair skill directory resolution paths | Coming soon |
+| `4` / `paths` | Show skill root resolution order, tiers, and shadowing | Available |
 | `5` / `help` | Print rich-formatted help with commands, flags, and examples | Available |
 
 ## Commands
@@ -192,6 +192,21 @@ Requires pytest (`pip install -e ".[dev]"` or `pip install -e ".[dev,all]"`).
 
 Exit code matches pytest (non-zero on failures or missing test paths).
 
+### skillware paths
+
+Show where Skillware looks for skills — same order as `SkillLoader.load_skill()` — with tier labels (**external**, **project**, **bundled**), per-root skill counts, and shadowing warnings when the same registry ID exists in multiple roots.
+
+    skillware paths
+    skillware paths --skills-root /path/to/my/skills
+
+#### Flags
+
+| Flag | Description |
+| :--- | :--- |
+| `--skills-root <path>` | Override the skills directory for this command only (shows a single override root). |
+
+Read-only in v0.4.x; persist project/external paths via config is tracked in #246. Interactive menu: **`4` / `paths`**.
+
 ## Path resolution
 
 `skillware list` searches for skills in the same order as `SkillLoader`:
@@ -199,6 +214,8 @@ Exit code matches pytest (non-zero on failures or missing test paths).
 1. Roots listed in `SKILLWARE_SKILL_PATH` (OS path separator between multiple entries)
 2. A `skills/` directory under the current working directory and its parents
 3. Bundled skills installed with the `skillware` package
+
+Run `skillware paths` for a live view of resolved roots, tiers, and shadowing.
 
 To point the CLI at a persistent custom root, set the environment variable:
 

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -17,6 +17,13 @@ from rich import box
 import importlib.metadata
 
 from skillware.core.loader import SkillLoader
+from skillware.core.discovery import (
+    SKILLWARE_SKILL_PATH_ENV,
+    find_shadow_conflicts,
+    get_skill_roots,
+    list_registry_skill_ids,
+    resolution_order_summary,
+)
 from skillware.version_policy import emit_upgrade_advisory, get_installed_version
 
 TABLE_STYLE = "bold #C7CEEA"  # lavender  - headers
@@ -177,26 +184,8 @@ def _load_examples_index() -> (
 
 
 def _get_skill_roots(skills_root_override: Optional[Path] = None) -> List[Path]:
-    """Return the list of roots to search for skills, mirrors SkillLoader resolution order."""
-    if skills_root_override is not None:
-        if skills_root_override.exists():
-            return [skills_root_override]
-        return []
-
-    roots = []
-    seen = set()
-
-    for root in (
-        SkillLoader._env_skill_roots()
-        + SkillLoader._cwd_skill_roots()
-        + [SkillLoader._bundled_skills_root()]
-    ):
-        resolved = root.resolve()
-        if resolved not in seen and resolved.exists():
-            seen.add(resolved)
-            roots.append(resolved)
-
-    return roots
+    """Return existing skill root paths in loader resolution order."""
+    return [root.path for root in get_skill_roots(skills_root_override)]
 
 
 def _short_description(data: Dict[str, Any], max_len: int = 80) -> str:
@@ -481,6 +470,100 @@ def cmd_examples(
     return 0
 
 
+def cmd_paths(
+    skills_root_override: Optional[Path] = None,
+    console=None,
+) -> int:
+    """Show skill root resolution order, tiers, and shadowing (read-only; #246 adds config)."""
+    if console is None:
+        console = Console()
+
+    cwd = Path.cwd().resolve()
+    console.print(Text("Skill path resolution", style=f"bold {TABLE_STYLE}"))
+    console.print(f"  cwd: {cwd}", style="dim")
+    console.print()
+
+    roots = get_skill_roots(skills_root_override, for_display=True)
+    if not roots:
+        console.print(
+            "No skill roots configured. Set "
+            f"{SKILLWARE_SKILL_PATH_ENV} or use --skills-root.",
+            style="bold #FF9AA2",
+        )
+        return 1
+
+    table = Table(
+        box=box.SIMPLE_HEAVY,
+        border_style=BORDER_STYLE,
+        header_style=TABLE_STYLE,
+        expand=True,
+    )
+    table.add_column("ORDER", style=CATEGORY_STYLE, no_wrap=True, ratio=1)
+    table.add_column("TIER", style=ID_STYLE, no_wrap=True, ratio=1)
+    table.add_column("PATH", ratio=4)
+    table.add_column("STATUS", no_wrap=True, ratio=1)
+    table.add_column("SKILLS", style="dim", no_wrap=True, ratio=1)
+
+    for index, root in enumerate(roots, start=1):
+        skill_count = len(list_registry_skill_ids(root.path)) if root.exists else 0
+        status = "ok" if root.exists else "missing"
+        status_style = ID_STYLE if root.exists else "bold #FF9AA2"
+        table.add_row(
+            str(index),
+            root.tier.value,
+            str(root.path),
+            Text(status, style=status_style),
+            str(skill_count) if root.exists else "—",
+        )
+
+    console.print(table)
+    console.print()
+
+    conflicts = find_shadow_conflicts(roots)
+    if conflicts:
+        console.print(
+            Text("Shadowing (first root wins on load)", style=f"bold {TABLE_STYLE}")
+        )
+        for conflict in conflicts[:20]:
+            console.print(
+                f"  {conflict.skill_id}: "
+                f"{conflict.winner.tier.value} at {conflict.winner.path} "
+                f"shadows {conflict.shadowed.tier.value} at {conflict.shadowed.path}",
+                style="bold #FF9AA2",
+            )
+        if len(conflicts) > 20:
+            console.print(f"  … and {len(conflicts) - 20} more", style="dim")
+        console.print()
+
+    console.print(Text("Resolution order", style=f"bold {TABLE_STYLE}"))
+    for label, detail in resolution_order_summary():
+        console.print(f"  {label}: {detail}", style="dim")
+    console.print()
+
+    console.print(Text("Tips", style=f"bold {TABLE_STYLE}"))
+    console.print(
+        "  • One-shot override: skillware list --skills-root /path/to/skills",
+        style=MENU_STYLE,
+    )
+    console.print(
+        f"  • Persistent external roots: export {SKILLWARE_SKILL_PATH_ENV}=/path/to/skills",
+        style=MENU_STYLE,
+    )
+    console.print(
+        "  • Trust tiers: docs/security/skill-trust-model.md",
+        style=f"dim {SPLASH_STYLE}",
+    )
+    console.print(
+        "  • Persist project/external paths in config: tracked in #246",
+        style="dim",
+    )
+    console.print(
+        "  • Flat-layout skills (<root>/<name>/) load but may not appear in list",
+        style="dim",
+    )
+    return 0
+
+
 def _prompt_examples_skill_id(console) -> Tuple[Optional[str], bool]:
     """Return (skill_id or None for all, should_run)."""
     try:
@@ -526,6 +609,7 @@ def cmd_help(console=None) -> None:
     console.print("  skillware test                — run all bundle tests")
     console.print("  skillware test <category/name> — run one skill bundle test")
     console.print("  skillware test --category <n> — run tests for a category")
+    console.print("  skillware paths               — show skill root resolution")
     console.print("  skillware --version           — print installed version")
     console.print()
 
@@ -533,7 +617,7 @@ def cmd_help(console=None) -> None:
     console.print("  list      available now", style=ID_STYLE)
     console.print("  examples  available now", style=ID_STYLE)
     console.print("  test      available now", style=ID_STYLE)
-    console.print("  paths     coming soon", style="dim")
+    console.print("  paths     available now", style=ID_STYLE)
     console.print()
 
     console.print(Text("Interactive mode", style=f"bold {TABLE_STYLE}"))
@@ -549,6 +633,7 @@ def cmd_help(console=None) -> None:
     console.print("  skillware list --examples --category dev_tools", style=MENU_STYLE)
     console.print("  skillware examples compliance/tos_evaluator", style=MENU_STYLE)
     console.print("  skillware test finance/wallet_screening", style=MENU_STYLE)
+    console.print("  skillware paths", style=MENU_STYLE)
     console.print()
 
     console.print(Text("Install", style=f"bold {TABLE_STYLE}"))
@@ -637,7 +722,7 @@ def cmd_interactive(console=None, parser=None) -> None:
         ("1", "list", "discover and display all locally installed skills"),
         ("2", "examples", "browse runnable scripts from examples/README.md"),
         ("3", "test", "run bundle tests (test_skill.py) for one or all skills"),
-        ("4", "paths (soon)", "show and repair skill directory resolution paths"),
+        ("4", "paths", "show skill directory resolution order and shadowing"),
         ("5", "help", "usage guide for any command"),
     ]
 
@@ -678,10 +763,7 @@ def cmd_interactive(console=None, parser=None) -> None:
         elif command == "test":
             cmd_test(console=console)
         elif command == "paths":
-            console.print(
-                "  'paths' is not yet implemented. Coming in a future release.",
-                style="dim",
-            )
+            cmd_paths(console=console)
         elif command == "help":
             cmd_help(console=console)
         else:
@@ -781,6 +863,17 @@ def main() -> None:
         help="Pass --no-header to pytest.",
     )
 
+    paths_parser = subparsers.add_parser(
+        "paths",
+        help="Show skill root resolution order and shadowing.",
+    )
+    paths_parser.add_argument(
+        "--skills-root",
+        type=Path,
+        default=None,
+        help="Override the skills directory path for this command only.",
+    )
+
     args = parser.parse_args()
 
     if args.help and args.command is None:
@@ -806,6 +899,8 @@ def main() -> None:
                 no_header=args.no_header,
             )
         )
+    elif args.command == "paths":
+        raise SystemExit(cmd_paths(skills_root_override=args.skills_root))
     else:
         cmd_interactive(parser=parser)
 

--- a/skillware/core/discovery.py
+++ b/skillware/core/discovery.py
@@ -1,0 +1,249 @@
+"""Shared skill root discovery for SkillLoader and the CLI."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+SKILLWARE_SKILL_PATH_ENV = "SKILLWARE_SKILL_PATH"
+_MAX_PARENT_WALK = 6
+
+
+class SkillRootTier(str, Enum):
+    """Provenance tier for a filesystem skills root (aligned with trust doc / #234)."""
+
+    EXTERNAL = "external"
+    PROJECT = "project"
+    BUNDLED = "bundled"
+    OVERRIDE = "override"
+
+
+@dataclass(frozen=True)
+class SkillRoot:
+    """A directory searched for registry-layout skills (`category/skill_name/`)."""
+
+    path: Path
+    tier: SkillRootTier
+    source: str
+    exists: bool
+
+    @property
+    def order_label(self) -> str:
+        labels = {
+            SkillRootTier.EXTERNAL: "1 — external",
+            SkillRootTier.PROJECT: "2 — project",
+            SkillRootTier.BUNDLED: "3 — bundled",
+            SkillRootTier.OVERRIDE: "override",
+        }
+        return labels.get(self.tier, self.tier.value)
+
+
+@dataclass(frozen=True)
+class ShadowConflict:
+    """Same registry ID discovered in multiple roots; the first root wins on load."""
+
+    skill_id: str
+    winner: SkillRoot
+    shadowed: SkillRoot
+
+
+def bundled_skills_root() -> Path:
+    """Skills shipped inside the installed skillware package."""
+    return Path(__file__).resolve().parent.parent.parent / "skills"
+
+
+def is_skill_dir(path: Path) -> bool:
+    return path.is_dir() and (path / "skill.py").is_file()
+
+
+def env_skill_roots(*, include_missing: bool = False) -> List[SkillRoot]:
+    raw = os.environ.get(SKILLWARE_SKILL_PATH_ENV, "").strip()
+    if not raw:
+        return []
+
+    roots: List[SkillRoot] = []
+    for entry in raw.split(os.pathsep):
+        entry = entry.strip()
+        if not entry:
+            continue
+        path = Path(entry).expanduser()
+        resolved = path.resolve() if path.exists() else path
+        exists = path.is_dir()
+        if exists or include_missing:
+            roots.append(
+                SkillRoot(
+                    path=resolved,
+                    tier=SkillRootTier.EXTERNAL,
+                    source=SKILLWARE_SKILL_PATH_ENV,
+                    exists=exists,
+                )
+            )
+    return roots
+
+
+def cwd_skill_roots(*, include_missing: bool = False) -> List[SkillRoot]:
+    roots: List[SkillRoot] = []
+    current = Path.cwd().resolve()
+    for _ in range(_MAX_PARENT_WALK):
+        candidate = current / "skills"
+        resolved = candidate.resolve()
+        exists = candidate.is_dir()
+        if exists or include_missing:
+            if not any(r.path == resolved for r in roots):
+                roots.append(
+                    SkillRoot(
+                        path=resolved,
+                        tier=SkillRootTier.PROJECT,
+                        source=f"./skills/ (from {current})",
+                        exists=exists,
+                    )
+                )
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return roots
+
+
+def bundled_skill_root(*, include_missing: bool = False) -> SkillRoot:
+    path = bundled_skills_root()
+    exists = path.is_dir()
+    return SkillRoot(
+        path=path.resolve() if exists else path,
+        tier=SkillRootTier.BUNDLED,
+        source="bundled wheel (site-packages/skills/)",
+        exists=exists,
+    )
+
+
+def get_skill_roots(
+    skills_root_override: Optional[Path] = None,
+    *,
+    for_display: bool = False,
+) -> List[SkillRoot]:
+    """
+    Return skill roots in loader resolution order.
+
+    When ``for_display`` is False (default), only existing directories are
+    returned — used by ``list``, ``test``, and ``load_skill``.
+
+    When ``for_display`` is True (``skillware paths``), configured env entries
+    and the bundled root are shown even when missing so operators can diagnose
+    misconfiguration.
+    """
+    if skills_root_override is not None:
+        exists = skills_root_override.is_dir()
+        if exists or for_display:
+            return [
+                SkillRoot(
+                    path=(
+                        skills_root_override.expanduser().resolve()
+                        if exists
+                        else skills_root_override.expanduser()
+                    ),
+                    tier=SkillRootTier.OVERRIDE,
+                    source="--skills-root",
+                    exists=exists,
+                )
+            ]
+        return []
+
+    include_missing = for_display
+    roots: List[SkillRoot] = []
+    seen: set[str] = set()
+
+    for root in (
+        env_skill_roots(include_missing=include_missing)
+        + cwd_skill_roots(include_missing=include_missing)
+        + [bundled_skill_root(include_missing=True)]
+    ):
+        key = str(root.path)
+        if key in seen:
+            continue
+        if root.exists or include_missing:
+            seen.add(key)
+            roots.append(root)
+
+    if for_display:
+        return roots
+
+    return [root for root in roots if root.exists]
+
+
+def existing_skill_root_paths(
+    skills_root_override: Optional[Path] = None,
+) -> List[Path]:
+    """Paths only — backward-compatible helper for callers expecting ``List[Path]``."""
+    return [root.path for root in get_skill_roots(skills_root_override)]
+
+
+def list_registry_skill_ids(root: Path) -> List[str]:
+    """Registry-layout skill IDs under ``root`` (`category/skill_name``)."""
+    if not root.is_dir():
+        return []
+
+    skill_ids: List[str] = []
+    for manifest_path in sorted(root.glob("*/*/manifest.yaml")):
+        skill_dir = manifest_path.parent
+        if is_skill_dir(skill_dir):
+            skill_ids.append(f"{skill_dir.parent.name}/{skill_dir.name}")
+    return skill_ids
+
+
+def find_shadow_conflicts(roots: Sequence[SkillRoot]) -> List[ShadowConflict]:
+    """Detect registry IDs that appear in more than one root (first root wins)."""
+    winner_for_id: Dict[str, SkillRoot] = {}
+    conflicts: List[ShadowConflict] = []
+
+    for root in roots:
+        if not root.exists:
+            continue
+        for skill_id in list_registry_skill_ids(root.path):
+            if skill_id in winner_for_id:
+                conflicts.append(
+                    ShadowConflict(
+                        skill_id=skill_id,
+                        winner=winner_for_id[skill_id],
+                        shadowed=root,
+                    )
+                )
+            else:
+                winner_for_id[skill_id] = root
+
+    return conflicts
+
+
+def collect_search_paths_for_skill_id(skill_id: str) -> List[str]:
+    """Absolute paths tried when resolving a registry ID (existing roots only)."""
+    searched: List[str] = []
+    for root in get_skill_roots():
+        attempt = (root.path / skill_id).resolve()
+        searched.append(str(attempt))
+    return searched
+
+
+def build_skill_not_found_message(skill_id: str) -> str:
+    """Operator-facing error text aligned with ``skillware paths`` output."""
+    searched = collect_search_paths_for_skill_id(skill_id)
+    lines = [
+        f"Skill not found: {skill_id!r}. Searched:",
+        *[f"  {path}" for path in searched],
+        f"Set {SKILLWARE_SKILL_PATH_ENV} or pass an absolute path to the skill directory.",
+        "Run `skillware paths` to inspect resolution order and shadowing.",
+    ]
+    return "\n".join(lines)
+
+
+def resolution_order_summary() -> List[Tuple[str, str]]:
+    """Short tier descriptions for docs and CLI help."""
+    return [
+        (
+            "External",
+            f"Roots in {SKILLWARE_SKILL_PATH_ENV} (OS path separator between entries)",
+        ),
+        ("Project", "`./skills/` under cwd and up to six parent directories"),
+        ("Bundled", "Registry shipped inside the installed skillware package"),
+    ]

--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -8,13 +8,23 @@ import importlib.util
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Type
 
+import skillware.core.discovery as _discovery
+from skillware.core.discovery import (
+    build_skill_not_found_message,
+    bundled_skills_root,
+    cwd_skill_roots,
+    env_skill_roots,
+    existing_skill_root_paths,
+    get_skill_roots,
+    is_skill_dir,
+)
+
+SKILLWARE_SKILL_PATH_ENV = _discovery.SKILLWARE_SKILL_PATH_ENV
+
 
 class SkillwareIdentityWarning(UserWarning):
     """Emitted when manifest.name does not match the registry folder path (warn-only in v1)."""
 
-
-SKILLWARE_SKILL_PATH_ENV = "SKILLWARE_SKILL_PATH"
-_MAX_PARENT_WALK = 6
 
 # PyPI distribution names that differ from their import paths.
 _REQUIREMENT_IMPORT_ALIASES = {
@@ -39,38 +49,23 @@ class SkillLoader:
 
     @staticmethod
     def _is_skill_dir(path: Path) -> bool:
-        return path.is_dir() and (path / "skill.py").is_file()
+        return is_skill_dir(path)
 
     @staticmethod
     def _bundled_skills_root() -> Path:
-        return Path(__file__).resolve().parent.parent.parent / "skills"
+        return bundled_skills_root()
 
     @staticmethod
     def _env_skill_roots() -> List[Path]:
-        raw = os.environ.get(SKILLWARE_SKILL_PATH_ENV, "").strip()
-        if not raw:
-            return []
-        return [
-            Path(entry).expanduser().resolve()
-            for entry in raw.split(os.pathsep)
-            if entry.strip()
-        ]
+        return [root.path for root in env_skill_roots()]
 
     @staticmethod
     def _all_skill_roots() -> List[Path]:
-        roots: List[Path] = []
-        seen: set[str] = set()
-        for root in (
-            SkillLoader._env_skill_roots()
-            + SkillLoader._cwd_skill_roots()
-            + [SkillLoader._bundled_skills_root()]
-        ):
-            resolved = root.resolve()
-            key = str(resolved)
-            if key not in seen:
-                seen.add(key)
-                roots.append(resolved)
-        return roots
+        return existing_skill_root_paths()
+
+    @staticmethod
+    def _cwd_skill_roots() -> List[Path]:
+        return [root.path for root in cwd_skill_roots()]
 
     @staticmethod
     def _expected_registry_id(skill_dir: Path) -> Optional[str]:
@@ -125,22 +120,6 @@ class SkillLoader:
         return expected
 
     @staticmethod
-    def _cwd_skill_roots() -> List[Path]:
-        roots: List[Path] = []
-        current = Path.cwd().resolve()
-        for _ in range(_MAX_PARENT_WALK):
-            candidate = current / "skills"
-            if candidate.is_dir():
-                resolved = candidate.resolve()
-                if resolved not in roots:
-                    roots.append(resolved)
-            parent = current.parent
-            if parent == current:
-                break
-            current = parent
-        return roots
-
-    @staticmethod
     def _resolve_skill_path(skill_path: str) -> Path:
         """
         Resolve a skill directory from an absolute path, a path relative to cwd,
@@ -162,30 +141,13 @@ class SkillLoader:
                 return resolved
 
         skill_id = raw.replace("\\", "/").strip("/")
-        searched: List[str] = []
 
-        def try_roots(roots: List[Path]) -> Optional[Path]:
-            for root in roots:
-                attempt = (root / skill_id).resolve()
-                searched.append(str(attempt))
-                if SkillLoader._is_skill_dir(attempt):
-                    return attempt
-            return None
+        for root in get_skill_roots():
+            attempt = (root.path / skill_id).resolve()
+            if SkillLoader._is_skill_dir(attempt):
+                return attempt
 
-        for roots in (
-            SkillLoader._env_skill_roots(),
-            SkillLoader._cwd_skill_roots(),
-            [SkillLoader._bundled_skills_root()],
-        ):
-            found = try_roots(roots)
-            if found is not None:
-                return found
-
-        raise FileNotFoundError(
-            f"Skill not found: {skill_id!r}. Searched:\n  "
-            + "\n  ".join(searched)
-            + f"\nSet {SKILLWARE_SKILL_PATH_ENV} or pass an absolute path to the skill directory."
-        )
+        raise FileNotFoundError(build_skill_not_found_message(skill_id))
 
     @staticmethod
     def _discover_skill_class(module: Any, skill_file: str) -> Type[Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from skillware.cli import (
     cmd_test,
     _short_description,
     cmd_help,
+    cmd_paths,
 )
 
 import pytest
@@ -638,3 +639,75 @@ def test_main_examples_subcommand_exits_with_cmd_examples_code(monkeypatch):
         assert exc.value.code == 0
     finally:
         sys.argv = argv
+
+
+def test_cmd_paths_shows_roots_and_tiers(tmp_path, monkeypatch):
+    import io
+    from rich.console import Console
+
+    root = tmp_path / "skills"
+    root.mkdir()
+    skill_dir = root / "office" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.py").touch()
+    (skill_dir / "manifest.yaml").write_text(
+        "name: office/demo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    assert cmd_paths(console=console) == 0
+
+    output = buf.getvalue()
+    assert "Skill path resolution" in output
+    assert "project" in output
+    assert "bundled" in output
+    assert str(root) in output or "skills" in output.lower()
+    assert " 1 " in output or output.rstrip().endswith("1")
+
+
+def test_cmd_help_includes_paths_command():
+    import io
+    from rich.console import Console
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    cmd_help(console=console)
+    output = buf.getvalue()
+    assert "skillware paths" in output
+    assert "available now" in output
+    assert "coming soon" not in output.lower()
+
+
+def test_main_paths_subcommand(monkeypatch):
+    import sys
+    from skillware.cli import main
+
+    monkeypatch.setattr("skillware.cli.cmd_paths", lambda **kwargs: 0)
+
+    argv = sys.argv
+    sys.argv = ["skillware", "paths"]
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+    finally:
+        sys.argv = argv
+
+
+def test_interactive_paths_dispatches(monkeypatch):
+    import io
+    from rich.console import Console
+
+    responses = iter(["4", "q"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    cmd_interactive(console=console)
+
+    output = buf.getvalue()
+    assert "Skill path resolution" in output
+    assert "not yet implemented" not in output.lower()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,111 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from skillware.core.discovery import (
+    SKILLWARE_SKILL_PATH_ENV,
+    SkillRootTier,
+    build_skill_not_found_message,
+    bundled_skills_root,
+    find_shadow_conflicts,
+    get_skill_roots,
+    list_registry_skill_ids,
+)
+from skillware.core.loader import SkillLoader
+
+
+def _write_registry_skill(root: Path, category: str, name: str) -> None:
+    skill_dir = root / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.py").write_text(
+        "from skillware.core.base_skill import BaseSkill\n"
+        "class S(BaseSkill):\n"
+        "    @property\n"
+        "    def manifest(self): return {'name': '%s/%s'}\n"
+        "    def execute(self, p): return {}\n" % (category, name),
+        encoding="utf-8",
+    )
+    (skill_dir / "manifest.yaml").write_text(
+        f"name: {category}/{name}\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+
+def test_get_skill_roots_order_env_project_bundled(tmp_path, monkeypatch):
+    env_root = tmp_path / "external"
+    env_root.mkdir()
+    project_root = tmp_path / "project" / "skills"
+    project_root.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path / "project")
+    monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, str(env_root))
+
+    roots = get_skill_roots()
+    tiers = [root.tier for root in roots]
+
+    assert tiers[0] == SkillRootTier.EXTERNAL
+    assert tiers[1] == SkillRootTier.PROJECT
+    assert tiers[-1] == SkillRootTier.BUNDLED
+    assert roots[-1].path == bundled_skills_root()
+
+
+def test_get_skill_roots_override_single_root(tmp_path):
+    override = tmp_path / "only"
+    override.mkdir()
+    roots = get_skill_roots(override)
+    assert len(roots) == 1
+    assert roots[0].tier == SkillRootTier.OVERRIDE
+    assert roots[0].path == override.resolve()
+
+
+def test_for_display_shows_missing_env_path(tmp_path, monkeypatch):
+    missing = tmp_path / "missing-external"
+    monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, str(missing))
+    monkeypatch.chdir(tmp_path)
+
+    roots = get_skill_roots(for_display=True)
+    external = [r for r in roots if r.tier == SkillRootTier.EXTERNAL]
+    assert len(external) == 1
+    assert external[0].exists is False
+
+
+def test_find_shadow_conflicts_first_root_wins(tmp_path, monkeypatch):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    _write_registry_skill(first, "office", "dup_skill")
+    _write_registry_skill(second, "office", "dup_skill")
+
+    monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, f"{first}{os.pathsep}{second}")
+    monkeypatch.chdir(tmp_path)
+
+    roots = get_skill_roots(for_display=True)
+    conflicts = find_shadow_conflicts(roots)
+    assert len(conflicts) == 1
+    assert conflicts[0].skill_id == "office/dup_skill"
+    assert conflicts[0].winner.path == first.resolve()
+    assert conflicts[0].shadowed.path == second.resolve()
+
+
+def test_list_registry_skill_ids_ignores_flat_layout(tmp_path):
+    flat = tmp_path / "flat_skill"
+    flat.mkdir()
+    (flat / "skill.py").write_text("x = 1\n", encoding="utf-8")
+    (flat / "manifest.yaml").write_text("name: flat\n", encoding="utf-8")
+
+    assert list_registry_skill_ids(tmp_path) == []
+
+
+def test_build_skill_not_found_message_includes_paths_tip(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    message = build_skill_not_found_message("missing/skill")
+    assert "missing/skill" in message
+    assert "skillware paths" in message
+
+
+def test_loader_uses_discovery_error_message(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        SkillLoader.load_skill("missing/skill")
+    assert "skillware paths" in str(exc.value)


### PR DESCRIPTION
Introduce `skillware/core/discovery.py` so `SkillLoader` and the CLI share one root resolution order. Adds `skillware paths`, wires interactive menu option 4, and improves skill-not-found errors. Docs and README updated.

Closes #81

## Description

Implements [#81](https://github.com/ARPAHLS/skillware/issues/81): a read-only `skillware paths` command and shared skill-root discovery used by the loader and CLI.

**Acceptance criteria → implementation**

| Criterion | Where |
| :--- | :--- |
| `skillware paths` shows loader resolution order (external → project → bundled) | `skillware/cli.py` (`cmd_paths`), `skillware/core/discovery.py` (`get_skill_roots`, `SkillRootTier`) |
| Tier labels, per-root status, skill counts | `cmd_paths` Rich table + `list_registry_skill_ids()` |
| Shadowing summary (first root wins) | `find_shadow_conflicts()` in `discovery.py`; rendered in `cmd_paths` |
| Interactive menu option `4` / `paths` | `skillware/cli.py` interactive menu + dispatch |
| `skillware paths` subcommand + `--skills-root` | `skillware/cli.py` argparse + `main()` |
| Loader and CLI use the same resolution order | `SkillLoader._resolve_skill_path()` → `get_skill_roots()`; CLI list/test/paths via discovery |
| Skill-not-found errors mention searched paths + `skillware paths` | `build_skill_not_found_message()` in `discovery.py`; used by `loader.py` |
| Help/menu no longer mark `paths` as “coming soon” | `skillware/cli.py` (`cmd_help`, menu) |
| Tests | `tests/test_discovery.py`, `tests/test_cli.py`, existing `tests/test_loader.py` |
| Docs | `docs/usage/cli.md`, `docs/introduction.md`, `docs/usage/README.md`, `docs/security/skill-trust-model.md`, `README.md`, `CHANGELOG.md` |

**Out of scope (follow-ups):** config persistence (#246), interactive path editing (#247), themes (#248), `doctor`.

### Type of Change

- [ ] **New Skill** — new registry bundle under `skills/`
- [ ] **Skill Upgrade** — changes to an existing skill under `skills/`
- [ ] **Bug Fix** — incorrect runtime or framework behavior
- [x] **Documentation** — docs, README, CONTRIBUTING only
- [x] **Framework Feature** — `skillware/core/` loader, env, adapters
- [x] **CLI** — `skillware/cli.py`, `docs/usage/cli.md`
- [ ] **Examples** — `examples/*.py`, agent loops, `examples/README.md`
- [ ] **Packaging** — PyPI wheel, `pyproject.toml`, `MANIFEST.in`
- [ ] **RFC / meta** — templates, labels, CI, or large design doc

## Checklist (all PRs)

- [x] Linked GitHub issue (`Fixes #…` or `Refs #…`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset)
- [x] `pytest skills/` and `pytest tests/` pass locally when relevant
- [x] `CHANGELOG.md` updated under `[Unreleased]` when user-visible behavior changes
- [x] `examples/README.md` updated if this PR adds, renames, or removes a runnable script *(N/A — no example changes)*
- [x] Ran `pytest tests/test_registry_docs.py` when skills, examples index, or agent-loops matrix changed *(N/A — no catalog/examples/agent-loops changes)*

## New or updated skill

Skip unless this PR adds or changes files under `skills/`.

## Constitution and safety (skills only)

N/A — framework/CLI only. No change to skill execution model or sandboxing. `skillware paths` is read-only filesystem inspection; shadowing visibility aligns with [skill trust model](docs/security/skill-trust-model.md).

## Test plan

- [x] `python -m black --check .`
- [x] `python -m flake8 .`
- [x] `python -m pytest skills/ tests/` — 257 passed
- [x] `skillware paths` — table shows order, tiers, skill counts, tips
- [x] `skillware` → menu option `4` / `paths` works
- [x] `SkillLoader.load_skill("missing/skill")` — error lists searched paths and `skillware paths` tip
- [x] `pytest tests/test_discovery.py tests/test_cli.py tests/test_loader.py`

## Related Issues

Closes #81

Follow-ups: #246 (config paths), #247 (paths editor + grouped help), #248 (themes)