### PR TITLE
Implement manifest param validation and standardize outputs key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **CLI:** `skillware paths` shows skill root resolution order (external → project → bundled), tier labels, shadowing summary, and operator tips; interactive menu option `4` wired (#81).
 - **Framework:** `skillware/core/discovery.py` — shared skill root discovery for `SkillLoader` and the CLI (tier labels, shadowing, registry ID listing; foundation for config-driven paths in #246).
-- **Framework:** Skill-not-found errors from `SkillLoader.load_skill()` include searched paths and a `skillware paths` tip (#81).
+- **Framework:** `BaseSkill.validate_params()` — optional helper to validate tool arguments against manifest `parameters` JSON Schema; raises `SkillwareParamValidationError` on mismatch. Not called automatically by the loader or `execute()` (#125). Reference: `examples/claude_wallet_check.py`, `examples/gemini_tos_evaluator.py`.
+- **Framework:** Registry manifests standardize on `outputs:` (legacy singular `output:` removed from `finance/wallet_screening`) (#125).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 **Optional but common:**
 
 - `env_vars` — API keys and configuration (never hardcode secrets in `skill.py`); document the same names on the skill catalog page and link to [API keys for skills](docs/usage/api_keys.md)
-- `category`, `outputs`, `presentation` — when they clarify the skill contract
+- `category`, `outputs`, `presentation` — when they clarify the skill contract. Use **`outputs:`** with named keys (never legacy singular **`output:`**).
 
 **Example:**
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -58,8 +58,8 @@ pip install -r requirements.txt
 
 ### Framework test
 
-- Core engine health: loader, CLI, issuer rules, version policy.
-- `tests/test_skill_issuer.py` also enforces registry packaging (`__init__.py`), issuer metadata, and presence of `test_skill.py` in every skill bundle.
+- Core engine health: loader, CLI, issuer rules, version policy, parameter schema validation (`tests/test_validate_params.py`).
+- `tests/test_skill_issuer.py` also enforces registry packaging (`__init__.py`), issuer metadata, presence of `test_skill.py` in every skill bundle, and rejects legacy manifest `output:` keys.
 - `tests/test_registry_docs.py` enforces doc-drift parity: skill catalog index matches manifests, examples README matches scripts on disk, and agent-loops.md references every registered skill.
 - Lives at the **root of `tests/`** only (`tests/test_loader.py`, `tests/test_cli.py`, …).
 - Clone-repo only; runs in CI via `pytest tests/` together with maintainer tests below.
@@ -82,7 +82,7 @@ pip install -r requirements.txt
 | :--- | :--- | :--- |
 | Manifest + execute contract for one skill | Bundle test | `skills/compliance/tos_evaluator/test_skill.py` |
 | Loader path + mocked externals (optional depth) | Maintainer test | `tests/skills/compliance/test_tos_evaluator.py` |
-| Loader, CLI, registry issuer rules | Framework test | `tests/test_loader.py`, `tests/test_skill_issuer.py`, `tests/test_registry_docs.py` |
+| Loader, CLI, registry issuer rules, param validation | Framework test | `tests/test_loader.py`, `tests/test_skill_issuer.py`, `tests/test_validate_params.py`, `tests/test_registry_docs.py` |
 | End-to-end provider demo script | Usage example | `examples/gemini_tos_evaluator.py` |
 
 **Rule of thumb:** if it ships with the skill and must pass before merge → **bundle test** (CI + local). If it is extra regression depth for clone-repo work → **maintainer test** (optional). If it proves provider integration → **example**, not pytest.

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -272,7 +272,7 @@ Complete the checklist that matches your issue during Stage 5.
 ### New or updated skill
 
 - [ ] `skills/<category>/<skill_name>/` exists with full bundle
-- [ ] `manifest.yaml`: `name` (`category/skill_name`, matches folder), `version`, `description`, `parameters`, `constitution`, real `issuer`
+- [ ] `manifest.yaml`: `name` (`category/skill_name`, matches folder), `version`, `description`, `parameters`, `constitution`, real `issuer`; use `outputs:` (not `output:`) when declaring return shape
 - [ ] Optional: `short_description` field (~80 chars) for a concise one-line summary in `skillware list`
 - [ ] `skill.py`: exactly one `BaseSkill` subclass (auto-discovered as `bundle["class"]`); deterministic, JSON-serializable returns, safe error handling
 - [ ] `instructions.md`: when to use, how to interpret output, limitations
@@ -304,7 +304,7 @@ Complete the checklist that matches your issue during Stage 5.
 
 - [ ] Framework issue approved
 - [ ] Changes in `skillware/` and relevant `tests/`
-- [ ] Loader or API docs updated when behavior changes (e.g. `registry_id`, identity warnings)
+- [ ] Loader or API docs updated when behavior changes (e.g. `registry_id`, identity warnings, `validate_params`)
 - [ ] `pytest tests/` passes
 - [ ] Usage docs updated if API changed
 - [ ] No undeclared breaking changes

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -116,7 +116,7 @@ This "Context Injection" ensures the model isn't just *able* to call the tool, b
 1.  **User Query**: "Is wallet 0x123 safe?"
 2.  **Model Cognition**: The LLM reads the injected `instructions.md` and realizes it should use the `finance/wallet_screening` tool.
 3.  **Tool Call**: The LLM outputs a structured tool call (e.g., JSON or Protobuf).
-4.  **Framework Execution**: Your script (or the model's auto-runner) executes `skill.execute({"address": "0x123"})`.
+4.  **Framework Execution**: Your script may validate tool arguments with `skill.validate_params(...)` before `execute()` (optional; recommended in agent loops). Direct integrations can call `skill.execute({"address": "0x123"})` without validation, as in many examples under `examples/`.
 5.  **The Body Acts**: `skill.py` runs. It fetches Etherscan data, checks local JSON sanctions lists, mimics the logic of a complex forensic tool.
 6.  **Structured Output**: The Body returns a rich JSON object.
 7.  **Synthesis**: The LLM receives the JSON. Guided again by the `instructions.md` (which says "Summarize risk factors clearly"), it translates the data into a human-readable report.

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -21,19 +21,19 @@ flowchart LR
 2. `skill = bundle["class"]()` — or `SkillLoader.get_skill_class(bundle)()`; `bundle["module"]` remains available for backward compatibility.
 3. Adapt `bundle` for the model (`to_gemini_tool`, `to_claude_tool`, etc.).
 4. Pass `bundle["instructions"]` as system context.
-5. On tool call, `result = skill.execute(arguments)` and return JSON to the model.
+5. On tool call, **optionally** validate arguments with `skill.validate_params(arguments)` against manifest `parameters` JSON Schema (recommended before `execute()` in production agent loops), then `result = skill.execute(arguments)` and return JSON to the model.
 
 | Step | Call |
 | :--- | :--- |
 | **load** | `SkillLoader.load_skill(id)` |
 | **wire** | `to_*_tool(bundle)` + `bundle["instructions"]` &rarr; model |
 | **prompt** | User query &rarr; model |
-| **execute** | `bundle["class"]().execute(args)` |
+| **execute** | Optional: `skill.validate_params(args)`; then `bundle["class"]().execute(args)` |
 | **return** | Tool result &rarr; model |
 
 ### Direct path (no model)
 
-You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON.
+You can also run skills directly without an LLM or agent loop (e.g., `examples/token_limiter_loop.py`): load the skill, call `execute(args)` directly, and process the returned JSON. **`validate_params()` is optional** — direct scripts and many examples skip it; skills may still validate or error inside `execute()`.
 
 ```mermaid
 flowchart LR
@@ -41,6 +41,8 @@ flowchart LR
 ```
 
 Provider guides contain full API details. Skill pages contain copy-paste examples with skill-specific paths and sample user messages.
+
+**Optional param validation:** Some agent-loop examples (e.g. `claude_wallet_check.py`, `gemini_tos_evaluator.py`) call `skill.validate_params(...)` before `execute()`; others call `execute()` directly.
 
 ---
 

--- a/examples/claude_wallet_check.py
+++ b/examples/claude_wallet_check.py
@@ -51,7 +51,7 @@ if message.stop_reason == "tool_use":
     print(f"Input: {tool_input}")
 
     if tool_name == TOOL_NAME:
-        # Execute the skill
+        wallet_skill.validate_params(tool_input)
         result = wallet_skill.execute(tool_input)
 
         print("\nSkill Execution Result (Summary):")

--- a/examples/gemini_tos_evaluator.py
+++ b/examples/gemini_tos_evaluator.py
@@ -46,6 +46,7 @@ while response.candidates and response.candidates[0].content.parts:
     print(f"Input: {fn_args}")
 
     if fn_name == TOOL_NAME:
+        tos_skill.validate_params(fn_args)
         result = tos_skill.execute(fn_args)
         print(json.dumps(result, indent=2))
         response = client.models.generate_content(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "python-dotenv",
     "beautifulsoup4",
     "packaging",
+    "jsonschema>=4.0",
     "rich>=13.0",
 ]
 requires-python = ">=3.10"

--- a/skills/finance/wallet_screening/manifest.yaml
+++ b/skills/finance/wallet_screening/manifest.yaml
@@ -16,9 +16,10 @@ parameters:
       description: The Ethereum wallet address to screen (starts with 0x).
   required:
     - address
-output:
-  type: object
-  description: A detailed JSON report containing risk assessment, sanctions hits, and transaction analysis.
+outputs:
+  report:
+    type: object
+    description: A detailed JSON report containing risk assessment, sanctions hits, and transaction analysis.
 constitution: |
   1. USER PRIVACY: Do not store or log the wallet address externally.
   2. ACCURACY: Always warn the user that this is a risk assessment tool and not legal advice.

--- a/skillware/core/base_skill.py
+++ b/skillware/core/base_skill.py
@@ -1,6 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
+import jsonschema
+from jsonschema import ValidationError
+
+
+class SkillwareParamValidationError(ValueError):
+    """Raised when tool arguments fail manifest ``parameters`` JSON Schema validation."""
+
 
 class BaseSkill(ABC):
     """
@@ -28,7 +35,28 @@ class BaseSkill(ABC):
 
     def validate_params(self, params: Dict[str, Any]) -> bool:
         """
-        Validates input parameters against the manifest schema.
+        Validates input parameters against the manifest ``parameters`` schema.
+
+        Returns ``True`` when validation passes. Raises ``SkillwareParamValidationError``
+        when ``params`` is not a mapping or does not satisfy the schema.
         """
-        # TODO: Implement schema validation (e.g. using Pydantic or jsonschema)
+        schema = self.manifest.get("parameters")
+        if not schema or not isinstance(schema, dict):
+            return True
+
+        skill_name = self.manifest.get("name", "unknown_skill")
+        if not isinstance(params, dict):
+            raise SkillwareParamValidationError(
+                f"Skill '{skill_name}' expects parameter arguments as a JSON object (dict), "
+                f"got {type(params).__name__}."
+            )
+
+        try:
+            jsonschema.validate(instance=params, schema=schema)
+        except ValidationError as exc:
+            path = ".".join(str(part) for part in exc.absolute_path) or "(root)"
+            raise SkillwareParamValidationError(
+                f"Skill '{skill_name}' parameter validation failed at '{path}': {exc.message}"
+            ) from exc
+
         return True

--- a/tests/test_skill_issuer.py
+++ b/tests/test_skill_issuer.py
@@ -95,6 +95,17 @@ def test_registry_skills_have_packaging_init_files():
         )
 
 
+def test_registry_manifests_use_outputs_not_output():
+    """Registry manifests must declare return shape under outputs:, not legacy output:."""
+    for skill_dir in _discover_skill_dirs():
+        rel = skill_dir.relative_to(REPO_ROOT).as_posix()
+        manifest = _load_manifest(skill_dir)
+        assert "output" not in manifest, (
+            f"{rel} manifest.yaml: rename legacy 'output:' to 'outputs:' "
+            "(named keys under outputs, see templates/python_skill/manifest.yaml)"
+        )
+
+
 def test_registry_card_issuer_matches_manifest_when_present():
     for skill_dir in _discover_skill_dirs():
         rel = skill_dir.relative_to(REPO_ROOT).as_posix()

--- a/tests/test_validate_params.py
+++ b/tests/test_validate_params.py
@@ -1,0 +1,79 @@
+"""Tests for BaseSkill.validate_params() against manifest parameters schema."""
+
+from typing import Any, Dict
+
+import pytest
+
+from skillware.core.base_skill import BaseSkill, SkillwareParamValidationError
+from skillware.core.loader import SkillLoader
+
+
+class _SchemaSkill(BaseSkill):
+    """Minimal skill with a fixed manifest schema for unit tests."""
+
+    @property
+    def manifest(self) -> Dict[str, Any]:
+        return {
+            "name": "test/schema_skill",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+                "required": ["query"],
+            },
+        }
+
+    def execute(self, params: Dict[str, Any]) -> Any:
+        return {"ok": True}
+
+
+def test_validate_params_accepts_valid_arguments():
+    skill = _SchemaSkill()
+    assert skill.validate_params({"query": "hello", "limit": 3}) is True
+
+
+def test_validate_params_rejects_missing_required_field():
+    skill = _SchemaSkill()
+    with pytest.raises(
+        SkillwareParamValidationError, match="'query' is a required property"
+    ):
+        skill.validate_params({})
+
+
+def test_validate_params_rejects_wrong_type():
+    skill = _SchemaSkill()
+    with pytest.raises(SkillwareParamValidationError, match="limit"):
+        skill.validate_params({"query": "hello", "limit": "three"})
+
+
+def test_validate_params_rejects_non_object_arguments():
+    skill = _SchemaSkill()
+    with pytest.raises(SkillwareParamValidationError, match="JSON object"):
+        skill.validate_params([])  # type: ignore[arg-type]
+
+
+def test_validate_params_no_schema_is_noop():
+    class _NoSchemaSkill(BaseSkill):
+        @property
+        def manifest(self) -> Dict[str, Any]:
+            return {"name": "test/no_schema"}
+
+        def execute(self, params: Dict[str, Any]) -> Any:
+            return {}
+
+    assert _NoSchemaSkill().validate_params({}) is True
+
+
+def test_registry_mental_coach_validates_required_user_prompt():
+    bundle = SkillLoader.load_skill("wellness/mental_coach")
+    skill = bundle["class"]()
+    assert skill.validate_params({"user_prompt": "I need a breathing exercise"}) is True
+
+
+def test_registry_mental_coach_rejects_missing_user_prompt():
+    bundle = SkillLoader.load_skill("wellness/mental_coach")
+    skill = bundle["class"]()
+    with pytest.raises(SkillwareParamValidationError, match="user_prompt"):
+        skill.validate_params({})


### PR DESCRIPTION
Fixes #125 — optional manifest parameter validation and a single registry manifest cleanup.

- **`BaseSkill.validate_params()`**, validates tool args against manifest `parameters` JSON Schema via `jsonschema`, raises `SkillwareParamValidationError` on mismatch. Not called by the loader or `execute()`, opt-in for host apps.
- **Issuer guard**, rejects legacy top-level `output:` in registry manifests (use `outputs:` with named keys).
- **`finance/wallet_screening`**, `output:` → `outputs.report:`.
- **Docs**, `agent_loops.md`, `introduction.md`, TESTING, CONTRIBUTING: validation optional, recommended before `execute()` in agent loops.
- **Examples**, `claude_wallet_check.py`, `gemini_tos_evaluator.py` show the pattern.

### Type of Change

- [ ] **New Skill**
- [ ] **Skill Upgrade**
- [ ] **Bug Fix**
- [x] **Documentation**
- [x] **Framework Feature**
- [ ] **CLI**
- [x] **Examples**
- [x] **Packaging**, `jsonschema>=4.0` added to core dependencies
- [ ] **RFC / meta**

## Checklist (all PRs)

- [x] Linked GitHub issue (`Fixes #125`)
- [x] Scope matches the issue, no unrelated refactors
- [x] `black --check` and `flake8` pass (Python 3.13)
- [x] `pytest tests/` and `pytest skills/` pass (265 tests)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `examples/README.md`, no script add/rename/remove
- [x] `pytest tests/test_registry_docs.py`, agent-loops touched, matrix unchanged

## New or updated skill

Minor manifest-only change to `finance/wallet_screening` (`outputs:` key). No logic, tests, or catalog updates required for that skill.

## Related Issues

Fixes #125