### PR TITLE
Add CITATION.cff and maintainer release citation guidance (#269).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Added
+
+- **Citation:** Root `CITATION.cff` and README **Citing** section for formal software citation; Zenodo concept DOI to follow maintainer GitHub–Zenodo linking (#269).
+
 ## [0.4.6] - 2026-07-23
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+# Citation metadata for ARPAHLS/skillware (the open-source software project).
+# Prefer the Zenodo concept DOI once minted (#269); keep version in methods text.
+# Validate: pip install cffconvert && cffconvert -i CITATION.cff -f apalike
+cff-version: 1.2.0
+message: >-
+  If you use this software, please cite it using the metadata below.
+  Prefer the Zenodo concept DOI when listed under identifiers.
+  Also record the Skillware version you used (PyPI or Git tag) for reproducibility.
+type: software
+title: Skillware
+abstract: >-
+  Skillware is an open-source Python framework for modular, self-contained skill
+  management for machines. It provides a loadable skill registry with manifests,
+  constitution and safety constraints, deterministic execute() implementations,
+  and adapters for logical system providers — whether LLM APIs, hosted inference,
+  or local runtimes.
+version: "0.4.6"
+date-released: "2026-07-23"
+license: MIT
+repository-code: "https://github.com/ARPAHLS/skillware"
+url: "https://skillware.site"
+authors:
+  - family-names: Peilivanidis
+    given-names: Vladimiros
+    alias: Ross Peili
+    email: vpeilivanidis@gmail.com
+    affiliation: "ARPA Hellenic Logical Systems"
+    website: "https://github.com/rosspeili"
+  - name: "ARPA Hellenic Logical Systems"
+    email: skillware-os@arpacorp.net
+    website: "https://arpacorp.net"
+keywords:
+  - skillware
+  - python
+  - ai
+  - ai-agents
+  - agent-skills
+  - autonomous-agents
+  - llm-tools
+  - function-calling
+  - local-ai
+  - sovereign-ai
+  - skill-registry
+  - open-source
+  - dev-tools
+# After Zenodo GitHub integration + first archived release (#269 Phase B), add:
+# identifiers:
+#   - type: doi
+#     value: 10.5281/zenodo.XXXXXXXX
+#     description: Concept DOI (all versions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Follow the [Agent Code of Conduct](CODE_OF_CONDUCT.md): deterministic skill outp
 ### Scope
 
 - Change only what the issue requires. Avoid unrelated refactors or drive-by edits.
-- Do not bump the package version in `pyproject.toml` unless the issue or a maintainer explicitly requests it (skill-only PRs typically do not version the framework).
+- Do not bump the package version in `pyproject.toml` (or `CITATION.cff` `version` / `date-released`) unless the issue or a maintainer explicitly requests it (skill-only PRs typically do not version the framework). See [Maintainer: cutting a framework release](#maintainer-cutting-a-framework-release).
 - When a PR changes **user-visible behavior** (framework features, new or changed skills, breaking fixes, CLI or documentation users rely on), add entries under `[Unreleased]` in [CHANGELOG.md](CHANGELOG.md) in the same PR (Keep a Changelog sections: Added / Changed / Fixed / Removed). Do not add version headers or publish releases; maintainers cut releases.
 - Skill-only PRs that will not ship in the next PyPI release may omit a CHANGELOG entry; ask on the issue or use maintainer judgment.
 
@@ -404,7 +404,27 @@ Registry IDs are always `category/skill_name` from the folder path and must matc
 | [Issue templates](.github/ISSUE_TEMPLATE/) | Bug, docs, skills, CLI, examples, RFC chooser |
 | [`.github/labels.json`](.github/labels.json) | Label names, colors, descriptions (synced via CI) |
 | [CHANGELOG.md](CHANGELOG.md) | Release history; contributors add under `[Unreleased]` |
+| [CITATION.cff](CITATION.cff) | Preferred software citation metadata (Zenodo concept DOI when present) |
 | [Security policy](SECURITY.md) | Reporting vulnerabilities |
+
+### Maintainer: cutting a framework release
+
+Routine contributor PRs must **not** bump the package version. Maintainers cut releases (chore / release PR or direct maintainer commit) and should keep version surfaces in sync:
+
+| Touch | Every framework release? | Notes |
+| :--- | :--- | :--- |
+| `pyproject.toml` → `[project].version` | **Yes** | Source of truth for PyPI / `importlib.metadata` / `skillware --version` |
+| `CHANGELOG.md` | **Yes** | Move `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`; leave a fresh empty `[Unreleased]` |
+| `CITATION.cff` → `version`, `date-released` | **Yes** | Match the release tag/date. Keep the Zenodo **concept DOI** in `identifiers` stable — do not swap it for a version DOI |
+| GitHub Release + tag (`vX.Y.Z`) | **Yes** | Triggers Zenodo archive when GitHub–Zenodo is linked (#269) |
+| PyPI upload | **Yes** | After tag / CI as usual |
+| `README.md` **Citing** example version | **Optional** | Only if an example pin (e.g. `0.4.6`) is present; otherwise “record the version you used” is enough |
+| `skillware/version_policy.py` + `SECURITY.md` | **Only when support windows change** | Not every release |
+| CLI / loader code | **Usually no** | Version is read from installed package metadata |
+| Skill `manifest.yaml` `version` | **No** (unless that skill changed) | Skill versions are independent of the framework version |
+| `docs/contributing/ai_native_workflow.md` / `CODE_OF_CONDUCT.md` | **No** | Not version bump surfaces |
+
+After the first Zenodo concept DOI exists: optional README DOI badge and a Citation/DOI entry under `[project.urls]` in `pyproject.toml`. Do not add `.zenodo.json` unless a Zenodo-only field is required (it would override CFF).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#contributing">Contributing</a> •
   <a href="#comparison">Comparison</a> •
   <a href="#stats">Stats</a> •
+  <a href="#citing">Citing</a> •
   <a href="CHANGELOG.md">Changelog</a> •
   <a href="#contact">Contact</a>
 </div>
@@ -252,6 +253,14 @@ Skillware differs from the Model Context Protocol (MCP), and Agent Skills (SKILL
 <a href="https://pepy.tech/projects/skillware"><img src="https://img.shields.io/pepy/dt/skillware?style=flat-square&label=DLs%20%E2%86%93%20total&color=bbf7d0" alt="Total downloads (PePy)"></a>
 
 PyPI download counts show how often `skillware` is installed from the package index. Numbers come from public third-party aggregators, and they include CI and mirror traffic, so they measure **install activity**, not unique users. Totals may differ slightly between services because each source uses its own window and methodology. Use the stats dashboards in the above badges for charts, version breakdowns, and longer history.
+
+## Citing
+
+If you use **this** software project (`ARPAHLS/skillware`) in research or products, please cite it via the repository [CITATION.cff](CITATION.cff) (GitHub **Cite this repository** in the sidebar).
+
+**Preferred form (once Zenodo is linked):** the Zenodo **concept DOI** recorded in `CITATION.cff` under `identifiers` — a stable target that does not change every release. Until that DOI is minted, use the CFF / GitHub citation export and the repository URL.
+
+For reproducibility, also record the **Skillware version** you used (PyPI package version or Git tag, for example `0.4.6`) in your methods or dependency list. You do not need a new DOI per release for ordinary citations.
 
 ## Contact
 


### PR DESCRIPTION
## Description

Adds root `CITATION.cff`, a README **Citing** section, and maintainer release guidance so Skillware has a formal cite path before Zenodo concept-DOI linking.

Refs #269 (Phase A). Phase B (Zenodo connect + DOI in CFF) follows after merge.

### Type of Change

- [x] **RFC / meta** — templates, labels, CI, or large design doc
- [x] **Documentation** — docs, README, CONTRIBUTING only

## Checklist (all PRs)

- [x] Linked GitHub issue (`Refs #269`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset) — N/A (docs/metadata only)
- [x] `pytest skills/` and `pytest tests/` pass locally when relevant — N/A
- [x] `CHANGELOG.md` updated under `[Unreleased]` when user-visible behavior changes
- [x] `examples/README.md` updated if this PR adds, renames, or removes a runnable script — N/A
- [x] Ran `pytest tests/test_registry_docs.py` when skills, examples index, or agent-loops matrix changed — N/A

## Related Issues

Refs #269