### PR TITLE
docs: add creative and security to skill proposal categories

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_skill_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/01_skill_proposal.yml
@@ -9,6 +9,8 @@ body:
         Thanks for helping expand the Skillware ecosystem!
         Please review the [Contribution Guidelines](https://github.com/ARPAHLS/skillware/blob/main/CONTRIBUTING.md) and start from [templates/python_skill/](https://github.com/ARPAHLS/skillware/tree/main/templates/python_skill).
 
+        See the [Skill categories](https://github.com/ARPAHLS/skillware/blob/main/CONTRIBUTING.md#skill-categories) table for the list of valid categories used in the dropdown below.
+
         To improve an **existing** skill, use the **Skill Upgrade** template instead.
 
   - type: input
@@ -27,6 +29,7 @@ body:
       description: Pick an existing category or propose a new one in the description
       options:
         - compliance
+        - creative
         - data_engineering
         - defi
         - dev_tools
@@ -34,6 +37,7 @@ body:
         - monitoring
         - office
         - optimization
+        - security
         - wellness
         - "Propose new category (describe below)"
     validations:

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -10,6 +10,11 @@
         "description": "Security vulnerabilities, trust model, or constitution updates."
     },
     {
+        "name": "creative",
+        "color": "F5D0FE",
+        "description": "Creative skills, image, video, audio, or generative content."
+    },
+    {
         "name": "packaging",
         "color": "DBD3DC",
         "description": "PyPI wheel, pyproject.toml, MANIFEST.in, or install extras."


### PR DESCRIPTION
Closes #277

Syncs the New Skill Proposal template with the current registry by adding the two missing categories (`creative`, `security`) that already have shipped skills.

## Changes

**`.github/ISSUE_TEMPLATE/01_skill_proposal.yml`**
- Added `creative` and `security` to the category dropdown, sorted alphabetically alongside the existing options
- Kept "Propose new category (describe below)" as the last option
- Added a one-line note in the intro linking to the Skill categories table in CONTRIBUTING.md, so future drift is easier to spot

**`.github/labels.json`**
- Added a `creative` label matching the format/style of the existing `security` label

## Notes

- Left `CONTRIBUTING.md` and the skill folder layout alone since they were marked out of scope
- Did not run `scripts/sync_labels.py` locally per your earlier note, CI will sync the new label on merge

Let me know if any adjustments are needed!