### PR TITLE
docs: add creative and security to skill proposal categories

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_skill_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/01_skill_proposal.yml
@@ -27,6 +27,7 @@ body:
       description: Pick an existing category or propose a new one in the description
       options:
         - compliance
+        - creative
         - data_engineering
         - defi
         - dev_tools
@@ -34,6 +35,7 @@ body:
         - monitoring
         - office
         - optimization
+        - security
         - wellness
         - "Propose new category (describe below)"
     validations:


### PR DESCRIPTION
## Summary
The New Skill Proposal issue template category dropdown was missing `creative` and `security`, which already exist under `skills/` and in CONTRIBUTING.

## Changes
- Add `creative` and `security` to the category options list (alphabetically with the rest).

Closes #277