### PR TITLE
chore(release): cut v0.4.9 with post-#247 polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report.yml
@@ -71,7 +71,7 @@ body:
       placeholder: |
         Windows 11
         Python 3.12
-        pip install skillware[gemini]==0.4.8
+        pip install skillware[gemini]==0.4.9
         google-genai 1.0.0
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/06_cli.yml
+++ b/.github/ISSUE_TEMPLATE/06_cli.yml
@@ -72,6 +72,6 @@ body:
     attributes:
       label: Environment
       placeholder: |
-        Windows 11, Python 3.12, skillware 0.4.8
+        Windows 11, Python 3.12, skillware 0.4.9
     validations:
       required: false

--- a/.github/RELEASE_v0.4.9.md
+++ b/.github/RELEASE_v0.4.9.md
@@ -1,0 +1,63 @@
+# GitHub Release — v0.4.9
+
+Copy the **title** and **body** below when creating the release at  
+https://github.com/ARPAHLS/skillware/releases/new?tag=v0.4.9
+
+Tag: `v0.4.9` · Target: `main`
+
+---
+
+## Title
+
+```
+v0.4.9 — CLI config, paths editor, doctor, and grouped help
+```
+
+---
+
+## Body
+
+```markdown
+## Added
+
+- **Config** — Persistent YAML configuration (global `config.yaml` and project `.skillware.yaml`); `paths` section drives skill root discovery when present; bundled registry always included (#246, #283).
+- **CLI** — `skillware config show` prints merged configuration (read-only); `skillware paths` tips updated for config files (#246, #283).
+- **CLI** — Interactive paths submenu (menu `4`) — view bundled registry, persist project/external paths to `.skillware.yaml`, shadowing and flat-layout diagnose; tiered help topics (menu `6`); universal navigation (`0` exit, `b` back); doctor spinner while diagnosing (#247, #285).
+- **Loader** — `SkillLoader.load_skill(..., execute_module=False)` inspect-only load (manifest, instructions, card, requirement pre-flight) without executing `skill.py`; clearer `ImportError` when `skill.py` import fails after pre-flight (#235, #282).
+- **CLI** — `skillware doctor` checks manifest deps and `skill.py` import readiness per skill (`DEPS` / `LOAD` table); optional skill ID, `--category`, and `--skills-root` (#235, #282).
+
+## Changed
+
+- **CLI** — `skillware examples` table — wider **EXTRA** column; **GITHUB** shows script filename as a clickable link (full URL on ctrl+click) (#247, #285).
+- **CLI** — Interactive menu option `6` description reflects grouped help topics (#247, #285).
+- **Loader** — Skill-not-found errors list searched roots with tier labels (`project`, `external`, `bundled`) (#247, #285).
+- **Loader** — `SkillLoader.load_skill()` validates manifest `requirements` version specifiers (for example `web3>=6.0.0`) against installed package versions before loading `skill.py`; unpinned entries still require importability only (#14, #281).
+- **GitHub** — New Skill Proposal template category dropdown synced with the registry (`creative`, `security`); added `creative` label (#279, #277).
+
+## Upgrade
+
+```shell
+pip install -U skillware
+```
+
+Dev / multi-skill:
+
+```shell
+pip install -U "skillware[dev,all,agents]"
+```
+
+See [CHANGELOG.md](https://github.com/ARPAHLS/skillware/blob/main/CHANGELOG.md) and [Install extras](https://github.com/ARPAHLS/skillware/blob/main/docs/usage/install_extras.md).
+
+## Contributors
+
+- @rosspeili — CLI config and paths editor (#246, #247), inspect-only load and `skillware doctor` (#235), manifest requirement version checks (#14), release cut
+- @UroojFatima-052 — Skill Proposal template category sync (#279)
+
+## Full changelog
+
+- #283 — Persistent YAML config and `skillware config show` (#246)
+- #285 — Interactive paths editor, tiered help, and nav (#247)
+- #282 — Inspect-only load and `skillware doctor` (#235)
+- #281 — Validate manifest requirement version specifiers (#14)
+- #279 — Add `creative` and `security` to skill proposal categories (#277)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-08-12
+
 ### Added
 
 - **Config:** Persistent YAML configuration (global `config.yaml` and project `.skillware.yaml`); `paths` section drives skill root discovery when present; bundled registry always included (#246).
@@ -19,6 +21,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Changed
 
 - **CLI:** `skillware examples` table — wider **EXTRA** column; **GITHUB** shows script filename as a clickable link (full URL on ctrl+click) (#247).
+- **CLI:** Interactive menu option `6` description reflects grouped help topics (#247).
 - **Loader:** Skill-not-found errors list searched roots with tier labels (`project`, `external`, `bundled`) (#247).
 - **Loader:** `SkillLoader.load_skill()` validates manifest `requirements` version specifiers (for example `web3>=6.0.0`) against installed package versions before loading `skill.py`; unpinned entries still require importability only (#14).
 - **GitHub**: New Skill Proposal template category dropdown synced with the registry (`creative`, `security`); added `creative` label (#279, #277).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ abstract: >-
   constitution and safety constraints, deterministic execute() implementations,
   and adapters for logical system providers — whether LLM APIs, hosted inference,
   or local runtimes.
-version: "0.4.8"
-date-released: "2026-08-03"
+version: "0.4.9"
+date-released: "2026-08-12"
 license: MIT
 repository-code: "https://github.com/ARPAHLS/skillware"
 url: "https://skillware.site"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Pick the path that matches your issue. Only the **skill** row requires the full 
 | **Skill upgrade** | Existing bundle under `skills/` | `skill upgrade`, `enhancement` | Skill Upgrade issue | Bundle test + catalog/docs as needed |
 | **Documentation** | `docs/`, `README.md`, `CONTRIBUTING.md` | `documentation` | Documentation Fix issue | Links valid; tone consistent |
 | **Core framework** | `skillware/core/`, framework `tests/` | `core framework`, `enhancement` | Framework Feature issue | `pytest tests/`; update usage docs if API changes |
-| **CLI** | `skillware/cli.py`, `docs/usage/cli.md` | `cli` | CLI issue | `pytest tests/test_cli.py` when relevant (`list`, `doctor`, `test`, `paths`, `examples`, menu) |
+| **CLI** | `skillware/cli.py`, `docs/usage/cli.md` | `cli` | CLI issue | `pytest tests/test_cli.py` when relevant (`list`, `doctor`, `test`, `paths`, `examples`, menu); `pytest tests/test_config.py` when config paths or `.skillware.yaml` persistence changes |
 | **Examples** | `examples/*.py`, agent loops, examples index | `examples` | Examples issue | Script runs; `pytest tests/test_registry_docs.py` when index changes |
 | **Packaging** | `pyproject.toml`, `MANIFEST.in`, wheel | `packaging` | Packaging issue | `scripts/wheel_smoke_test.py` after wheel build (see [TESTING.md](docs/TESTING.md#packaging-smoke-test)) |
 | **Bug fix** | Paths named in issue | `bug` | Bug Report | Reproduction or failing test |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ PyPI download counts show how often `skillware` is installed from the package in
 
 <a href="https://doi.org/10.5281/zenodo.21552745"><img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21552745-c7d2fe?style=flat-square" alt="DOI 10.5281/zenodo.21552745"></a>
 
-If you use Skillware in research or products, please cite it using [CITATION.cff](CITATION.cff) (GitHub **Cite this repository**) or the Zenodo **concept DOI** above. That DOI is stable across releases. For reproducibility, also record the **Skillware version** you used (PyPI or Git tag, for example `0.4.8`).
+If you use Skillware in research or products, please cite it using [CITATION.cff](CITATION.cff) (GitHub **Cite this repository**) or the Zenodo **concept DOI** above. That DOI is stable across releases. For reproducibility, also record the **Skillware version** you used (PyPI or Git tag, for example `0.4.9`).
 
 ## Contact
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -86,7 +86,7 @@ pip install -r requirements.txt
 | :--- | :--- | :--- |
 | Manifest + execute contract for one skill | Bundle test | `skills/compliance/tos_evaluator/test_skill.py` |
 | Loader path + mocked externals (optional depth) | Maintainer test | `tests/skills/compliance/test_tos_evaluator.py` |
-| Loader, CLI, registry issuer rules, param validation, manifest requirement pins | Framework test | `tests/test_loader.py`, `tests/test_requirements_check.py`, `tests/test_skill_issuer.py`, `tests/test_validate_params.py`, `tests/test_registry_docs.py`, `tests/test_card_ui_schema.py` |
+| Loader, CLI, registry issuer rules, param validation, manifest requirement pins, config and path discovery | Framework test | `tests/test_loader.py`, `tests/test_cli.py`, `tests/test_config.py`, `tests/test_discovery.py`, `tests/test_requirements_check.py`, `tests/test_skill_issuer.py`, `tests/test_validate_params.py`, `tests/test_registry_docs.py`, `tests/test_card_ui_schema.py` |
 | End-to-end provider demo script | Usage example | `examples/gemini_tos_evaluator.py` |
 
 **Rule of thumb:** if it ships with the skill and must pass before merge → **bundle test** (CI + local). If it is extra regression depth for clone-repo work → **maintainer test** (optional). If it proves provider integration → **example**, not pytest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillware"
-version = "0.4.8"
+version = "0.4.9"
 description = "A framework for modular, self-contained AI skills."
 readme = "README.md"
 authors = [

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -1392,7 +1392,7 @@ def cmd_interactive(console=None, parser=None) -> None:
         ("3", "test", "run bundle tests (test_skill.py) for one or all skills"),
         ("4", "paths", "paths submenu — view, edit, and diagnose skill roots"),
         ("5", "doctor", "check manifest deps and skill.py import readiness"),
-        ("6", "help", "usage guide for any command"),
+        ("6", "help", "grouped help topics and doc links"),
     ]
 
     commands = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,9 @@ from skillware.cli import (
     _load_examples_index,
     _example_counts_by_skill,
     _example_github_url,
+    _parse_nav,
+    _NAV_EXIT,
+    _NAV_BACK,
     cmd_list,
     cmd_examples,
     cmd_interactive,
@@ -737,6 +740,38 @@ def test_interactive_paths_dispatches(monkeypatch):
     assert "Paths" in output
     assert "Skill path resolution" in output
     assert "not yet implemented" not in output.lower()
+
+
+def test_parse_nav_exit_and_back():
+    assert _parse_nav("0") == (None, _NAV_EXIT)
+    assert _parse_nav("q") == (None, _NAV_EXIT)
+    assert _parse_nav("quit") == (None, _NAV_EXIT)
+    assert _parse_nav("b") == (None, _NAV_BACK)
+    assert _parse_nav("back") == (None, _NAV_BACK)
+    assert _parse_nav("list") == ("list", None)
+    assert _parse_nav(None) == (None, _NAV_BACK)
+    assert _parse_nav("") == ("", None)
+
+
+def test_cmd_paths_submenu_edit_project(tmp_path, monkeypatch):
+    import io
+    from rich.console import Console
+
+    project_skills = tmp_path / "my-skills"
+    project_skills.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("SKILLWARE_CONFIG_DIR", str(tmp_path / "no-global"))
+
+    responses = iter(["3", str(project_skills), "b"])
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    cmd_paths_submenu(console=console, input_fn=lambda _: next(responses))
+
+    config_path = repo / ".skillware.yaml"
+    assert config_path.is_file()
+    assert str(project_skills.resolve()) in config_path.read_text(encoding="utf-8")
 
 
 def test_cmd_paths_submenu_view_bundled(tmp_path, monkeypatch):

--- a/tests/test_version_policy.py
+++ b/tests/test_version_policy.py
@@ -41,7 +41,7 @@ def test_emit_advisory_silent_for_current_release(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.4.8",
+        lambda _name: "0.4.9",
     )
     version_policy.emit_upgrade_advisory()
     assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Description

Maintainer release cut for **v0.4.9**: bumps version surfaces, moves `CHANGELOG.md` `[Unreleased]` → `[0.4.9]`, and adds `.github/RELEASE_v0.4.9.md` for manual GitHub release.

Also includes small post-#247 polish: CONTRIBUTING/TESTING pointers for config tests, menu `6` help label, and `_parse_nav` / project-path CLI tests.

### Type of Change

- [x] **Documentation** — CHANGELOG, CONTRIBUTING, TESTING, release notes draft
- [x] **Packaging** — `pyproject.toml`, `CITATION.cff`, issue template pins

## Checklist (all PRs)

- [x] Scope matches the issue — release chore only
- [x] `black` / `flake8` pass locally
- [x] `pytest tests/` pass (new CLI tests included)
- [x] `CHANGELOG.md` — `[Unreleased]` cut to `0.4.9`
- [ ] `examples/README.md` — N/A
- [ ] `test_registry_docs.py` — N/A

## New or updated skill

N/A — skip.

## Related Issues

Refs release after #246, #247, #235, #14, #279.