### PR TITLE
Add operator expectations for bundled vs external skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **Framework:** `SkillLoader` delegates root resolution to `discovery.get_skill_roots()` so load, list, test, and `paths` use the same order (#81).
 - **CLI:** Help and menu list `paths` as available (no longer “coming soon”) (#81).
 - **Documentation:** README — trim redundant Contributing cross-links, add `skillware paths` to install verification, and link the skill trust model in the docs table; cross-link `skillware paths` in `docs/introduction.md` and `docs/usage/README.md`.
+- **Documentation**: Add operator expectations (bundled vs external, out-of-band changes, where to report issues) and an instruction-only content note to `docs/security/skill-trust-model.md`; add trust-model cross-links from README configuration and CONTRIBUTING Skill Package Standard (#243).
 
 ## [0.4.3] - 2026-07-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,8 @@ Agents must follow [Agent Contribution Workflow](docs/contributing/ai_native_wor
 
 ## Skill Package Standard
 
+Skills you submit are reviewed for origin and quality, not sandboxed at runtime — operators run them in their own process. Understand the [skill trust model](docs/security/skill-trust-model.md) before designing a skill's behavior.
+
 Every registry skill lives in `skills/<category>/<skill_name>/` and **must** include the files below. This is the detailed standard for the **skill** contribution type.
 
 ### 1. `manifest.yaml` (metadata and governance)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Copy-Item .env.example .env
 
 Edit `.env` with agent keys (for example Gemini) and any keys your skills need. Agent keys power your LLM client; skill keys are declared per skill in the [Skill library](docs/skills/README.md). See [API keys for skills](docs/usage/api_keys.md) for setup, security, and framework variables.
 
+> Note: any loaded skill runs in your process and can read every variable in `os.environ`. Before wiring in real keys — especially with skills you did not write — see the [skill trust model](docs/security/skill-trust-model.md).
+
 ### 4. Usage Example (Gemini)
 
 This example requires the Google SDK optional extra: `pip install "skillware[gemini]"` (local dev: `pip install -e ".[gemini]"`). See the [Gemini usage guide](docs/usage/gemini.md) for setup details.

--- a/docs/security/skill-trust-model.md
+++ b/docs/security/skill-trust-model.md
@@ -50,6 +50,15 @@ A skill's tier describes where it came from and who reviewed it, which is the ba
 
 **External.** Skills loaded from SKILLWARE_SKILL_PATH or an absolute path. This is third-party code you did not write and no one has reviewed for you. Treat it as untrusted until you have read it yourself.
 
+### Operator expectations
+
+What you can reasonably expect from each origin:
+
+- **Bundled** skills are maintainer-reviewed before they ship — and still run unsandboxed in your process. Review raises confidence in the code's intent; it does not add isolation.
+- **Project and External** skills are your responsibility as the operator. As the identity RFC (#234) puts it: the project can provide the emulator for any skill, but external ROMs/skills are 100% the responsibility of the user. Nothing implies vetting of code the maintainers have never seen.
+- **External skills can change out of band.** A skill imported from a URL or git repository can change at any time, independently of Skillware releases. If you depend on one, pin it (a specific commit or copy) and re-review when you update.
+- **Where to report problems:** issues with bundled skills or the loader belong in this repository. Problems inside an external skill belong with that skill's maintainer — this repo can't fix or vouch for code it doesn't host.
+
 ## 4. constitution is guidance, not isolation
 
 A skill's manifest.yaml can declare a constitution — a set of natural-language rules such as "use a dedicated wallet only," "never pass private keys in tool arguments," or "fail closed on missing confirmation." For example, defi/evm_tx_handler declares a constitution covering dedicated wallets, secret handling, and fail-closed behavior.
@@ -63,6 +72,10 @@ The same distinction applies to other manifest fields. Declaring env_vars docume
 | Tell the agent how the skill should be used | Sandbox or restrict skill.py |
 | Document expected env vars and dependencies | Limit which env vars or files the code can access |
 | Set norms reviewers and agents can rely on | Enforce those norms at runtime |
+
+### Instruction-only content
+
+Some skill content is instructions rather than code — markdown packs and similar material that an agent reads. Loading it does not execute Python in your process, but that does not make it safe: instructions can still steer what the agent does (including how it uses other tools and skills). The risk moves from process access to agent behavior. Treat instruction-only content from outside your project with the same provenance judgment as executable skills: read it before you let an agent follow it.
 
 ## 5. Concrete flows
 


### PR DESCRIPTION
## Summary

Resolves #243 (docs only). Adds operator-facing expectations to the skill trust model and strengthens cross-links.

Fixes #243

## What's included

- `docs/security/skill-trust-model.md`:
  - **Operator expectations** (end of Provenance tiers): bundled = reviewed but still unsandboxed; project/external = operator responsibility (quoting the emulator/ROM framing from the #234 discussion); external skills can change out of band — pin and re-review; where to report problems (this repo vs the external maintainer).
  - **Instruction-only content** (end of the constitution section): loading it doesn't execute Python, but it can still steer the agent — the risk moves from process access to agent behavior.
- Cross-links: README (Configuration — note that skills can read all of `os.environ`, before wiring real keys) and CONTRIBUTING (Skill Package Standard intro) → trust doc. This also closes the under-linking flagged in #219.

## Scope notes

Docs only — no loader/CLI changes. Plain wording throughout; no #234 taxonomy terms (the RFC hasn't landed), written to be easy to expand once #234 closes.

Made with [Cursor](https://cursor.com)