### PR TITLE
Add PyPI wheel packaging smoke test for bundled registry skills (#182).

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ exclude =
     build,
     dist,
     .venv,
+    .venv-wheel-smoke,
     env,
     venv,
     src/skillware.egg-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,27 @@ jobs:
         ANTHROPIC_API_KEY: "dummy_key_for_ci"
         ETHERSCAN_API_KEY: "dummy_key_for_ci"
       run: pytest tests/
+
+  wheel-smoke:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Build wheel
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build --wheel --outdir dist/
+
+    - name: Install wheel in clean venv
+      run: |
+        python -m venv /tmp/wheel-smoke-venv
+        /tmp/wheel-smoke-venv/bin/pip install --upgrade pip
+        /tmp/wheel-smoke-venv/bin/pip install dist/skillware-*.whl
+
+    - name: Wheel packaging smoke test
+      run: /tmp/wheel-smoke-venv/bin/python scripts/wheel_smoke_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 env/
 venv/
 .venv/
+.venv-wheel-smoke/
 build/
 dist/
 *.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Added
 
+- **CI:** PyPI wheel packaging smoke test — builds a wheel, installs it in a fresh venv (base deps only), and verifies every bundled registry skill is present and loadable via `scripts/wheel_smoke_test.py` (#182).
+- **Documentation:** Cross-linked wheel-smoke CI job in `CONTRIBUTING.md` and `docs/contributing/ai_native_workflow.md` (#182).
 - **CLI:** `skillware paths` shows skill root resolution order (external → project → bundled), tier labels, shadowing summary, and operator tips; interactive menu option `4` wired (#81).
 - **Framework:** `skillware/core/discovery.py` — shared skill root discovery for `SkillLoader` and the CLI (tier labels, shadowing, registry ID listing; foundation for config-driven paths in #246).
 - **Framework:** `BaseSkill.validate_params()` — optional helper to validate tool arguments against manifest `parameters` JSON Schema; raises `SkillwareParamValidationError` on mismatch. Not called automatically by the loader or `execute()` (#125). Reference: `examples/claude_wallet_check.py`, `examples/gemini_tos_evaluator.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Pick the path that matches your issue. Only the **skill** row requires the full 
 | **Core framework** | `skillware/core/`, framework `tests/` | `core framework`, `enhancement` | Framework Feature issue | `pytest tests/`; update usage docs if API changes |
 | **CLI** | `skillware/cli.py`, `docs/usage/cli.md` | `cli` | CLI issue | `pytest tests/test_cli.py` when relevant |
 | **Examples** | `examples/*.py`, agent loops, examples index | `examples` | Examples issue | Script runs; `pytest tests/test_registry_docs.py` when index changes |
-| **Packaging** | `pyproject.toml`, `MANIFEST.in`, wheel | `packaging` | Packaging issue | Build/install smoke per issue |
+| **Packaging** | `pyproject.toml`, `MANIFEST.in`, wheel | `packaging` | Packaging issue | `scripts/wheel_smoke_test.py` after wheel build (see [TESTING.md](docs/TESTING.md#packaging-smoke-test)) |
 | **Bug fix** | Paths named in issue | `bug` | Bug Report | Reproduction or failing test |
 | **Good first issue** | Usually docs, tests, or small fixes | `good first issue` | Read acceptance criteria literally | Checklist for underlying type above |
 | **RFC / large change** | Architecture, manifest contract | `discussion`, `core framework` | RFC issue | Per RFC scope |
@@ -128,7 +128,10 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 - **Framework test** — `tests/test_*.py` at repo root (loader, CLI, issuer rules, doc-drift guards).
 - **Maintainer skill test** — optional `tests/skills/<category>/test_<name>.py` for extra loader or edge-case coverage.
 - **Usage examples** — `examples/*.py` are not tests and are not run in CI.
-- **GitHub Actions** installs `pip install -e ".[dev,all]"`, runs `python -m black --check .`, then `flake8 .`, then **`pytest skills/`** (bundle tests), then **`pytest tests/`** (framework + maintainer tests). Do not add per-skill pip lines or hardcoded skill paths to `.github/workflows/ci.yml`.
+- **GitHub Actions** runs two jobs on every PR (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
+  - **`build`** — editable install `pip install -e ".[dev,all]"`, then `python -m black --check .`, `flake8 .`, **`pytest skills/`** (bundle tests), **`pytest tests/`** (framework + maintainer tests).
+  - **`wheel-smoke`** — builds a wheel, installs it in a fresh venv (base deps only), runs **`scripts/wheel_smoke_test.py`** to verify every bundled registry skill ships correctly. See [Packaging smoke test](docs/TESTING.md#packaging-smoke-test).
+- Do not add per-skill pip lines or hardcoded skill paths to `.github/workflows/ci.yml`.
 - Run locally before opening a PR:
 
   ```bash
@@ -297,7 +300,7 @@ Registry skills are shipped inside the `skillware` wheel. Per-skill layout uses 
 
 - Add an empty `__init__.py` in `skills/<category>/` when you introduce a **new category**, and in `skills/<category>/<skill_name>/` for each new skill directory (enforced by `tests/test_skill_issuer.py`).
 - Non-Python files (`manifest.yaml`, `instructions.md`, `card.json`, data files) are included automatically via `MANIFEST.in` and `[tool.setuptools.package-data]` (`skills = ["**/*"]`).
-- Confirm `SkillLoader.load_skill("<category>/<skill_name>")` works from the repo root and, when changing the loader, from a clean `pip install` of the built wheel.
+- Confirm `SkillLoader.load_skill("<category>/<skill_name>")` works from the repo root. CI **wheel-smoke** verifies every bundled skill from a clean `pip install` of the built wheel; run [`scripts/wheel_smoke_test.py`](scripts/wheel_smoke_test.py) locally when changing packaging, `MANIFEST.in`, or skill bundle layout (see [TESTING.md](docs/TESTING.md#packaging-smoke-test)).
 
 **Manifest `requirements` and optional extras**
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,8 +17,9 @@ Tests fall into four layers: **bundle**, **framework**, **maintainer**, and **ex
 | CLI `skillware test` for bundle discovery | Done |
 | Doc-drift guards (`test_registry_docs.py`) | Done |
 | GitHub label policy test (`test_github_labels.py`) | Done |
+| PyPI wheel packaging smoke test (`scripts/wheel_smoke_test.py`) | Done |
 
-Every pull request runs `black --check`, `flake8`, `pytest skills/`, and `pytest tests/`. Bundle tests gate merge the same as framework and maintainer tests.
+Every pull request runs `black --check`, `flake8`, `pytest skills/`, `pytest tests/`, and a **wheel-smoke** job that builds a wheel, installs it in a fresh venv (base install only — no `[all]` or per-skill extras), and verifies every bundled registry skill is present and loadable. Bundle tests gate merge the same as framework and maintainer tests.
 
 When [`.github/labels.json`](../../.github/labels.json) changes on `main`, the [Sync GitHub Labels](../../.github/workflows/sync-labels.yml) workflow updates label colors and descriptions on the repository automatically — do not edit labels manually in the GitHub UI.
 
@@ -86,6 +87,27 @@ pip install -r requirements.txt
 | End-to-end provider demo script | Usage example | `examples/gemini_tos_evaluator.py` |
 
 **Rule of thumb:** if it ships with the skill and must pass before merge → **bundle test** (CI + local). If it is extra regression depth for clone-repo work → **maintainer test** (optional). If it proves provider integration → **example**, not pytest.
+
+## Packaging smoke test
+
+Editable clone tests (`pytest skills/`, `pytest tests/`) do not prove that a **built PyPI wheel** ships every registry bundle. CI runs an additional **wheel-smoke** job (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)) that:
+
+1. Builds a wheel from the PR branch (`python -m build --wheel`).
+2. Creates a fresh virtualenv and `pip install`s the wheel (**base install only** — no `[all]` or per-skill extras).
+3. Runs `scripts/wheel_smoke_test.py`, which checks every bundled skill for required bundle files, manifest/name parity, instructions and card assets, and `SkillLoader.load_skill(..., check_requirements=False)`.
+
+Skills whose optional runtime deps are not in the base wheel may be **deferred** (packaging verified, import skipped until extras are installed). That is expected; bundle tests in editable mode still cover execute paths with mocked deps.
+
+Run locally after building a wheel:
+
+```bash
+python -m build --wheel --outdir dist/
+python -m venv /tmp/wheel-smoke-venv
+/tmp/wheel-smoke-venv/bin/pip install dist/skillware-*.whl
+/tmp/wheel-smoke-venv/bin/python scripts/wheel_smoke_test.py
+```
+
+On Windows, use `Scripts\python` and `Scripts\pip` under the venv path.
 
 ## 1. Code Formatting (Black)
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -216,7 +216,7 @@ You should:
 
 1. Draft the PR description (why, not only what; link the issue).
 2. Map changed files to the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md)—skill checklist only when `skills/` changed.
-3. Monitor CI (lint, `pytest skills/`, and `pytest tests/`). If checks fail, diagnose, fix in Stage 4, and push to the same branch.
+3. Monitor CI: **`build`** (lint, `pytest skills/`, `pytest tests/`) and **`wheel-smoke`** (built wheel + `scripts/wheel_smoke_test.py`). If checks fail, diagnose, fix in Stage 4, and push to the same branch.
 4. Address review comments with focused follow-up commits.
 
 Do not force-push shared branches unless a maintainer instructs you.

--- a/scripts/wheel_smoke_test.py
+++ b/scripts/wheel_smoke_test.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Packaging smoke test for installed skillware wheels.
+
+Run after ``pip install`` of a built wheel (not editable). Validates that every
+registry skill bundle shipped in the wheel is present on disk and loadable
+without installing optional per-skill extras or downloading models.
+
+Usage (CI):
+    python -m venv /tmp/smoke-venv
+    /tmp/smoke-venv/bin/pip install dist/skillware-*.whl
+    /tmp/smoke-venv/bin/python scripts/wheel_smoke_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Sequence
+
+import yaml
+
+from skillware.core.discovery import bundled_skills_root, list_registry_skill_ids
+from skillware.core.loader import SkillLoader
+
+BUNDLE_FILES = (
+    "manifest.yaml",
+    "skill.py",
+    "instructions.md",
+    "card.json",
+    "test_skill.py",
+)
+
+REQUIRED_BUNDLE_KEYS = ("manifest", "instructions", "module", "class")
+
+
+@dataclass
+class SkillSmokeResult:
+    skill_id: str
+    loaded: bool
+    deferred: bool = False
+    reason: str = ""
+
+
+@dataclass
+class SmokeReport:
+    skill_ids: List[str] = field(default_factory=list)
+    loaded: List[str] = field(default_factory=list)
+    deferred: List[SkillSmokeResult] = field(default_factory=list)
+    failures: List[str] = field(default_factory=list)
+
+
+def _missing_manifest_requirements(manifest: dict) -> List[str]:
+    missing: List[str] = []
+    for req in manifest.get("requirements") or []:
+        import_name = SkillLoader._requirement_import_name(req)
+        if importlib.util.find_spec(import_name) is None:
+            missing.append(import_name)
+    return missing
+
+
+def _verify_bundle_files(skill_dir: Path, skill_id: str, failures: List[str]) -> None:
+    for filename in BUNDLE_FILES:
+        path = skill_dir / filename
+        if not path.is_file():
+            failures.append(f"{skill_id}: missing bundle file {filename}")
+
+    category_init = skill_dir.parent / "__init__.py"
+    if not category_init.is_file():
+        failures.append(f"{skill_id}: missing category __init__.py at {category_init}")
+
+    skill_init = skill_dir / "__init__.py"
+    if not skill_init.is_file():
+        failures.append(f"{skill_id}: missing skill __init__.py")
+
+
+def _verify_manifest_assets(
+    skill_dir: Path, skill_id: str, failures: List[str]
+) -> dict:
+    manifest_path = skill_dir / "manifest.yaml"
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        failures.append(f"{skill_id}: invalid manifest.yaml — {exc}")
+        return {}
+
+    manifest_name = str(manifest.get("name", "")).strip()
+    if manifest_name != skill_id:
+        failures.append(
+            f"{skill_id}: manifest name {manifest_name!r} does not match registry id"
+        )
+
+    instructions_path = skill_dir / "instructions.md"
+    instructions = instructions_path.read_text(encoding="utf-8").strip()
+    if not instructions:
+        failures.append(f"{skill_id}: instructions.md is empty")
+
+    card_path = skill_dir / "card.json"
+    try:
+        json.loads(card_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        failures.append(f"{skill_id}: invalid card.json — {exc}")
+
+    return manifest
+
+
+def _try_load_skill(skill_id: str, manifest: dict) -> SkillSmokeResult:
+    try:
+        bundle = SkillLoader.load_skill(skill_id, check_requirements=False)
+    except ImportError as exc:
+        missing_reqs = _missing_manifest_requirements(manifest)
+        if missing_reqs:
+            return SkillSmokeResult(
+                skill_id=skill_id,
+                loaded=False,
+                deferred=True,
+                reason=(
+                    f"optional extras not installed ({', '.join(missing_reqs)}); "
+                    f"bundle files verified — {exc}"
+                ),
+            )
+        return SkillSmokeResult(
+            skill_id=skill_id,
+            loaded=False,
+            reason=f"import failed without optional extras: {exc}",
+        )
+    except Exception as exc:
+        return SkillSmokeResult(
+            skill_id=skill_id,
+            loaded=False,
+            reason=f"load failed: {exc}",
+        )
+
+    missing_keys = [key for key in REQUIRED_BUNDLE_KEYS if key not in bundle]
+    if missing_keys:
+        return SkillSmokeResult(
+            skill_id=skill_id,
+            loaded=False,
+            reason=f"bundle missing keys: {', '.join(missing_keys)}",
+        )
+
+    if not bundle.get("instructions"):
+        return SkillSmokeResult(
+            skill_id=skill_id,
+            loaded=False,
+            reason="bundle instructions empty",
+        )
+
+    return SkillSmokeResult(skill_id=skill_id, loaded=True)
+
+
+def run_wheel_smoke() -> SmokeReport:
+    bundled_root = bundled_skills_root()
+    if not bundled_root.is_dir():
+        raise SystemExit(f"Bundled skills root not found: {bundled_root}")
+
+    skill_ids = list_registry_skill_ids(bundled_root)
+    if not skill_ids:
+        raise SystemExit(f"No registry skills found under {bundled_root}")
+
+    report = SmokeReport(skill_ids=skill_ids)
+
+    for skill_id in skill_ids:
+        skill_dir = bundled_root / skill_id
+        failures_before = len(report.failures)
+
+        _verify_bundle_files(skill_dir, skill_id, report.failures)
+        manifest = _verify_manifest_assets(skill_dir, skill_id, report.failures)
+        if len(report.failures) > failures_before:
+            continue
+
+        result = _try_load_skill(skill_id, manifest)
+        if result.loaded:
+            report.loaded.append(skill_id)
+        elif result.deferred:
+            report.deferred.append(result)
+        else:
+            report.failures.append(f"{skill_id}: {result.reason}")
+
+    return report
+
+
+def _isolated_smoke_env() -> None:
+    """Avoid project ./skills/ or SKILLWARE_SKILL_PATH shadowing bundled wheel."""
+    os.environ.pop("SKILLWARE_SKILL_PATH", None)
+    os.chdir(tempfile.mkdtemp(prefix="skillware-wheel-smoke-"))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    del argv
+    _isolated_smoke_env()
+    report = run_wheel_smoke()
+
+    print(f"Wheel smoke: {len(report.skill_ids)} registry skill(s) in bundled wheel")
+    print(f"  loaded:   {len(report.loaded)}")
+    print(f"  deferred: {len(report.deferred)} (optional extras not installed)")
+    for item in report.deferred:
+        print(f"    - {item.skill_id}: {item.reason}")
+
+    if report.failures:
+        print(f"  failed:   {len(report.failures)}", file=sys.stderr)
+        for line in report.failures:
+            print(f"    - {line}", file=sys.stderr)
+        return 1
+
+    if not report.loaded and not report.deferred:
+        print("No skills loaded or deferred — unexpected", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skillware/core/loader.py
+++ b/skillware/core/loader.py
@@ -186,7 +186,9 @@ class SkillLoader:
         return skill_class
 
     @staticmethod
-    def load_skill(skill_path: str) -> Dict[str, Any]:
+    def load_skill(
+        skill_path: str, *, check_requirements: bool = True
+    ) -> Dict[str, Any]:
         """
         Loads a skill and returns a bundled object with:
         - module: The loaded skill.py module
@@ -195,6 +197,9 @@ class SkillLoader:
         - instructions: The system prompt content
         - card: The UI card definition
         - registry_id: Path-derived registry ID when validation applies
+
+        Set ``check_requirements=False`` for packaging smoke tests that install
+        the base wheel without optional skill extras (``[all]``, ``[defi]``, etc.).
         """
         resolved_path = SkillLoader._resolve_skill_path(skill_path)
         skill_path = str(resolved_path)
@@ -209,7 +214,7 @@ class SkillLoader:
         registry_id = SkillLoader._validate_manifest_identity(resolved_path, manifest)
 
         # Check Dependencies
-        if "requirements" in manifest:
+        if check_requirements and "requirements" in manifest:
             missing = []
             for req in manifest["requirements"]:
                 import_name = SkillLoader._requirement_import_name(req)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -28,6 +28,16 @@ def test_load_skill_registry_has_manifest():
     assert SkillLoader.get_skill_class(bundle) is bundle["class"]
 
 
+def test_load_skill_can_skip_requirement_check():
+    """Packaging smoke installs base wheel only; optional extras may be absent."""
+    bundle = SkillLoader.load_skill(
+        "compliance/mica_module",
+        check_requirements=False,
+    )
+    assert bundle["manifest"].get("name") == "compliance/mica_module"
+    assert bundle["class"].__name__ == "MiCAModuleSkill"
+
+
 def test_load_skill_class_is_instantiable():
     bundle = SkillLoader.load_skill("optimization/prompt_rewriter")
     skill = bundle["class"]()


### PR DESCRIPTION
## Summary

Adds a **wheel-smoke** CI job that validates the PyPI shipping path: build a wheel, install it in a fresh venv (base deps only — no `[all]` or per-skill extras), and verify every bundled registry skill via `scripts/wheel_smoke_test.py`.

`SkillLoader.load_skill()` gains `check_requirements=False` so the smoke test can load bundles for packaging checks without installing optional skill extras.

Refs #182

### What changed

- **`scripts/wheel_smoke_test.py`** — checks bundle files, manifest/name parity, instructions/card assets; loads skills where possible; defers skills that need optional extras (expected)
- **`.github/workflows/ci.yml`** — new `wheel-smoke` job (existing `build` job unchanged)
- **`skillware/core/loader.py`** — `check_requirements: bool = True` kwarg
- **`tests/test_loader.py`** — coverage for `check_requirements=False`
- **Docs** — `TESTING.md`, `CONTRIBUTING.md`, `ai_native_workflow.md`
- **`.flake8` / `.gitignore`** — exclude local `.venv-wheel-smoke/` test venv

### Type of change

- [x] **Framework Feature** — `SkillLoader.check_requirements`
- [x] **Packaging** — wheel smoke test for bundled skills
- [x] **RFC / meta** — CI workflow

## Checklist

- [x] Linked issue (`Refs #182`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `black --check` and `flake8` pass locally
- [x] `pytest skills/` and `pytest tests/` pass locally (266 passed)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `examples/README.md` — N/A
- [ ] `test_registry_docs.py` — N/A (no skill/catalog changes)

## Test plan

- [x] `python -m black --check .`
- [x] `python -m flake8 .`
- [x] `python -m pytest skills/ tests/`
- [x] Build wheel + `scripts/wheel_smoke_test.py` locally (10 loaded, 3 deferred)
- [ ] Confirm **`wheel-smoke`** job passes on GitHub Actions

## Related issues

Refs #182