### PR TITLE
test: add CI guard for manifest.name parity and global uniqueness (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Added
+
+- **CI:** `tests/test_registry_identity.py` - CI guard asserting every registry-layout skill's `manifest.name` matches its path-derived registry ID and that all manifest names are globally unique (#280).
+
 ## [0.4.9] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ### Added
 
 - **CI:** `tests/test_registry_identity.py` - CI guard asserting every registry-layout skill's `manifest.name` matches its path-derived registry ID and that all manifest names are globally unique (#280).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Defines the tool interface, safety constitution, dependencies, and issuer attrib
 
 **Required fields and sections:**
 
-- `name` — registry skill ID in `category/skill_name` form; **must match** the folder path under `skills/` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). Do not use a short name alone (for example `pdf_form_filler` without the `office/` prefix). The loader emits `SkillwareIdentityWarning` when a registry-layout skill (`<skill_root>/<category>/<skill_name>/`) has a missing or mismatched `name` (warn-only in v1; may become an error later). Flat private layouts (`<skill_root>/<skill_name>/`) skip this check.
+- `name` — registry skill ID in `category/skill_name` form; **must match** the folder path under `skills/` (same string as `SkillLoader.load_skill(...)` and the CLI `ID` column). Do not use a short name alone (for example `pdf_form_filler` without the `office/` prefix). The loader emits `SkillwareIdentityWarning` when a registry-layout skill (`<skill_root>/<category>/<skill_name>/`) has a missing or mismatched `name` (warn-only in v1; may become an error later). Flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Enforced in CI via `tests/test_registry_identity.py` — mismatched or duplicate `manifest.name` blocks merge (#280).
 - `version`, `description`
 - `issuer` — see [Issuer attribution](#issuer-attribution); `name` and `email` required, `github` and `org` optional
 - `short_description` — optional one-line summary (~80 chars) shown in `skillware list` when present

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -88,7 +88,7 @@ pip install -r requirements.txt
 | :--- | :--- | :--- |
 | Manifest + execute contract for one skill | Bundle test | `skills/compliance/tos_evaluator/test_skill.py` |
 | Loader path + mocked externals (optional depth) | Maintainer test | `tests/skills/compliance/test_tos_evaluator.py` |
-| Loader, CLI, registry issuer rules, param validation, manifest requirement pins, config and path discovery | Framework test | `tests/test_loader.py`, `tests/test_cli.py`, `tests/test_config.py`, `tests/test_discovery.py`, `tests/test_requirements_check.py`, `tests/test_skill_issuer.py`, `tests/test_validate_params.py`, `tests/test_registry_docs.py`, `tests/test_card_ui_schema.py` |
+| Loader, CLI, registry issuer rules, param validation, manifest requirement pins, config and path discovery | Framework test | `tests/test_loader.py`, `tests/test_cli.py`, `tests/test_config.py`, `tests/test_discovery.py`, `tests/test_requirements_check.py`, `tests/test_skill_issuer.py`, `tests/test_validate_params.py`, `tests/test_registry_docs.py`, `tests/test_card_ui_schema.py`, `tests/test_registry_identity.py` |
 | End-to-end provider demo script | Usage example | `examples/gemini_tos_evaluator.py` |
 
 **Rule of thumb:** if it ships with the skill and must pass before merge → **bundle test** (CI + local). If it is extra regression depth for clone-repo work → **maintainer test** (optional). If it proves provider integration → **example**, not pytest.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -16,6 +16,7 @@ Tests fall into four layers: **bundle**, **framework**, **maintainer**, and **ex
 | `[all]` extra covers bundle-test runtime deps | Done |
 | CLI `skillware test` for bundle discovery | Done |
 | Doc-drift guards (`test_registry_docs.py`) | Done |
+| Registry identity guard (`test_registry_identity.py`) | Done |
 | GitHub label policy test (`test_github_labels.py`) | Done |
 | PyPI wheel packaging smoke test (`scripts/wheel_smoke_test.py`) | Done |
 | Optional extras sync (`scripts/sync_extras.py`, `tests/test_extras_sync.py`) | Done |
@@ -65,6 +66,7 @@ pip install -r requirements.txt
 - `tests/test_skill_issuer.py` also enforces registry packaging (`__init__.py`), issuer metadata, presence of `test_skill.py` in every skill bundle, and rejects legacy manifest `output:` keys.
 - `tests/test_card_ui_schema.py` validates output-card `ui_schema.fields[].key` dot paths against fixtures in `tests/fixtures/card_ui_schema/` (#199).
 - `tests/test_registry_docs.py` enforces doc-drift parity: skill catalog index matches manifests, examples README matches scripts on disk, and agent-loops.md references every registered skill.
+- `tests/test_registry_identity.py` enforces manifest identity parity: every registry-layout skill's `manifest.name` matches its path-derived registry ID, and all manifest names are globally unique (#280).
 - Lives at the **root of `tests/`** only (`tests/test_loader.py`, `tests/test_cli.py`, …).
 - Clone-repo only; runs in CI via `pytest tests/` together with maintainer tests below.
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -286,6 +286,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] **Usage Examples** on the catalog page (all five providers per [skill usage template](../usage/skill_usage_template.md)); link to `docs/usage/` and list skill `env_vars` without duplicating [api_keys.md](../usage/api_keys.md)
 - [ ] `pytest tests/test_skill_issuer.py` passes
 - [ ] `pytest tests/test_registry_docs.py` passes (catalog index, examples index, and agent-loops parity)
+- [ ] `pytest tests/test_registry_identity.py` passes (`manifest.name` matches folder path; globally unique across the registry)
 - [ ] `SkillLoader.load_skill("<category>/<skill_name>")` works or deps are documented
 - [ ] `examples/README.md` updated if a new or changed script lives under `examples/`
 - [ ] No placeholders under `skills/`

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -1,0 +1,85 @@
+"""Registry-layout skills must have manifest.name matching their path and globally unique names."""
+
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "skills"
+
+
+def _discover_skill_dirs():
+    if not SKILLS_ROOT.is_dir():
+        return []
+    return sorted(p.parent for p in SKILLS_ROOT.rglob("manifest.yaml"))
+
+
+def _load_manifest(skill_dir: Path) -> dict:
+    with open(skill_dir / "manifest.yaml", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data if isinstance(data, dict) else {}
+
+
+def _expected_registry_id(skill_dir: Path):
+    """Return category/skill_name for registry-layout skills, None for flat or non-standard layouts."""
+    try:
+        relative = skill_dir.relative_to(SKILLS_ROOT)
+    except ValueError:
+        return None
+    if len(relative.parts) != 2:
+        return None
+    return relative.as_posix()
+
+
+def test_registry_manifest_name_matches_path():
+    """Every registry-layout skill's manifest.name must equal its path-derived registry ID."""
+    skill_dirs = _discover_skill_dirs()
+    assert skill_dirs, "expected at least one skill under skills/"
+
+    mismatches = []
+    for skill_dir in skill_dirs:
+        expected = _expected_registry_id(skill_dir)
+        if expected is None:
+            continue
+
+        manifest = _load_manifest(skill_dir)
+        manifest_name = (manifest.get("name") or "").strip()
+        rel_path = skill_dir.relative_to(REPO_ROOT).as_posix()
+
+        if not manifest_name:
+            mismatches.append(
+                f"{rel_path}: manifest.yaml missing 'name' (expected {expected!r})"
+            )
+        elif manifest_name != expected:
+            mismatches.append(
+                f"{rel_path}: manifest.name is {manifest_name!r}, expected {expected!r}"
+            )
+
+    assert not mismatches, "manifest.name parity violations:\n  " + "\n  ".join(
+        mismatches
+    )
+
+
+def test_registry_manifest_names_are_globally_unique():
+    """No two registry-layout skills may share the same manifest.name."""
+    name_to_paths = defaultdict(list)
+
+    for skill_dir in _discover_skill_dirs():
+        if _expected_registry_id(skill_dir) is None:
+            continue
+
+        manifest = _load_manifest(skill_dir)
+        manifest_name = (manifest.get("name") or "").strip()
+        if not manifest_name:
+            continue
+
+        rel_path = skill_dir.relative_to(REPO_ROOT).as_posix()
+        name_to_paths[manifest_name].append(rel_path)
+
+    duplicates = {
+        name: paths for name, paths in name_to_paths.items() if len(paths) > 1
+    }
+    assert (
+        not duplicates
+    ), f"duplicate manifest.name across registry skills: {dict(duplicates)}"


### PR DESCRIPTION
Closes #280

Adds a static YAML scan under `tests/test_registry_identity.py` that runs as part of `pytest tests/` in CI. Two independent tests, following the discovery pattern from `tests/test_skill_issuer.py`.

## Changes

**`tests/test_registry_identity.py`** (new)
- `test_registry_manifest_name_matches_path`, for every registry-layout skill (`skills/<category>/<skill_name>/`), asserts `manifest.name` equals the path-derived registry ID. Whitespace-only names are treated as missing (strip first). Flat layouts are skipped since `_expected_registry_id` returns `None` for them.
- `test_registry_manifest_names_are_globally_unique`, groups skill paths by `manifest.name` using `defaultdict(list)`; asserts no name has more than one path. Duplicate failures report both conflicting paths.
- Failure messages use paths relative to `REPO_ROOT` for readability in CI logs.
- Both tests batch their errors (collect all violations, then assert once) so a single CI run surfaces every bad skill instead of failing on the first one.

**`docs/TESTING.md`**
- Added `test_registry_identity.py` row to the Status table.
- Added a one-line description under the Framework test section.

**`CHANGELOG.md`**
- Added entry under `[Unreleased] > Added`.

## Notes

- No loader behavior changes, kept warn-only per v1 scope.
- Both tests pass locally on current `main` (2 passed in 0.47s).
- `black --check` and `flake8` clean.
- Did not touch out-of-scope items: `load_skill_by_id()`, `index.json`, or promoting `SkillwareIdentityWarning` to a hard error.