### PR TITLE
fix(meta): shorten cat: security label description for GitHub API limit

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -132,7 +132,7 @@
     {
         "name": "cat: security",
         "color": "E6D9F5",
-        "description": "Registry skill category — security skills (`skills/security/`). For vulnerabilities or trust-model work, use the repo-wide security label."
+        "description": "Registry skill category — security (`skills/security/`)."
     },
     {
         "name": "cat: wellness",

--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -14,6 +14,7 @@ from typing import Any
 
 LABELS_FILE = Path(__file__).resolve().parent.parent / "labels.json"
 API_ROOT = "https://api.github.com"
+GITHUB_LABEL_DESCRIPTION_MAX = 100
 # Labels removed from labels.json — deleted on sync so GitHub UI does not keep stale pills.
 DEPRECATED_LABELS = ["core-framework", "creative", "office"]
 
@@ -57,6 +58,11 @@ def _load_labels() -> list[dict[str, str]]:
         description = entry.get("description", "").strip()
         if not name:
             raise ValueError("Each label entry requires a name")
+        if len(description) > GITHUB_LABEL_DESCRIPTION_MAX:
+            raise ValueError(
+                f"Label {name!r} description is {len(description)} chars; "
+                f"GitHub maximum is {GITHUB_LABEL_DESCRIPTION_MAX}"
+            )
         if len(color) != 6 or any(c not in "0123456789ABCDEF" for c in color):
             raise ValueError(f"Label {name!r} has invalid color {color!r}")
         if name in seen:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 - **Meta:** GitHub issue templates refreshed for v0.5.1 CLI (`doctor`, `config show`, paths/mail submenus) and `office/gmail_handler` filing paths; label taxonomy adds all registry `cat: <category>` labels (shared pastel color) so category filters never collide with repo-wide labels such as `security` (#294).
 
+### Fixed
+
+- **Meta:** Shorten `cat: security` label description to fit GitHub's 100-character limit; enforce max length in label sync and tests.
+
 ## [0.5.1] - 2026-08-19
 
 ### Added

--- a/tests/test_github_labels.py
+++ b/tests/test_github_labels.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 LABELS_PATH = Path(__file__).resolve().parent.parent / ".github" / "labels.json"
 HEX_COLOR = re.compile(r"^[0-9A-Fa-f]{6}$")
+GITHUB_LABEL_DESCRIPTION_MAX = 100
 
 # Keep in sync with .github/ISSUE_TEMPLATE/01_skill_proposal.yml category dropdown.
 REGISTRY_CATEGORIES = (
@@ -80,6 +81,10 @@ def test_label_entries_well_formed():
         names.add(name)
         assert HEX_COLOR.match(color), f"Bad color for {name}: {color!r}"
         assert description and isinstance(description, str)
+        assert len(description) <= GITHUB_LABEL_DESCRIPTION_MAX, (
+            f"Label {name!r} description is {len(description)} chars; "
+            f"GitHub maximum is {GITHUB_LABEL_DESCRIPTION_MAX}"
+        )
 
 
 def test_rfc_template_labels_exist():


### PR DESCRIPTION
## Description

Fixes the **sync-labels** workflow failure after #294: GitHub rejects label descriptions over **100 characters**. The `cat: security` description was 156 chars and blocked creation of the last category label.

Refs #294 (follow-up hotfix)

| Change | File |
|--------|------|
| Shorten `cat: security` description to match other `cat:` labels | `.github/labels.json` |
| Enforce 100-char max at load time | `.github/scripts/sync_labels.py` |
| CI guard for description length | `tests/test_github_labels.py` |
| CHANGELOG | `[Unreleased]` Fixed note |

### Type of Change

- [ ] **New Skill**
- [ ] **Skill Upgrade**
- [ ] **Bug Fix**
- [ ] **Documentation**
- [ ] **Framework Feature**
- [ ] **CLI**
- [ ] **Examples**
- [ ] **Packaging**
- [x] **RFC / meta** — templates, labels, CI, or large design doc

## Checklist (all PRs)

- [x] Linked GitHub issue (`Refs #294`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset)
- [x] `pytest skills/` and `pytest tests/` pass locally when relevant (`pytest tests/test_github_labels.py`)
- [x] `CHANGELOG.md` updated under `[Unreleased]` when user-visible behavior changes
- [ ] `examples/README.md` updated — N/A
- [ ] Ran `pytest tests/test_registry_docs.py` — N/A

## New or updated skill

N/A — no changes under `skills/`.

## Related Issues

Refs #294