### PR TITLE
Document append-only skill context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation:** Clarified that skill `instructions.md` files provide concise, append-only skill context rather than host-agent personas (#258).
+
 ## [0.4.5] - 2026-07-16
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,12 +272,13 @@ requirements:
 
 ### 3. `instructions.md` (cognition)
 
-The primary guide for the host LLM.
+The primary guide for the host LLM. Treat it as a short, append-only block of context for this skill: host agents already own their system prompt and persona.
 
-- Open with context such as: "You are an agent equipped with [Skill Name]..."
-- Explain **when** to invoke the tool.
-- Explain how to interpret outputs and handle edge cases.
-- Keep prompts and persona here, not in `skill.py`.
+- Open with the skill's ID, purpose, and important limits.
+- Explain **when** to invoke the tool, which inputs fit each scenario, and how to interpret outputs and errors.
+- Keep the guidance concise because operators may load multiple skills.
+- Avoid persona assignments such as "You are an agent equipped with...", restating host-wide policies, or instructions that could conflict with another skill.
+- Keep skill-specific prompts here, not in `skill.py`.
 
 ### 4. `card.json` (presentation)
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -243,7 +243,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 - On each catalog page, add a **Usage Examples** section (Gemini, Claude, OpenAI, DeepSeek, Ollama prompt mode) per [skill usage template](../usage/skill_usage_template.md). Keep provider mechanics in `docs/usage/`; put skill-specific paths, sample user messages, and `execute` payloads on the skill page.
 - Categories: `compliance`, `creative`, `data_engineering`, `defi`, `dev_tools`, `finance`, `monitoring`, `office`, `optimization`, `wellness` — see [Skill library](../skills/README.md) for the live registry; [Choosing a category](../../CONTRIBUTING.md#choosing-a-category) in CONTRIBUTING.md (issue first for new top-level folders)
 - Do not bump `pyproject.toml` version in skill-only PRs unless requested
-- Logic in `skill.py`; prompts and persona in `instructions.md`
+- Logic in `skill.py`; skill-specific context in `instructions.md`. Keep instructions short and append-only: host agents already own their system prompt and persona, so describe this skill's use, limits, outputs, and errors instead of assigning a role.
 - Never commit secrets; document `env_vars` in the manifest
 
 ### Core framework (`skillware/core/`)

--- a/templates/python_skill/instructions.md
+++ b/templates/python_skill/instructions.md
@@ -1,14 +1,20 @@
-# Instructions: My Awesome Skill
+# My Awesome Skill (`category/my_awesome_skill`)
 
-You are an agent equipped with the **My Awesome Skill**. 
+[Describe what this skill does, whether it is local or deterministic, and important limits.]
 
 ### When to use this tool
 - Use this tool when the user asks for [describe primary use case].
 - Do not use this tool for [describe anti-patterns].
 
+### How to use this tool
+- Use `param1` when [describe scenario].
+- Use `param2` when [describe scenario].
+
 ### How to interpret the output
 - The tool returns a `result` field containing [describe result].
-- If you see an error message, explain to the user that [describe error handling].
+- If you see an error message, [describe the host's next step].
+
+Keep this guidance focused on the skill. It is appended to the host agent's context, so do not assign a persona, restate host-wide policies, or add a long playbook.
 
 ### Examples
 - User: "Run my awesome skill with value X" -> Call `my-awesome-skill(param1="X")`


### PR DESCRIPTION
# Document append-only skill context

## Summary

Clarifies that skill `instructions.md` files are concise, append-only skill-context blocks rather than host-agent persona prompts. The guidance preserves contributor flexibility while helping multiple skills coexist in a host agent's context.

Fixes #258

## Changes

- Reframed the `instructions.md` contributor guidance around skill purpose, limits, inputs, outputs, and errors.
- Added a brief append-only skill-context note to the AI contribution workflow.
- Replaced the Python skill template's persona opener with a skill-context starter and practical usage guidance.
- Added an Unreleased changelog entry.

## Testing

- `sandbox-run "python -m pytest tests/test_registry_docs.py"` — passed: 7 tests.
- `sandbox-run "pip install -e '.[dev]' && python -m flake8"` — passed.
- `git diff --check` — passed.
- `sandbox-run "pip install -e '.[dev]' && python -m black --check CONTRIBUTING.md docs/contributing/ai_native_workflow.md templates/python_skill/instructions.md CHANGELOG.md && python -m flake8"` — not applicable as written: Black was invoked on Markdown files and reported parse errors before Flake8 ran; the standalone Flake8 command above passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
