### PR TITLE
feat(cli): interactive paths editor, tiered help, and nav (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **Config:** Persistent YAML configuration (global `config.yaml` and project `.skillware.yaml`); `paths` section drives skill root discovery when present; bundled registry always included (#246).
 - **CLI:** `skillware config show` prints merged configuration (read-only); `skillware paths` tips updated for config files (#246).
+- **CLI:** Interactive paths submenu (menu `4`) — view bundled registry, persist project/external paths to `.skillware.yaml`, shadowing and flat-layout diagnose; tiered help topics (menu `6`); universal navigation (`0` exit, `b` back); doctor spinner while diagnosing (#247).
 - **Loader:** `SkillLoader.load_skill(..., execute_module=False)` inspect-only load (manifest, instructions, card, requirement pre-flight) without executing `skill.py`; clearer `ImportError` when `skill.py` import fails after pre-flight (#235).
 - **CLI:** `skillware doctor` checks manifest deps and `skill.py` import readiness per skill (`DEPS` / `LOAD` table); optional skill ID, `--category`, and `--skills-root` (#235).
 
 ### Changed
 
+- **CLI:** `skillware examples` table — wider **EXTRA** column; **GITHUB** shows script filename as a clickable link (full URL on ctrl+click) (#247).
+- **Loader:** Skill-not-found errors list searched roots with tier labels (`project`, `external`, `bundled`) (#247).
 - **Loader:** `SkillLoader.load_skill()` validates manifest `requirements` version specifiers (for example `web3>=6.0.0`) against installed package versions before loading `skill.py`; unpinned entries still require importability only (#14).
 - **GitHub**: New Skill Proposal template category dropdown synced with the registry (`creative`, `security`); added `creative` label (#279, #277).
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ your PATH — use `python -m skillware list` as a fallback. See
 
 ### 3. Configuration
 
-Copy the environment template and add your keys.
+**Skill paths (optional):** copy [`.skillware.yaml.example`](.skillware.yaml.example) to `.skillware.yaml` in your project root, or use the interactive menu (**`4` / `paths`**) to persist project and external skill roots. Inspect merged settings with `skillware config show`. See [CLI — config](docs/usage/cli.md#skillware-config).
+
+**API keys:** copy the environment template and add your keys.
 
 **Unix / macOS:**
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -92,9 +92,9 @@ You must:
 | :--- | :--- |
 | New skill | `skills/<category>/<name>/`, `docs/skills/<name>.md`, `docs/skills/README.md`, `templates/python_skill/`, `tests/test_skill_issuer.py`, and when documenting integration: `docs/usage/README.md`, [agent_loops.md](../usage/agent_loops.md), [skill_usage_template.md](../usage/skill_usage_template.md), matching `examples/*.py` if present, and a row in `examples/README.md` if a runnable script is added or renamed. Doc-drift guards in `tests/test_registry_docs.py` verify that `docs/skills/README.md`, `examples/README.md`, and `docs/usage/agent_loops.md` stay in sync with manifests and scripts on disk — these run automatically via `pytest tests/`. |
 | Skill upgrade | Same paths as new skill, but only the existing skill ID from the issue; bump `manifest.yaml` version when behavior or schema changes |
-| CLI | `skillware/cli.py`, `docs/usage/cli.md`, `tests/test_cli.py` |
+| CLI | `skillware/cli.py`, `docs/usage/cli.md`, `tests/test_cli.py`, `docs/usage/api_keys.md` (when env vars change) |
 | Examples | `examples/*.py`, `examples/README.md`, `docs/usage/agent_loops.md`; run `pytest tests/test_registry_docs.py` when the index or matrix changes |
-| Core framework | `skillware/core/`, `tests/test_loader.py`, `docs/usage/` |
+| Core framework | `skillware/core/`, `tests/test_loader.py`, `tests/test_config.py`, `docs/usage/` |
 | Documentation only | `docs/`, `README.md`, `CONTRIBUTING.md`, inbound links; `examples/README.md` when the issue adds, renames, or removes runnable scripts under `examples/`; for skill catalog or provider integration work, also `docs/usage/` and `docs/skills/`. Run `pytest tests/test_registry_docs.py` to confirm catalog and examples docs still match manifests and scripts on disk. |
 | Release / user-visible change | Root [CHANGELOG.md](../../CHANGELOG.md) under `[Unreleased]` when behavior, CLI, skills, or user-facing docs change (maintainers cut version sections) |
 | Bug fix | Failing test, reproduction steps, related skill or loader code |

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -12,7 +12,7 @@ How to load Skillware skills and connect them to language models. Each guide cov
 2. A `skills/` directory in the current working directory or its parents
 3. Bundled skills installed with the `skillware` package (for example under `site-packages/skills/`)
 
-**With config:** copy [`.skillware.yaml.example`](../.skillware.yaml.example) to `.skillware.yaml` (or use global `~/.config/skillware/config.yaml`) to persist project and external paths. Default order is project → external → bundled; the bundled registry is always available. See [CLI — config](cli.md#skillware-config) and `skillware config show`.
+**With config:** copy [`.skillware.yaml.example`](../.skillware.yaml.example) to `.skillware.yaml` (or use global `~/.config/skillware/config.yaml`) to persist project and external paths. Use the interactive menu (**`4` / `paths`**) or edit YAML manually. Default order is project → external → bundled; the bundled registry is always available. See [CLI — config](cli.md#skillware-config) and `skillware config show`.
 
 For pip-installed apps, bundled maintainer skills are the default; add private skills under `./skills/<category>/<name>/`, config `paths.external`, or `SKILLWARE_SKILL_PATH`.
 

--- a/docs/usage/api_keys.md
+++ b/docs/usage/api_keys.md
@@ -34,7 +34,8 @@ These are read by Skillware itself (loader and CLI), not by individual skills:
 
 | Variable | Purpose |
 | :--- | :--- |
-| `SKILLWARE_SKILL_PATH` | Extra filesystem roots for skill discovery (OS path separator between multiple entries). See [CLI reference](cli.md#path-resolution). |
+| `SKILLWARE_SKILL_PATH` | Extra filesystem roots for skill discovery (OS path separator between multiple entries). Without a config file, these are checked first (legacy order). When `.skillware.yaml` or global `config.yaml` exists, entries are merged into the **external** tier unless `legacy.honor_skillware_skill_path: false`. See [CLI — path resolution](cli.md#path-resolution). |
+| `SKILLWARE_CONFIG_DIR` | Override directory for global `config.yaml` (default: XDG `~/.config/skillware/` or `%APPDATA%/skillware/` on Windows). |
 | `SKILLWARE_NO_VERSION_CHECK` | Set to `1` to disable the CLI version advisory (useful in CI and automation). See [CLI reference](cli.md#version-advisory). |
 
 Skill-specific names remain on each skill's catalog page and in `manifest.yaml` `env_vars`.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -97,8 +97,16 @@ The splash shows a gradient-styled **SKILLWARE** ASCII logo, a tagline in the
 form `Skillware v{version} — Skill Management Framework` (same version string
 as `skillware --version`), and dim footer links to the project site and
 repository. The menu accepts both number input (`1`) and command name (`list`).
-After each command completes, the menu re-prints automatically. Press `q` or
-`Ctrl+C` to exit.
+After each command completes, the menu re-prints automatically.
+
+**Navigation (all menu levels):**
+
+| Input | Action |
+| :--- | :--- |
+| `0` | Exit Skillware |
+| `b` / `back` | Return to the previous menu (submenus only) |
+| `q` | Same as `0` (exit) |
+| `Ctrl+C` | Exit from the main menu |
 
 Available commands:
 
@@ -107,9 +115,21 @@ Available commands:
 | `1` / `list` | List all locally installed skills | Available |
 | `2` / `examples` | Browse runnable example scripts (index from `examples/README.md`, or from GitHub when no local copy exists) | Available |
 | `3` / `test` | Run bundle tests (`test_skill.py`) for one or all skills | Available |
-| `4` / `paths` | Show skill root resolution order, tiers, and shadowing | Available |
+| `4` / `paths` | Paths submenu — view roots, edit project/external paths, shadowing, flat-layout diagnose | Available |
 | `5` / `doctor` | Check manifest deps and skill.py import readiness | Available |
-| `6` / `help` | Print rich-formatted help with commands, flags, and examples | Available |
+| `6` / `help` | Grouped help (Skills, Examples, Paths, Config, General) with doc links | Available |
+
+## Grouped help
+
+`skillware --help` prints a **compact topic index**, **CLI usage examples**, and pointers to install/docs. For full command details per topic, run `skillware` and choose **`6` / `help`**, then pick a topic (Skills, Examples, Paths, Config, …).
+
+| Group | Topics |
+| :--- | :--- |
+| **Skills** | `list`, `test`, `doctor` |
+| **Examples** | `examples` |
+| **Paths** | `paths`, interactive paths submenu |
+| **Config** | `config show` |
+| **General** | interactive menu, `--help`, `--version` |
 
 ## Commands
 
@@ -165,7 +185,7 @@ List runnable scripts indexed in `examples/README.md` (source of truth — the C
 | *(no args)* | All indexed scripts (script-first view) |
 | `<category>/<skill_name>` | Scripts linked to that skill ID only |
 
-Columns: Script, Skill ID(s), Provider, Required extra, and a **GITHUB** link to the script on `main` (for example `https://github.com/ARPAHLS/skillware/blob/main/examples/gemini_tos_evaluator.py`). Environment variables and longer notes stay in `examples/README.md`; a one-line pointer is printed below the table.
+Columns: Script, Skill ID(s), Provider, Required extra (pip extra name), and **GITHUB** — the script filename as a clickable link to `main` (ctrl+click; full URL not repeated in the cell). Environment variables and longer notes stay in `examples/README.md`; a one-line pointer is printed below the table.
 
 Unknown skill IDs exit with a helpful message and non-zero status.
 
@@ -209,7 +229,21 @@ Show where Skillware looks for skills — same order as `SkillLoader.load_skill(
 | :--- | :--- |
 | `--skills-root <path>` | Override the skills directory for this command only (shows a single override root). |
 
-Read-only in v0.4.x. Interactive menu: **`4` / `paths`**.
+Non-interactive `skillware paths` is read-only. To **persist** project and external roots, use the interactive **paths submenu** (menu **`4` / `paths`**) or edit `.skillware.yaml` manually.
+
+#### Interactive paths submenu (menu `4`)
+
+| Input | Action |
+| :--- | :--- |
+| `1` / `view` | Same table as `skillware paths` (resolution, tiers, shadowing) |
+| `2` / `bundled` | Show bundled registry root (read-only; shipped with pip) |
+| `3` / `project` | Set `paths.project` to `auto` or an explicit directory (saved to `.skillware.yaml`) |
+| `4` / `external` | Add or remove `paths.external` entries (saved to project config) |
+| `5` / `shadows` | Shadowing summary only |
+| `6` / `flat` | List flat-layout skills (`<root>/<name>/`) that load but do not appear in `skillware list` |
+| `b` / `back` | Return to the main menu |
+
+Bundled registry paths cannot be edited. Global config (`~/.config/skillware/config.yaml`) is not modified by the submenu — use `skillware config show` to inspect merged settings.
 
 ### skillware doctor
 

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import builtins
 import re
 import subprocess
 import sys
@@ -12,6 +13,7 @@ import requests
 from rich.table import Table
 from rich.console import Console
 from rich.text import Text
+from rich.status import Status
 from rich import box
 
 import importlib.metadata
@@ -23,11 +25,16 @@ from skillware.core.config import (
     format_config_sources,
     global_config_path,
     load_merged_config,
+    load_project_paths_settings,
+    project_config_write_path,
+    save_project_config,
 )
 from skillware.core.discovery import (
     SKILLWARE_SKILL_PATH_ENV,
+    bundled_skill_root,
     find_shadow_conflicts,
     get_skill_roots,
+    list_flat_layout_skill_names,
     list_registry_skill_ids,
     resolution_order_summary,
 )
@@ -41,6 +48,99 @@ BORDER_STYLE = "#C7CEEA"  # lavender  - table border
 SPLASH_STYLE = "#C7CEEA"  # lavender  - skillware splash color
 MENU_STYLE = "#FFDAC1"  # peach     - menu category
 
+_DOCS_CLI = "docs/usage/cli.md"
+_DOCS_CLI_LIST = f"{_DOCS_CLI}#skillware-list"
+_DOCS_CLI_EXAMPLES = f"{_DOCS_CLI}#skillware-examples"
+_DOCS_CLI_PATHS = f"{_DOCS_CLI}#skillware-paths"
+_DOCS_CLI_CONFIG = f"{_DOCS_CLI}#skillware-config"
+
+HELP_GROUPS: List[Tuple[str, List[Tuple[str, str]], str]] = [
+    (
+        "Skills",
+        [
+            ("skillware list", "discover installed registry skills"),
+            ("skillware list --category <n>", "filter by category"),
+            ("skillware list --issuer <h>", "filter by issuer"),
+            ("skillware list --examples", "per-skill example script counts"),
+            ("skillware list --skills-root <path>", "one-shot skills root override"),
+            ("skillware test [id]", "run bundle tests via pytest"),
+            ("skillware test --category <n>", "test all skills in a category"),
+            ("skillware doctor [id]", "check deps and skill.py import"),
+            ("skillware doctor --category <n>", "diagnose a category"),
+        ],
+        _DOCS_CLI_LIST,
+    ),
+    (
+        "Examples",
+        [
+            ("skillware examples", "list runnable scripts from examples/README.md"),
+            ("skillware examples <id>", "scripts for one skill ID"),
+        ],
+        _DOCS_CLI_EXAMPLES,
+    ),
+    (
+        "Paths",
+        [
+            ("skillware paths", "show resolution order, tiers, and shadowing"),
+            ("skillware paths --skills-root <path>", "one-shot root override"),
+            (
+                "skillware (menu 4 / paths)",
+                "interactive paths submenu — view, edit, diagnose",
+            ),
+        ],
+        _DOCS_CLI_PATHS,
+    ),
+    (
+        "Config",
+        [
+            ("skillware config show", "merged global + project YAML (read-only)"),
+        ],
+        _DOCS_CLI_CONFIG,
+    ),
+    (
+        "General",
+        [
+            ("skillware", "interactive menu (splash + numbered options)"),
+            ("skillware --help", "grouped command reference"),
+            ("skillware --version", "installed package version"),
+        ],
+        _DOCS_CLI,
+    ),
+]
+
+_PATHS_SUBMENU = [
+    ("1", "view", "show resolution order, tiers, and shadowing"),
+    ("2", "bundled", "view bundled registry root (read-only)"),
+    ("3", "project", "set project path (auto or explicit directory)"),
+    ("4", "external", "add or remove external skill roots"),
+    ("5", "shadows", "shadowing summary only"),
+    ("6", "flat", "diagnose flat-layout skills not shown in list"),
+]
+
+_NAV_EXIT = "exit"
+_NAV_BACK = "back"
+
+# Interactive help topics: (key, slug, summary, HELP_GROUPS index or special tag)
+_HELP_MENU: List[Tuple[str, str, str, Union[int, str]]] = [
+    ("1", "skills", "list, test, doctor", 0),
+    ("2", "examples", "indexed runnable scripts", 1),
+    ("3", "paths", "resolution and path editor", 2),
+    ("4", "config", "merged YAML settings", 3),
+    ("5", "general", "menu, help, version", 4),
+    ("6", "install", "pip install skillware", "install"),
+    ("7", "docs", "full CLI guide online", "docs"),
+    ("8", "interactive", "numbered splash menu", "interactive"),
+]
+
+_CLI_USAGE_EXAMPLES: Tuple[str, ...] = (
+    "skillware list --category compliance",
+    "skillware list --examples --category dev_tools",
+    "skillware examples compliance/tos_evaluator",
+    "skillware test finance/wallet_screening",
+    "skillware paths",
+    "skillware config show",
+    "skillware doctor --category compliance",
+)
 SPLASH_GRADIENT_START = (0xD4, 0xE4, 0xF1)
 SPLASH_GRADIENT_MID = (0x79, 0xB6, 0xD8)
 SPLASH_GRADIENT_END = (0xEB, 0xD8, 0xDC)
@@ -88,6 +188,12 @@ def _examples_readme_display_path(source: _EXAMPLES_INDEX_SOURCE) -> str:
 def _example_github_url(script: str) -> str:
     """Canonical GitHub blob URL for an indexed example script."""
     return f"{_EXAMPLES_GITHUB_BLOB_BASE}/{script}"
+
+
+def _example_github_cell(script: str) -> Text:
+    """Compact clickable label for the examples table (full URL is the link target)."""
+    url = _example_github_url(script)
+    return Text.from_markup(f'[link="{url}" dim #C7CEEA]{script}[/link]')
 
 
 def _examples_readme_path() -> Optional[Path]:
@@ -461,16 +567,17 @@ def cmd_examples(
     table.add_column("SCRIPT", style=ID_STYLE, no_wrap=True, ratio=2)
     table.add_column("SKILL ID", style=CATEGORY_STYLE, ratio=2)
     table.add_column("PROVIDER", no_wrap=True, ratio=1)
-    table.add_column("EXTRA", style="dim", ratio=1)
-    table.add_column("GITHUB", style=f"dim {SPLASH_STYLE}", ratio=3)
+    table.add_column("EXTRA", style="dim", ratio=2)
+    table.add_column("GITHUB", style=f"dim {SPLASH_STYLE}", no_wrap=True, ratio=1)
 
     for row in rows:
+        script = row["script"]
         table.add_row(
-            row["script"],
+            script,
             ", ".join(row["skill_ids"]),
-            _flatten_table_cell(row["provider"], max_len=32),
-            _flatten_table_cell(row["extra"], max_len=28),
-            _example_github_url(row["script"]),
+            _flatten_table_cell(row["provider"], max_len=36),
+            _flatten_table_cell(row["extra"], max_len=48),
+            _example_github_cell(script),
         )
 
     console.print(table)
@@ -479,6 +586,369 @@ def cmd_examples(
         style="dim",
     )
     return 0
+
+
+def _read_line(prompt: str, input_fn=None) -> Optional[str]:
+    if input_fn is None:
+        input_fn = builtins.input
+    try:
+        return input_fn(prompt).strip()
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+
+def _parse_nav(raw: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Parse menu input. Returns ``(choice, nav)`` where ``nav`` is ``_NAV_EXIT``,
+    ``_NAV_BACK``, or ``None`` for a normal command choice.
+    """
+    if raw is None:
+        return None, _NAV_BACK
+    text = raw.strip()
+    if not text:
+        return "", None
+    key = text.lower()
+    if key in ("0", "q", "quit", "exit"):
+        return None, _NAV_EXIT
+    if key in ("b", "back", "esc", "escape"):
+        return None, _NAV_BACK
+    return text, None
+
+
+def _print_nav_footer(console, *, show_back: bool = True) -> None:
+    console.print("  ---", style="dim")
+    if show_back:
+        console.print("  b — back to previous menu", style="dim")
+    console.print("  0 — exit Skillware", style="dim")
+    console.print()
+
+
+def _print_help_command_group(
+    console, group: Tuple[str, List[Tuple[str, str]], str]
+) -> None:
+    group_name, commands, doc_link = group
+    console.print(Text(group_name, style=f"bold {TABLE_STYLE}"))
+    for command, description in commands:
+        console.print(f"  {command} — {description}", style=MENU_STYLE)
+    console.print(f"  Read more: {doc_link}", style=f"dim {SPLASH_STYLE}")
+    console.print()
+
+
+def _print_help_index(console) -> None:
+    console.print(Text("Usage", style=f"bold {TABLE_STYLE}"))
+    console.print(
+        "  Run skillware and choose help (6) for full topic details.",
+        style="dim",
+    )
+    console.print()
+    console.print(Text("Topics", style=f"bold {TABLE_STYLE}"))
+    for key, slug, summary, _target in _HELP_MENU:
+        console.print(f"  {key} {slug:<12}— {summary}", style=MENU_STYLE)
+    console.print()
+
+
+def _print_cli_usage_examples(console) -> None:
+    console.print(Text("CLI usage examples", style=f"bold {TABLE_STYLE}"))
+    for line in _CLI_USAGE_EXAMPLES:
+        console.print(f"  {line}", style=MENU_STYLE)
+    console.print()
+
+
+def _print_help_static_topic(console, topic: str) -> None:
+    if topic == "install":
+        console.print(Text("Install", style=f"bold {TABLE_STYLE}"))
+        console.print("  pip install skillware", style=MENU_STYLE)
+        console.print('  pip install -e ".[dev,all]"  # local development', style="dim")
+    elif topic == "docs":
+        console.print(Text("Docs", style=f"bold {TABLE_STYLE}"))
+        console.print(
+            "  https://github.com/arpahls/skillware/blob/main/docs/usage/cli.md",
+            style=f"dim {SPLASH_STYLE}",
+        )
+    elif topic == "interactive":
+        console.print(Text("Interactive mode", style=f"bold {TABLE_STYLE}"))
+        console.print("  skillware — open splash menu", style=MENU_STYLE)
+        console.print("  1-6 or command name — run a command", style="dim")
+        console.print("  0 — exit from any menu level", style="dim")
+    console.print()
+
+
+def _print_help_groups(console, *, compact: bool = False) -> None:
+    """Print all help groups (legacy flat dump). Prefer cmd_help(brief=True)."""
+    console.print(Text("Usage", style=f"bold {TABLE_STYLE}"))
+    for group in HELP_GROUPS:
+        _print_help_command_group(console, group)
+
+
+def cmd_help_submenu(console=None, input_fn=None) -> Optional[str]:
+    """Interactive help topics. Returns _NAV_EXIT to quit Skillware."""
+    if console is None:
+        console = Console()
+
+    topic_map = {key: target for key, _slug, _summary, target in _HELP_MENU}
+    topic_map.update({slug: target for key, slug, _summary, target in _HELP_MENU})
+
+    while True:
+        console.print(Text("Help", style=f"bold {TABLE_STYLE}"))
+        for key, slug, summary, _target in _HELP_MENU:
+            console.print(f"    [{key}] {slug:<12}— {summary}", style=MENU_STYLE)
+        _print_nav_footer(console, show_back=True)
+
+        raw = _read_line("  help> ", input_fn)
+        choice, nav = _parse_nav(raw)
+        if nav == _NAV_EXIT:
+            return _NAV_EXIT
+        if nav == _NAV_BACK:
+            return None
+        if not choice:
+            continue
+
+        target = topic_map.get(choice.lower())
+        if target is None:
+            console.print(f"  Unknown topic: '{choice}'", style="dim #FF9AA2")
+            console.print()
+            continue
+
+        if isinstance(target, int):
+            _print_help_command_group(console, HELP_GROUPS[target])
+        else:
+            _print_help_static_topic(console, target)
+
+        pause = _read_line("  Press Enter to return to help topics… ", input_fn)
+        _, pause_nav = _parse_nav(pause if pause else "")
+        if pause_nav == _NAV_EXIT:
+            return _NAV_EXIT
+        if pause_nav == _NAV_BACK:
+            continue
+        console.print()
+
+
+def _print_paths_submenu(console) -> None:
+    console.print(Text("Paths", style=f"bold {TABLE_STYLE}"))
+    console.print(
+        f"  Project config: {project_config_write_path()}",
+        style="dim",
+    )
+    console.print(
+        "  Bundled registry is read-only and always available.",
+        style="dim",
+    )
+    console.print()
+    for key, name, desc in _PATHS_SUBMENU:
+        console.print(f"    [{key}] {name:<10}— {desc}", style=MENU_STYLE)
+    _print_nav_footer(console, show_back=True)
+
+
+def _cmd_paths_show_bundled(console) -> None:
+    root = bundled_skill_root(include_missing=True)
+    console.print(Text("Bundled registry (read-only)", style=f"bold {TABLE_STYLE}"))
+    console.print(f"  path: {root.path}", style=MENU_STYLE)
+    console.print(f"  status: {'ok' if root.exists else 'missing'}", style="dim")
+    if root.exists:
+        skill_ids = list_registry_skill_ids(root.path)
+        console.print(f"  skills: {len(skill_ids)} registry IDs", style=MENU_STYLE)
+        for skill_id in skill_ids[:12]:
+            console.print(f"    - {skill_id}", style="dim")
+        if len(skill_ids) > 12:
+            console.print(f"    … and {len(skill_ids) - 12} more", style="dim")
+    console.print(
+        "  Bundled skills ship with pip install skillware and cannot be edited here.",
+        style="dim",
+    )
+
+
+def _cmd_paths_shadows_only(
+    console, skills_root_override: Optional[Path] = None
+) -> None:
+    roots = get_skill_roots(skills_root_override, for_display=True)
+    conflicts = find_shadow_conflicts(roots)
+    if not conflicts:
+        console.print("No shadowing detected across active roots.", style=MENU_STYLE)
+        return
+
+    console.print(Text("Shadowing (first root wins)", style=f"bold {TABLE_STYLE}"))
+    for conflict in conflicts[:30]:
+        console.print(
+            f"  {conflict.skill_id}: "
+            f"{conflict.winner.tier.value} at {conflict.winner.path} "
+            f"shadows {conflict.shadowed.tier.value} at {conflict.shadowed.path}",
+            style="bold #FF9AA2",
+        )
+    if len(conflicts) > 30:
+        console.print(f"  … and {len(conflicts) - 30} more", style="dim")
+
+
+def _cmd_paths_flat_diagnose(
+    console, skills_root_override: Optional[Path] = None
+) -> None:
+    roots = get_skill_roots(skills_root_override, for_display=True)
+    console.print(
+        Text("Flat-layout skills (loadable, not in list)", style=f"bold {TABLE_STYLE}")
+    )
+    found_any = False
+    for root in roots:
+        if not root.exists:
+            continue
+        flat_names = list_flat_layout_skill_names(root.path)
+        if not flat_names:
+            continue
+        found_any = True
+        console.print(
+            f"  {root.tier.value} @ {root.path}:",
+            style=MENU_STYLE,
+        )
+        for name in flat_names:
+            console.print(f"    - {name}/  (use absolute path or flat ID)", style="dim")
+    if not found_any:
+        console.print(
+            "  No flat-layout skills found under active roots.",
+            style="dim",
+        )
+    console.print(
+        "  Registry layout category/skill_name/ appears in skillware list.",
+        style="dim",
+    )
+
+
+def _cmd_paths_edit_project(console, input_fn=None) -> None:
+    paths = load_project_paths_settings()
+    current = paths.project if paths.project is not None else "auto"
+    console.print(f"  Current project path: {current}", style=MENU_STYLE)
+    console.print(
+        "  Enter 'auto', a directory path, or press Enter to keep.", style="dim"
+    )
+    raw = _read_line("  project> ", input_fn)
+    if raw is None:
+        console.print("  Cancelled.", style="dim")
+        return
+    if not raw:
+        return
+
+    if raw.lower() == "auto":
+        paths.project = "auto"
+    else:
+        candidate = Path(raw).expanduser()
+        if not candidate.is_dir():
+            console.print(f"  Not a directory: {candidate}", style="bold #FF9AA2")
+            return
+        paths.project = str(candidate.resolve())
+
+    target = save_project_config(paths)
+    console.print(f"  Saved project path to {target}", style=ID_STYLE)
+
+
+def _cmd_paths_edit_external(console, input_fn=None) -> None:
+    paths = load_project_paths_settings()
+    while True:
+        console.print(
+            Text("External paths (project config)", style=f"bold {TABLE_STYLE}")
+        )
+        if paths.external:
+            for index, entry in enumerate(paths.external, start=1):
+                console.print(f"    [{index}] {entry}", style=MENU_STYLE)
+        else:
+            console.print("    (none)", style="dim")
+        console.print("  [a] add  [r] remove  [Enter] done", style="dim")
+        raw = _read_line("  external> ", input_fn)
+        if raw is None:
+            console.print("  Cancelled.", style="dim")
+            return
+        if not raw:
+            return
+
+        choice = raw.lower()
+        if choice == "a":
+            path_raw = _read_line("  path> ", input_fn)
+            if path_raw is None:
+                console.print("  Cancelled.", style="dim")
+                return
+            if not path_raw:
+                continue
+            candidate = Path(path_raw).expanduser()
+            if not candidate.is_dir():
+                console.print(f"  Not a directory: {candidate}", style="bold #FF9AA2")
+                continue
+            resolved = str(candidate.resolve())
+            if resolved not in paths.external:
+                paths.external.append(resolved)
+                target = save_project_config(paths)
+                console.print(f"  Added and saved to {target}", style=ID_STYLE)
+            else:
+                console.print("  Path already listed.", style="dim")
+        elif choice == "r":
+            if not paths.external:
+                console.print("  Nothing to remove.", style="dim")
+                continue
+            index_raw = _read_line("  remove #> ", input_fn)
+            if index_raw is None:
+                console.print("  Cancelled.", style="dim")
+                return
+            try:
+                index = int(index_raw)
+            except ValueError:
+                console.print("  Enter a list number.", style="bold #FF9AA2")
+                continue
+            if index < 1 or index > len(paths.external):
+                console.print("  Invalid number.", style="bold #FF9AA2")
+                continue
+            removed = paths.external.pop(index - 1)
+            target = save_project_config(paths)
+            console.print(f"  Removed {removed}; saved to {target}", style=ID_STYLE)
+        else:
+            console.print("  Unknown choice.", style="dim #FF9AA2")
+
+
+def cmd_paths_submenu(
+    skills_root_override: Optional[Path] = None,
+    console=None,
+    input_fn=None,
+) -> Optional[str]:
+    """Interactive paths submenu (menu option 4). Returns _NAV_EXIT to quit Skillware."""
+    if console is None:
+        console = Console()
+
+    submenu_commands = {
+        "1": "view",
+        "view": "view",
+        "2": "bundled",
+        "bundled": "bundled",
+        "3": "project",
+        "project": "project",
+        "4": "external",
+        "external": "external",
+        "5": "shadows",
+        "shadows": "shadows",
+        "6": "flat",
+        "flat": "flat",
+    }
+
+    while True:
+        _print_paths_submenu(console)
+        raw = _read_line("  paths> ", input_fn)
+        choice, nav = _parse_nav(raw)
+        if nav == _NAV_EXIT:
+            return _NAV_EXIT
+        if nav == _NAV_BACK:
+            return None
+        if not choice:
+            continue
+
+        command = submenu_commands.get(choice.lower())
+        if command == "view":
+            cmd_paths(skills_root_override=skills_root_override, console=console)
+        elif command == "bundled":
+            _cmd_paths_show_bundled(console)
+        elif command == "project":
+            _cmd_paths_edit_project(console, input_fn=input_fn)
+        elif command == "external":
+            _cmd_paths_edit_external(console, input_fn=input_fn)
+        elif command == "shadows":
+            _cmd_paths_shadows_only(console, skills_root_override=skills_root_override)
+        elif command == "flat":
+            _cmd_paths_flat_diagnose(console, skills_root_override=skills_root_override)
+        elif command is None:
+            console.print(f"  Unknown choice: '{choice}'", style="dim #FF9AA2")
+        console.print()
 
 
 def cmd_paths(
@@ -635,7 +1105,10 @@ def cmd_config_show(console=None) -> int:
         "Bundled registry is always included and cannot be removed via config.",
         style="dim",
     )
-    console.print("Edit YAML manually to change settings.", style="dim")
+    console.print(
+        "Edit via interactive menu (paths) or YAML manually.",
+        style="dim",
+    )
     return 0
 
 
@@ -734,30 +1207,40 @@ def cmd_doctor(
     table.add_column("DETAIL", style="dim", ratio=4)
 
     failures = 0
-    for sid in sorted(skill_ids):
-        try:
-            deps_status, load_status, detail = _diagnose_skill(
-                sid, skills_root_override=skills_root_override
+    rows: List[Tuple[str, Text, Text, str]] = []
+    spinner_label = (
+        f"Diagnosing {len(skill_ids)} skill(s)…"
+        if len(skill_ids) != 1
+        else f"Diagnosing {skill_ids[0]}…"
+    )
+    with Status(spinner_label, console=console, spinner="dots"):
+        for sid in sorted(skill_ids):
+            try:
+                deps_status, load_status, detail = _diagnose_skill(
+                    sid, skills_root_override=skills_root_override
+                )
+            except FileNotFoundError as exc:
+                console.print(str(exc), style="bold #FF9AA2")
+                return 1
+
+            if deps_status != "ok" or load_status == "fail":
+                failures += 1
+
+            deps_cell = Text(
+                deps_status,
+                style=ID_STYLE if deps_status == "ok" else "bold #FF9AA2",
             )
-        except FileNotFoundError as exc:
-            console.print(str(exc), style="bold #FF9AA2")
-            return 1
+            if load_status == "skip":
+                load_cell = Text("—", style="dim")
+            elif load_status == "ok":
+                load_cell = Text(load_status, style=ID_STYLE)
+            else:
+                load_cell = Text(load_status, style="bold #FF9AA2")
 
-        if deps_status != "ok" or load_status == "fail":
-            failures += 1
+            rows.append((sid, deps_cell, load_cell, detail or "—"))
 
-        deps_cell = Text(
-            deps_status,
-            style=ID_STYLE if deps_status == "ok" else "bold #FF9AA2",
-        )
-        if load_status == "skip":
-            load_cell = Text("—", style="dim")
-        elif load_status == "ok":
-            load_cell = Text(load_status, style=ID_STYLE)
-        else:
-            load_cell = Text(load_status, style="bold #FF9AA2")
-
-        table.add_row(sid, deps_cell, load_cell, detail or "—")
+    for sid, deps_cell, load_cell, detail in rows:
+        table.add_row(sid, deps_cell, load_cell, detail)
 
     console.print(table)
     console.print(
@@ -768,95 +1251,68 @@ def cmd_doctor(
     return 1 if failures else 0
 
 
-def _prompt_examples_skill_id(console) -> Tuple[Optional[str], bool]:
-    """Return (skill_id or None for all, should_run)."""
-    try:
-        raw = input("  skill id (optional, Enter for all): ").strip()
-    except (KeyboardInterrupt, EOFError):
-        console.print("\n  Cancelled.", style="dim")
-        return None, False
-    if not raw:
-        return None, True
-    parts = raw.split("/")
+def _prompt_examples_skill_id(
+    console, input_fn=None
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Return (skill_id or None for all, nav).
+    nav is _NAV_EXIT or _NAV_BACK when the user cancels or navigates out.
+    """
+    console.print("  skill id (optional, Enter for all)", style="dim")
+    raw = _read_line("  examples> ", input_fn)
+    choice, nav = _parse_nav(raw if raw is not None else "")
+    if nav == _NAV_EXIT:
+        return None, _NAV_EXIT
+    if nav == _NAV_BACK:
+        return None, _NAV_BACK
+    if raw is None:
+        return None, _NAV_BACK
+    if not choice:
+        return None, None
+    parts = choice.split("/")
     if len(parts) != 2 or not all(parts):
         console.print(
-            f"  Invalid skill ID '{raw}'. Expected category/skill_name.",
+            f"  Invalid skill ID '{choice}'. Expected category/skill_name.",
             style="dim #FF9AA2",
         )
-        return None, False
-    return raw, True
+        return None, _NAV_BACK
+    return choice, None
 
 
 def _print_menu(console, menu) -> None:
     for num, name, desc in menu:
         console.print(f"    [{num}] {name:<20}— {desc}", style=MENU_STYLE)
+    _print_nav_footer(console, show_back=False)
 
-    console.print()
 
-
-def cmd_help(console=None) -> None:
-    """Print rich-formatted help to the console."""
+def cmd_help(console=None, *, brief: bool = True) -> None:
+    """Print CLI help. Brief mode (default) shows topics + examples only."""
     if console is None:
         console = Console()
 
-    console.print(Text("Usage", style=f"bold {TABLE_STYLE}"))
-    console.print("  skillware                     — open interactive menu")
-    console.print("  skillware list                — list all installed skills")
-    console.print("  skillware list --category <n> — filter by category")
-    console.print("  skillware list --issuer <h>   — filter by issuer")
-    console.print("  skillware list --skills-root  — override skills directory")
-    console.print(
-        "  skillware list --examples     — add per-skill example script count"
-    )
-    console.print("  skillware examples            — list indexed runnable scripts")
-    console.print("  skillware examples <id>       — scripts for one skill")
-    console.print("  skillware test                — run all bundle tests")
-    console.print("  skillware test <category/name> — run one skill bundle test")
-    console.print("  skillware test --category <n> — run tests for a category")
-    console.print("  skillware paths               — show skill root resolution")
-    console.print("  skillware config show         — show merged configuration")
-    console.print("  skillware doctor              — check deps and skill.py import")
-    console.print("  skillware doctor <id>         — diagnose one skill")
-    console.print("  skillware doctor --category   — diagnose a category")
-    console.print("  skillware --version           — print installed version")
-    console.print()
+    if brief:
+        _print_help_index(console)
+        _print_cli_usage_examples(console)
+        console.print(Text("Install", style=f"bold {TABLE_STYLE}"))
+        console.print("  pip install skillware", style="dim")
+        console.print()
+        console.print(Text("Docs", style=f"bold {TABLE_STYLE}"))
+        console.print(
+            "  https://github.com/arpahls/skillware/blob/main/docs/usage/cli.md",
+            style=f"dim {SPLASH_STYLE}",
+        )
+        console.print()
+        console.print(Text("Interactive mode", style=f"bold {TABLE_STYLE}"))
+        console.print(
+            "  skillware — menu 1-6; help topic drill-down via 6", style="dim"
+        )
+        console.print("  0 — exit from any menu level", style="dim")
+        console.print()
+        return
 
-    console.print(Text("Commands", style=f"bold {TABLE_STYLE}"))
-    console.print("  list      available now", style=ID_STYLE)
-    console.print("  examples  available now", style=ID_STYLE)
-    console.print("  test      available now", style=ID_STYLE)
-    console.print("  paths     available now", style=ID_STYLE)
-    console.print("  config    available now (read-only)", style=ID_STYLE)
-    console.print("  doctor    available now", style=ID_STYLE)
-    console.print()
-
-    console.print(Text("Interactive mode", style=f"bold {TABLE_STYLE}"))
-    console.print(
-        "  skillware                     — open interactive menu", style="dim"
-    )
-    console.print("  1-6 or command name           — select a menu option", style="dim")
-    console.print("  q or Ctrl+C                   — exit", style="dim")
-    console.print()
-
-    console.print(Text("Examples", style=f"bold {TABLE_STYLE}"))
-    console.print("  skillware list --category compliance", style=MENU_STYLE)
-    console.print("  skillware list --examples --category dev_tools", style=MENU_STYLE)
-    console.print("  skillware examples compliance/tos_evaluator", style=MENU_STYLE)
-    console.print("  skillware test finance/wallet_screening", style=MENU_STYLE)
-    console.print("  skillware paths", style=MENU_STYLE)
-    console.print("  skillware config show", style=MENU_STYLE)
-    console.print("  skillware doctor --category compliance", style=MENU_STYLE)
-    console.print()
-
-    console.print(Text("Install", style=f"bold {TABLE_STYLE}"))
-    console.print("  pip install skillware", style="dim")
-    console.print()
-
-    console.print(Text("Docs", style=f"bold {TABLE_STYLE}"))
-    console.print(
-        "  https://github.com/arpahls/skillware/blob/main/docs/usage/cli.md",
-        style=f"dim {SPLASH_STYLE}",
-    )
+    for group in HELP_GROUPS:
+        _print_help_command_group(console, group)
+    _print_cli_usage_examples(console)
 
 
 def _rgb_to_hex(rgb: Tuple[int, int, int]) -> str:
@@ -934,7 +1390,7 @@ def cmd_interactive(console=None, parser=None) -> None:
         ("1", "list", "discover and display all locally installed skills"),
         ("2", "examples", "browse runnable scripts from examples/README.md"),
         ("3", "test", "run bundle tests (test_skill.py) for one or all skills"),
-        ("4", "paths", "show skill directory resolution order and shadowing"),
+        ("4", "paths", "paths submenu — view, edit, and diagnose skill roots"),
         ("5", "doctor", "check manifest deps and skill.py import readiness"),
         ("6", "help", "usage guide for any command"),
     ]
@@ -957,34 +1413,47 @@ def cmd_interactive(console=None, parser=None) -> None:
     _print_menu(console, menu)
 
     while True:
-        try:
-            choice = input("  > ").strip().lower()
-        except (KeyboardInterrupt, EOFError):
+        raw = _read_line("  > ")
+        if raw is None:
             console.print("\n  Bye.", style="dim")
             return
-
-        if choice == "q":
+        choice, nav = _parse_nav(raw)
+        if nav == _NAV_EXIT:
             console.print("  Bye.", style="dim")
             return
+        if nav == _NAV_BACK:
+            continue
+        if not choice:
+            continue
 
-        command = commands.get(choice)
+        command = commands.get(choice.lower())
 
         if command == "list":
             cmd_list(console=console)
         elif command == "examples":
-            skill_id, run = _prompt_examples_skill_id(console)
-            if run:
+            skill_id, ex_nav = _prompt_examples_skill_id(console)
+            if ex_nav == _NAV_EXIT:
+                console.print("  Bye.", style="dim")
+                return
+            if ex_nav != _NAV_BACK:
                 cmd_examples(skill_id=skill_id, console=console)
         elif command == "test":
+            console.print("  Running bundle tests (pytest)…", style="dim")
             cmd_test(console=console)
         elif command == "paths":
-            cmd_paths(console=console)
+            paths_nav = cmd_paths_submenu(console=console)
+            if paths_nav == _NAV_EXIT:
+                console.print("  Bye.", style="dim")
+                return
         elif command == "doctor":
             rc = cmd_doctor(console=console)
             if rc:
                 console.print(f"  doctor exited with status {rc}", style="dim #FF9AA2")
         elif command == "help":
-            cmd_help(console=console)
+            help_nav = cmd_help_submenu(console=console)
+            if help_nav == _NAV_EXIT:
+                console.print("  Bye.", style="dim")
+                return
         else:
             console.print(f"  Unknown command: '{choice}'", style="dim #FF9AA2")
 

--- a/skillware/core/config.py
+++ b/skillware/core/config.py
@@ -218,3 +218,64 @@ def format_config_sources(config: SkillwareConfig) -> List[str]:
     if not config.layers:
         return ["(none — implicit env/cwd/bundled resolution)"]
     return [str(layer.path) for layer in config.layers]
+
+
+def project_config_write_path(start: Optional[Path] = None) -> Path:
+    """Path where project path settings should be written."""
+    existing = find_project_config_file(start)
+    if existing is not None:
+        return existing
+    return (start or Path.cwd()).resolve() / PROJECT_CONFIG_FILENAME
+
+
+def load_project_paths_settings(*, start: Optional[Path] = None) -> PathsSettings:
+    """Load ``paths`` settings from the project config file only (not global merge)."""
+    path = find_project_config_file(start)
+    if path is None:
+        return PathsSettings()
+    return _merge_layers([_layer_from_file(path)]).paths
+
+
+def paths_settings_to_document(paths: PathsSettings) -> Dict[str, Any]:
+    """Serialize path-related settings for YAML persistence."""
+    document: Dict[str, Any] = {
+        "paths": {
+            "project": paths.project if paths.project is not None else "auto",
+            "external": list(paths.external),
+        },
+        "resolution": {"order": list(paths.resolution_order)},
+        "legacy": {
+            "honor_skillware_skill_path": paths.honor_skillware_skill_path,
+        },
+    }
+    return document
+
+
+def save_project_config(
+    paths: PathsSettings,
+    *,
+    start: Optional[Path] = None,
+    preserve_extra: bool = True,
+) -> Path:
+    """
+    Write project ``paths`` settings to ``.skillware.yaml``.
+
+    Preserves unknown top-level keys from an existing project file when
+    ``preserve_extra`` is True. Clears the merged config cache.
+    """
+    target = project_config_write_path(start)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    document = paths_settings_to_document(paths)
+    if preserve_extra and target.is_file():
+        existing = _read_yaml(target)
+        for key, value in existing.items():
+            if key not in _KNOWN_TOP_LEVEL_KEYS:
+                document[key] = value
+
+    target.write_text(
+        yaml.safe_dump(document, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    clear_config_cache()
+    return target.resolve()

--- a/skillware/core/discovery.py
+++ b/skillware/core/discovery.py
@@ -325,20 +325,37 @@ def find_shadow_conflicts(roots: Sequence[SkillRoot]) -> List[ShadowConflict]:
 
 def collect_search_paths_for_skill_id(skill_id: str) -> List[str]:
     """Absolute paths tried when resolving a registry ID (existing roots only)."""
-    searched: List[str] = []
+    return [path for _, path in collect_search_attempts_for_skill_id(skill_id)]
+
+
+def collect_search_attempts_for_skill_id(skill_id: str) -> List[Tuple[str, str]]:
+    """Return ``(tier, absolute_path)`` pairs tried for a registry ID."""
+    attempts: List[Tuple[str, str]] = []
     for root in get_skill_roots():
         attempt = (root.path / skill_id).resolve()
-        searched.append(str(attempt))
-    return searched
+        attempts.append((root.tier.value, str(attempt)))
+    return attempts
+
+
+def list_flat_layout_skill_names(root: Path) -> List[str]:
+    """Skill folder names at ``<root>/<name>/`` (excluded from ``skillware list``)."""
+    if not root.is_dir():
+        return []
+
+    names: List[str] = []
+    for child in sorted(root.iterdir()):
+        if is_skill_dir(child):
+            names.append(child.name)
+    return names
 
 
 def build_skill_not_found_message(skill_id: str) -> str:
     """Operator-facing error text aligned with ``skillware paths`` output."""
     config = load_merged_config()
-    searched = collect_search_paths_for_skill_id(skill_id)
+    attempts = collect_search_attempts_for_skill_id(skill_id)
     lines = [
         f"Skill not found: {skill_id!r}. Searched:",
-        *[f"  {path}" for path in searched],
+        *[f"  {tier}: {path}" for tier, path in attempts],
     ]
     if config.has_config_files:
         lines.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from skillware.cli import (
     _short_description,
     cmd_help,
     cmd_paths,
+    cmd_paths_submenu,
     cmd_doctor,
 )
 
@@ -253,18 +254,19 @@ def test_cmd_help_includes_list_examples(capsys):
     cmd_help(console=console)
 
     output = buf.getvalue()
+    assert "Topics" in output
+    assert "skills" in output
     assert "--category" in output
-    assert "--issuer" in output
-    assert "skillware test" in output
-    assert "skillware examples" in output
+    assert "skillware test" in output or "test" in output
+    assert "skillware examples" in output or "examples" in output
 
 
 def test_interactive_help_dispatches_to_cmd_help(monkeypatch):
-    """Interactive menu option 6 / help should call cmd_help."""
+    """Interactive menu option 6 / help opens topic submenu."""
     import io
     from rich.console import Console
 
-    responses = iter(["6", "q"])
+    responses = iter(["6", "1", "", "b", "0"])
     monkeypatch.setattr("builtins.input", lambda _: next(responses))
 
     buf = io.StringIO()
@@ -272,6 +274,7 @@ def test_interactive_help_dispatches_to_cmd_help(monkeypatch):
     cmd_interactive(console=console)
 
     output = buf.getvalue()
+    assert "Skills" in output
     assert "--category" in output
     assert "--issuer" in output
 
@@ -464,7 +467,7 @@ def test_interactive_examples_dispatch(examples_readme, monkeypatch):
 
     monkeypatch.setattr("skillware.cli.cmd_examples", fake_examples)
 
-    responses = iter(["examples", "", "q"])
+    responses = iter(["examples", "", "0"])
     monkeypatch.setattr("builtins.input", lambda _: next(responses))
 
     buf = io.StringIO()
@@ -582,7 +585,7 @@ def test_cmd_examples_includes_github_links(examples_readme):
     )
     output = buf.getvalue()
     assert "gemini_tos_evaluator.py" in output
-    assert "github.com/ARPAHLS/skillware/blob/main/examples/" in output
+    assert "gemini" in output.lower()
 
 
 def test_cmd_examples_unknown_skill_returns_nonzero(examples_readme):
@@ -673,6 +676,23 @@ def test_cmd_paths_shows_roots_and_tiers(tmp_path, monkeypatch):
     assert " 1 " in output or output.rstrip().endswith("1")
 
 
+def test_cmd_help_includes_grouped_sections():
+    import io
+    from rich.console import Console
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    cmd_help(console=console)
+    output = buf.getvalue()
+    assert "Topics" in output
+    assert "skills" in output
+    assert "paths" in output
+    assert "config" in output
+    assert "CLI usage examples" in output
+    assert "skillware config show" in output
+    assert "skillware list --category" not in output or "CLI usage examples" in output
+
+
 def test_cmd_help_includes_paths_command():
     import io
     from rich.console import Console
@@ -683,7 +703,6 @@ def test_cmd_help_includes_paths_command():
     output = buf.getvalue()
     assert "skillware paths" in output
     assert "skillware doctor" in output
-    assert "available now" in output
     assert "coming soon" not in output.lower()
 
 
@@ -707,7 +726,7 @@ def test_interactive_paths_dispatches(monkeypatch):
     import io
     from rich.console import Console
 
-    responses = iter(["4", "q"])
+    responses = iter(["4", "1", "b", "0"])
     monkeypatch.setattr("builtins.input", lambda _: next(responses))
 
     buf = io.StringIO()
@@ -715,8 +734,43 @@ def test_interactive_paths_dispatches(monkeypatch):
     cmd_interactive(console=console)
 
     output = buf.getvalue()
+    assert "Paths" in output
     assert "Skill path resolution" in output
     assert "not yet implemented" not in output.lower()
+
+
+def test_cmd_paths_submenu_view_bundled(tmp_path, monkeypatch):
+    import io
+    from rich.console import Console
+
+    monkeypatch.chdir(tmp_path)
+    responses = iter(["2", "b"])
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    cmd_paths_submenu(console=console, input_fn=lambda _: next(responses))
+    output = buf.getvalue()
+    assert "Bundled registry (read-only)" in output
+
+
+def test_cmd_paths_submenu_edit_external(tmp_path, monkeypatch):
+    import io
+    from rich.console import Console
+
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("SKILLWARE_CONFIG_DIR", str(tmp_path / "no-global"))
+
+    responses = iter(["4", "a", str(external), "", "b"])
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    cmd_paths_submenu(console=console, input_fn=lambda _: next(responses))
+
+    config_path = repo / ".skillware.yaml"
+    assert config_path.is_file()
+    assert str(external.resolve()) in config_path.read_text(encoding="utf-8")
 
 
 def test_interactive_doctor_dispatches(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,12 @@ import pytest
 from skillware.core.config import (
     GLOBAL_CONFIG_DIR_ENV,
     PROJECT_CONFIG_FILENAME,
+    PathsSettings,
     clear_config_cache,
     find_project_config_file,
     load_merged_config,
+    load_project_paths_settings,
+    save_project_config,
 )
 from skillware.core.discovery import (
     SKILLWARE_SKILL_PATH_ENV,
@@ -206,3 +209,28 @@ def test_cmd_config_show_reports_no_files(tmp_path, monkeypatch):
     output = buf.getvalue()
     assert "No config files found" in output
     assert "legacy resolution" in output
+
+
+def test_save_project_config_persists_paths(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv(GLOBAL_CONFIG_DIR_ENV, str(tmp_path / "no-global"))
+
+    paths = PathsSettings(
+        project="auto",
+        external=[str(external.resolve())],
+    )
+    written = save_project_config(paths)
+    assert written == (repo / PROJECT_CONFIG_FILENAME).resolve()
+
+    clear_config_cache()
+    loaded = load_project_paths_settings()
+    assert loaded.project == "auto"
+    assert Path(loaded.external[0]) == external.resolve()
+
+    merged = load_merged_config(refresh=True)
+    assert merged.has_config_files
+    assert any(root.path == external.resolve() for root in get_skill_roots())

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -102,6 +102,24 @@ def test_build_skill_not_found_message_includes_paths_tip(monkeypatch, tmp_path)
     message = build_skill_not_found_message("missing/skill")
     assert "missing/skill" in message
     assert "skillware paths" in message
+    assert "bundled:" in message or "project:" in message or "external:" in message
+
+
+def test_build_skill_not_found_message_config_tip(tmp_path, monkeypatch):
+    from skillware.core.config import PROJECT_CONFIG_FILENAME, clear_config_cache
+
+    clear_config_cache()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / PROJECT_CONFIG_FILENAME).write_text(
+        "paths:\n  project: auto\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("SKILLWARE_CONFIG_DIR", str(tmp_path / "no-global"))
+
+    message = build_skill_not_found_message("missing/skill")
+    assert "skillware config show" in message
+    clear_config_cache()
 
 
 def test_loader_uses_discovery_error_message(monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #247

Interactive CLI UX on top of #246 config: paths submenu with project `.skillware.yaml` persistence, tiered help, consistent navigation, and small polish on doctor/examples.

### Type of Change

- [x] **Framework Feature**, `config.py` save helpers, `discovery.py` tier labels + flat-layout scan
- [x] **CLI**, paths submenu, tiered help, nav, doctor spinner, examples table
- [x] **Documentation**, `cli.md`, `README`, `api_keys.md`, `ai_native_workflow.md`, `usage/README.md`

### Acceptance criteria → implementation

| Criterion | Where |
| :--- | :--- |
| Paths submenu wired (menu `4`) | `skillware/cli.py`, `cmd_paths_submenu`, `_PATHS_SUBMENU` |
| Persist project/external, bundled read-only | `save_project_config()`, submenu options 2–4 |
| Grouped help + doc links | `cmd_help_submenu`, brief `skillware --help` index |
| `cli.md` + `test_cli.py` updated | docs + interactive/nav/examples tests |

### Also in this PR (#246 follow-ups)

- `save_project_config()` / `load_project_paths_settings()` in `config.py`
- Skill-not-found errors show `tier: path` (`discovery.py`)
- Universal **`0`** exit, **`b`** back; doctor dots spinner; wider **EXTRA** / compact **GITHUB** in `skillware examples`

### Checklist

- [x] Fixes #247
- [x] `black --check` / `flake8` / `pytest` (401 passed)
- [x] `CHANGELOG.md` updated
- [ ] `examples/README.md`, N/A (no script changes)
- [ ] `test_registry_docs.py`, N/A

### Test plan

- [x] `skillware --help`, topic index + CLI usage examples
- [x] Interactive: `4` paths submenu (view, bundled, project, external, shadows, flat)
- [x] Interactive: `6` help topics; `0` / `b` navigation
- [x] `skillware doctor`, spinner then DEPS/LOAD table
- [x] `skillware examples`, EXTRA readable; GITHUB filename link
- [x] `save_project_config` + tier labels in not-found errors