### PR TITLE
Docs/skill version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Added
 
+- **Documentation:** Skill catalog pages include a **Version** header and **Skill history** table (commit links, dates, versions, and linked GitHub contributor handles); [docs/skills/README.md](docs/skills/README.md) adds a **Version** column to category tables.
+- **Tests:** `test_catalog_pages_have_version_and_history_blocks()` and `test_skill_library_index_has_version_column()` in `tests/test_registry_docs.py` guard catalog version/history coverage.
+
 - **Skill (`finance/uk_companies_house_handler` v1.2.0):** Phase v2b upgrade — `run_pipeline` for sequential multi-step execution with automatic halting on `needs_input` (disambiguation) or `error`, step-slicing resumption (`steps[prior_completed:]`), placeholder auto-substitution (`<from_resolve>`), and cumulative data payload merging (#220).
 - **Skill (`finance/uk_companies_house_handler` v1.2.0):** Composite actions `resolve_and_get_officers` and `resolve_and_get_filings` to resolve companies and fetch target records in single-turn operations (#220).
 - **Skill (`finance/uk_companies_house_handler` v1.2.0):** Default limit 10 previews with `partial` response status and `agent_hint` metadata for officers and filing history (#220).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
-- **Docs:** Updated contributor instructions guidance in `CONTRIBUTING.md`, `ai_native_workflow.md`, and `templates/python_skill/instructions.md` to emphasize concise, append-only skill context over persona starters (#258, #284).
+- **Docs:** Updated contributor instructions guidance in `CONTRIBUTING.md`, `ai_native_workflow.md`, and `templates/python_skill/` to emphasize concise, append-only skill context over persona starters (#258, #284).
+- **Docs:** Aligned `ai_native_workflow.md` and `templates/python_skill/README.md` checklists with catalog **Version** and **Skill history** requirements.
 - **Meta:** GitHub issue templates refreshed for v0.5.1 CLI (`doctor`, `config show`, paths/mail submenus) and `office/gmail_handler` filing paths; label taxonomy adds all registry `cat: <category>` labels (shared pastel color) so category filters never collide with repo-wide labels such as `security` (#294).
 - **Skill (`finance/uk_companies_house_handler` v1.2.0):** `get_officers` default `active_only` is now **true** (v1.x default was false) — resigned officers are excluded unless `active_only: false` (#220).
 - **Skill (`finance/uk_companies_house_handler` v1.2.0):** Removed conversational prefix stripping from composite actions; agents must pass clean `query` / `company_query` plus optional `role_hint`. `map_intent` returns `needs_input` when a company name is required but missing (#220).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,14 +321,15 @@ Registry skills are shipped inside the `skillware` wheel. Per-skill layout uses 
 ### 6. `docs/skills/<skill_name>.md` (catalog page)
 
 - Human-readable documentation linked from the [Skill Library](docs/skills/README.md).
-- Include **ID**, **Issuer**, and **Recommended install** (`pip install "skillware[<category>_<skill>]"` — see [install_extras.md](install_extras.md)) near the top.
+- Include **ID**, **Issuer**, **Version** (from `manifest.yaml`), and **Recommended install** (`pip install "skillware[<category>_<skill>]"` — see [install_extras.md](install_extras.md)) near the top.
 - Describe capabilities, prerequisites, arguments, and limitations.
 - If the skill calls external services, list its environment variables in a short table and link to [API keys for skills](docs/usage/api_keys.md). Do not duplicate the full setup guide on the skill page.
 - Add a **Usage Examples** section with runnable snippets for Gemini, Claude, OpenAI, DeepSeek, and Ollama (prompt mode). Follow [skill usage example template](docs/usage/skill_usage_template.md) and link to [usage guides](docs/usage/README.md) and [agent loops](docs/usage/agent_loops.md).
+- Add a **Skill history** section before the enterprise disclaimer: a table of notable commits that touched the skill bundle or catalog page. Link each commit SHA and list contributors as linked GitHub usernames (`[@username](https://github.com/username)`). Append a row when you ship a skill update in the same PR.
 
 ### 7. Registry index row
 
-- Add or update the skill table in [docs/skills/README.md](docs/skills/README.md) (Skill, ID, Issuer, Description).
+- Add or update the skill table in [docs/skills/README.md](docs/skills/README.md) (Skill, ID, Version, Issuer, Description). Set **Version** to `` `x.y.z` (DD Mon YYYY) `` from the manifest and the release/merge date.
 
 ### Issuer attribution
 

--- a/docs/contributing/ai_native_workflow.md
+++ b/docs/contributing/ai_native_workflow.md
@@ -241,7 +241,7 @@ These align with [CONTRIBUTING.md](../../CONTRIBUTING.md). Violations block merg
 - `issuer.name` and `issuer.email` required; `github` and `org` optional; no template placeholders in registry paths
 - `card.json` issuer must match manifest `name` and `email` when present
 - Output-card `ui_schema.fields[].key` values must resolve in `execute()` JSON; keep `tests/fixtures/card_ui_schema/<category>__<skill_name>.json` in sync (#199)
-- Update `docs/skills/<skill_name>.md` and `docs/skills/README.md`
+- Update `docs/skills/<skill_name>.md` and `docs/skills/README.md` (**Version**, **Skill history**, and index columns per [CONTRIBUTING.md § catalog page](../../CONTRIBUTING.md#6-docsskillsskill_namemd-catalog-page))
 - On each catalog page, add a **Usage Examples** section (Gemini, Claude, OpenAI, DeepSeek, Ollama prompt mode) per [skill usage template](../usage/skill_usage_template.md). Keep provider mechanics in `docs/usage/`; put skill-specific paths, sample user messages, and `execute` payloads on the skill page.
 - Categories: `compliance`, `creative`, `data_engineering`, `defi`, `dev_tools`, `finance`, `monitoring`, `office`, `optimization`, `security`, `wellness` — see [Skill library](../skills/README.md) for the live registry; [Choosing a category](../../CONTRIBUTING.md#choosing-a-category) in CONTRIBUTING.md (issue first for new top-level folders)
 - Do not bump `pyproject.toml` version in skill-only PRs unless requested
@@ -281,7 +281,7 @@ Complete the checklist that matches your issue during Stage 5.
 - [ ] `card.json`: `issuer` matches manifest; output-card `ui_schema.fields[].key` paths resolve in `tests/fixtures/card_ui_schema/<category>__<skill_name>.json` (update fixture when `execute()` output changes)
 - [ ] `test_skill.py` (bundle test) passes — `pytest skills/<category>/<skill_name>/test_skill.py` or `skillware test <category>/<skill_name>`
 - [ ] Bundle tests mock all network calls and model downloads; CI does not download models.
-- [ ] `docs/skills/<skill_name>.md` and catalog row in `docs/skills/README.md` (include **Recommended install:** `pip install "skillware[<category>_<skill>]"` per [install_extras.md](../usage/install_extras.md))
+- [ ] `docs/skills/<skill_name>.md` and catalog row in `docs/skills/README.md` (**Version** from manifest, **Skill history** with linked GitHub usernames, **Recommended install:** `pip install "skillware[<category>_<skill>]"` per [install_extras.md](../usage/install_extras.md))
 - [ ] After changing `manifest.yaml` `requirements`, run `python scripts/sync_extras.py` and confirm `python scripts/sync_extras.py --check` passes
 - [ ] **Usage Examples** on the catalog page (all five providers per [skill usage template](../usage/skill_usage_template.md)); link to `docs/usage/` and list skill `env_vars` without duplicating [api_keys.md](../usage/api_keys.md)
 - [ ] `pytest tests/test_skill_issuer.py` passes

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -7,84 +7,84 @@ Browse by category below, or run `skillware list` after `pip install skillware` 
 ## Office
 Skills for document processing, email automation, and productivity.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[PDF Form Filler](pdf_form_filler.md)** | `office/pdf_form_filler` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Fills AcroForm-based PDFs by mapping user instructions to detected form fields using LLM-based semantic understanding. |
-| **[Gmail Handler](gmail_handler.md)** | `office/gmail_handler` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Gmail send, search, read, reply, and attachments via IMAP/SMTP with address book, signatures, and confirmation gates. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[PDF Form Filler](pdf_form_filler.md)** | `office/pdf_form_filler` | `0.1.0` (16 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Fills AcroForm-based PDFs by mapping user instructions to detected form fields using LLM-based semantic understanding. |
+| **[Gmail Handler](gmail_handler.md)** | `office/gmail_handler` | `0.2.0` (19 Aug 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Gmail send, search, read, reply, and attachments via IMAP/SMTP with address book, signatures, and confirmation gates. |
 
 ## Creative
 Skills for image processing, media editing, and creative utilities.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Background Remover](bg_remover.md)** | `creative/bg_remover` | [@AyushSrivastava1818](https://github.com/AyushSrivastava1818) | Removes image backgrounds locally using rembg and returns transparent PNGs. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Background Remover](bg_remover.md)** | `creative/bg_remover` | `0.2.0` (2 Aug 2026) | [@AyushSrivastava1818](https://github.com/AyushSrivastava1818) | Removes image backgrounds locally using rembg and returns transparent PNGs. |
 
 ## Finance
 Tools for financial analysis, blockchain interaction, and regulatory compliance.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Wallet Screening](wallet_screening.md)** | `finance/wallet_screening` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Comprehensive risk assessment for Ethereum wallets. Checks sanctions lists (OFAC, FBI) and identifies interactions with malicious contracts (Mixers, Scams). |
-| **[UK Companies House Handler](uk_companies_house_handler.md)** | `finance/uk_companies_house_handler` | [@Areen-09](https://github.com/Areen-09) ([@ARPAHLS](https://github.com/ARPAHLS)) | Deterministic UK Companies House API handler: company search, officers, PSC, filing history, pipeline orchestration, and UK corporate terminology translation via structured actions. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Wallet Screening](wallet_screening.md)** | `finance/wallet_screening` | `1.0.1` (23 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Comprehensive risk assessment for Ethereum wallets. Checks sanctions lists (OFAC, FBI) and identifies interactions with malicious contracts (Mixers, Scams). |
+| **[UK Companies House Handler](uk_companies_house_handler.md)** | `finance/uk_companies_house_handler` | `1.2.0` (24 Aug 2026) | [@Areen-09](https://github.com/Areen-09) ([@ARPAHLS](https://github.com/ARPAHLS)) | Deterministic UK Companies House API handler: company search, officers, PSC, filing history, pipeline orchestration, and UK corporate terminology translation via structured actions. |
 
 ## DeFi
 On-chain execution and trading for dedicated agent wallets (structured intent, previews, confirmations).
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[EVM Transaction Handler](evm_tx_handler.md)** | `defi/evm_tx_handler` | [@Hendobox](https://github.com/Hendobox) | Uni V2 quote, preview, execute, and transfer on Ethereum/Base from structured intent. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[EVM Transaction Handler](evm_tx_handler.md)** | `defi/evm_tx_handler` | `0.2.0` (16 Jul 2026) | [@Hendobox](https://github.com/Hendobox) | Uni V2 quote, preview, execute, and transfer on Ethereum/Base from structured intent. |
 
 ## Optimization
 Middleware skills that operate on text or state to increase performance, security, or efficiency.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Prompt Token Rewriter](prompt_rewriter.md)** | `optimization/prompt_rewriter` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Aggressively compresses massive prompts or context histories while retaining semantic meaning to save tokens. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Prompt Token Rewriter](prompt_rewriter.md)** | `optimization/prompt_rewriter` | `0.1.0` (16 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Aggressively compresses massive prompts or context histories while retaining semantic meaning to save tokens. |
 
 ## Data Engineering
 Skills tailored for generating, parsing, and orchestrating large datasets for machine learning or analytics workflows.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Synthetic Data Generator](synthetic_generator.md)** | `data_engineering/synthetic_generator` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Generates high-entropy structured synthetic data for model fine-tuning to avoid mode collapse. |
-| **[Novelty Extractor](novelty_extractor.md)** | `data_engineering/novelty_extractor` | [@rizzoMartin](https://github.com/rizzoMartin) | Filters a text dataset by semantic novelty, retaining only chunks that carry new information above a configurable threshold. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Synthetic Data Generator](synthetic_generator.md)** | `data_engineering/synthetic_generator` | `0.1.0` (16 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Generates high-entropy structured synthetic data for model fine-tuning to avoid mode collapse. |
+| **[Novelty Extractor](novelty_extractor.md)** | `data_engineering/novelty_extractor` | `0.1.0` (16 Jul 2026) | [@rizzoMartin](https://github.com/rizzoMartin) | Filters a text dataset by semantic novelty, retaining only chunks that carry new information above a configurable threshold. |
 
 ## Compliance
 Enforces privacy, guardrails, and secure handling of sensitive data before it reaches external endpoints.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[PII Masker](pii_masker.md)** | `compliance/pii_masker` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | High-precision, local PII (Personally Identifiable Information) detection and redaction using the micro-f1-mask model. |
-| **[MiCA Module](mica_module.md)** | `compliance/mica_module` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Self-contained local Policy Enforcement and RAG engine strictly adhering to MiCA crypto-asset regulation. |
-| **[Terms of Service Evaluator](tos_evaluator.md)** | `compliance/tos_evaluator` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Local-first evaluation of robots.txt and website legal pages to decide whether an intended automated action appears permissible. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[PII Masker](pii_masker.md)** | `compliance/pii_masker` | `0.1.0` (20 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | High-precision, local PII (Personally Identifiable Information) detection and redaction using the micro-f1-mask model. |
+| **[MiCA Module](mica_module.md)** | `compliance/mica_module` | `0.1.0` (20 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Self-contained local Policy Enforcement and RAG engine strictly adhering to MiCA crypto-asset regulation. |
+| **[Terms of Service Evaluator](tos_evaluator.md)** | `compliance/tos_evaluator` | `0.1.0` (16 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Local-first evaluation of robots.txt and website legal pages to decide whether an intended automated action appears permissible. |
 
 ## Security
 Offline and local-first defenses for untrusted input before it reaches model context or host agents.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Prompt Injection Firewall](prompt_injection_firewall.md)** | `security/prompt_injection_firewall` | [@mrmasa88](https://github.com/mrmasa88) (AO) | Offline deterministic scan and sanitization for hostile instructions in untrusted text before LLM context. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Prompt Injection Firewall](prompt_injection_firewall.md)** | `security/prompt_injection_firewall` | `0.1.0` (31 Jul 2026) | [@mrmasa88](https://github.com/mrmasa88) (AO) | Offline deterministic scan and sanitization for hostile instructions in untrusted text before LLM context. |
 
 ## Dev Tools
 Skills that assist developers in understanding codebases, planning changes, and resolving issues across any repository.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Issue Resolver](issue_resolver.md)** | `dev_tools/issue_resolver` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | GitHub issue URL prep, optional caller-fetched repository profiles, nine-stage agent workflow, conditional verify/commit gates, and commit-message validation. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Issue Resolver](issue_resolver.md)** | `dev_tools/issue_resolver` | `0.3.0` (3 Aug 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | GitHub issue URL prep, optional caller-fetched repository profiles, nine-stage agent workflow, conditional verify/commit gates, and commit-message validation. |
 
 ## Monitoring
 Observability and guardrails for long-running autonomous agent loops.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Token Limiter](token_limiter.md)** | `monitoring/token_limiter` | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Deterministic token budget gate that returns CONTINUE, WARN, or FORCE_TERMINATE for host loops. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Token Limiter](token_limiter.md)** | `monitoring/token_limiter` | `1.0.0` (16 Jul 2026) | [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS)) | Deterministic token budget gate that returns CONTINUE, WARN, or FORCE_TERMINATE for host loops. |
 
 ## Wellness
 Supportive coaching guardrails, crisis triage, and grounded psychoeducation for host agents.
 
-| Skill | ID | Issuer | Description |
-| :--- | :--- | :--- | :--- |
-| **[Mental Coach](mental_coach.md)** | `wellness/mental_coach` | [@mrmasa88](https://github.com/mrmasa88) (AO) | Deterministic wellness coaching firewall with crisis triage, scope limits, and cited KB retrieval. |
+| Skill | ID | Version | Issuer | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **[Mental Coach](mental_coach.md)** | `wellness/mental_coach` | `0.1.0` (16 Jul 2026) | [@mrmasa88](https://github.com/mrmasa88) (AO) | Deterministic wellness coaching firewall with crisis triage, scope limits, and cited KB retrieval. |
 
 ---
 

--- a/docs/skills/bg_remover.md
+++ b/docs/skills/bg_remover.md
@@ -2,6 +2,9 @@
 
 **ID**: `creative/bg_remover`
 **Issuer**: [@AyushSrivastava1818](https://github.com/AyushSrivastava1818)
+<!-- skill-doc-meta:begin -->
+**Version**: `0.2.0` — 2 Aug 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[creative_bg_remover]"`. See [Install extras](../usage/install_extras.md).
 **Category**: Creative
@@ -322,6 +325,17 @@ print(json.dumps(result, indent=2))
 - The skill does not fetch URLs or cloud objects directly
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`creative/bg_remover`](https://github.com/ARPAHLS/skillware/tree/main/skills/creative/bg_remover)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`d32260e`](https://github.com/ARPAHLS/skillware/commit/d32260e) | feat(bg_remover): harden skill to v0.2.0 (#268) | 2 Aug 2026 | `0.2.0` | [@AyushSrivastava1818](https://github.com/AyushSrivastava1818), [@rosspeili](https://github.com/rosspeili) |
+| [`c6d4c53`](https://github.com/ARPAHLS/skillware/commit/c6d4c53) | feat(creative): add offline background removal skill (#244) | 16 Jul 2026 | `0.1.0` | [@AyushSrivastava1818](https://github.com/AyushSrivastava1818), [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/evm_tx_handler.md
+++ b/docs/skills/evm_tx_handler.md
@@ -2,6 +2,9 @@
 
 **ID**: `defi/evm_tx_handler`  
 **Issuer**: [@Hendobox](https://github.com/Hendobox) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.2.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[defi_evm_tx_handler]"`. See [Install extras](../usage/install_extras.md).
 
@@ -181,3 +184,21 @@ client = OpenAI(
 - Fail closed on missing RPC, registry entries, missing wallet key, or USD price when `max_trade_usd` is set.  
 - `confirm_before_send` blocks execute/transfer until `confirmed: true`.  
 - Not financial or legal advice; agents can mis-parse NL — always preview.
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`defi/evm_tx_handler`](https://github.com/ARPAHLS/skillware/tree/main/skills/defi/evm_tx_handler)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `0.2.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`91bef48`](https://github.com/ARPAHLS/skillware/commit/91bef48) | docs: document manifest ID alignment and provider tool names (#201) | 1 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`673e227`](https://github.com/ARPAHLS/skillware/commit/673e227) | fix: align pdf_form_filler and evm_tx_handler manifest names with registry paths | 1 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`6ecd350`](https://github.com/ARPAHLS/skillware/commit/6ecd350) | style(defi): format evm_tx_handler for black CI (#142) | 5 Jun 2026 | `0.2.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`cad61be`](https://github.com/ARPAHLS/skillware/commit/cad61be) | docs(defi): polish evm_tx_handler for merge (#142) | 4 Jun 2026 | `0.2.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`0c9c475`](https://github.com/ARPAHLS/skillware/commit/0c9c475) | feat(defi): implement evm_tx_handler execute flow (#142) | 2 Jun 2026 | `0.2.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`93117b4`](https://github.com/ARPAHLS/skillware/commit/93117b4) | feat(defi): add evm_tx_handler PR1 (quote, preview, transfer) Introduce defi/evm_tx_handler for a dedicated EVM agent wallet on Ethereum and Base. First PR ships resolve, quote, preview, transfer, balances, wallet_info, and update_preferences with YAML registries and mocked Web3 tests. Swap execute is stubbed for a follow-up PR. | 1 Jun 2026 | `0.1.0` | [@Hendobox](https://github.com/Hendobox) |
+<!-- skill-history:end -->

--- a/docs/skills/gmail_handler.md
+++ b/docs/skills/gmail_handler.md
@@ -2,6 +2,9 @@
 
 **ID**: `office/gmail_handler`  
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.2.0` — 19 Aug 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[office_gmail_handler]"`. See [Install extras](../usage/install_extras.md).
 
@@ -377,6 +380,18 @@ Catalog snippets only for Claude, OpenAI, DeepSeek, and Ollama — follow [skill
 - Fail closed on missing credentials or ambiguous recipients.
 - Recipient cap (`max_recipients`, default 5) blocks bulk sends.
 - Confirmation gate on `send` and `reply` when `confirm_before_send` is true (default).
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`office/gmail_handler`](https://github.com/ARPAHLS/skillware/tree/main/skills/office/gmail_handler)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`907c7dc`](https://github.com/ARPAHLS/skillware/commit/907c7dc) | feat(gmail_handler): v0.2 attachments, reply signatures, and multi-profile sigs | 19 Aug 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`a1bab61`](https://github.com/ARPAHLS/skillware/commit/a1bab61) | Add mail CLI and config for gmail_handler operator UX (#292) | 19 Aug 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`13473ce`](https://github.com/ARPAHLS/skillware/commit/13473ce) | feat(office/gmail_handler): add Gmail IMAP/SMTP skill for agent mail workflows (#208) (#291) | 17 Aug 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/issue_resolver.md
+++ b/docs/skills/issue_resolver.md
@@ -3,6 +3,9 @@
 **Domain:** `dev_tools`
 **Skill ID:** `dev_tools/issue_resolver`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.3.0` — 3 Aug 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[dev_tools_issue_resolver]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -368,6 +371,26 @@ response = client.chat.completions.create(
 Skill history and version notes: [CHANGELOG.md](../../CHANGELOG.md) (#56, #143, #145).
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`dev_tools/issue_resolver`](https://github.com/ARPAHLS/skillware/tree/main/skills/dev_tools/issue_resolver)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`e90ba2f`](https://github.com/ARPAHLS/skillware/commit/e90ba2f) | chore(release): 0.4.8 — skills, profiles, version policy | 3 Aug 2026 | `0.3.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`1e039a2`](https://github.com/ARPAHLS/skillware/commit/1e039a2) | feat: add repository profiles to issue resolver (#271) | 3 Aug 2026 | `0.3.0` | [@TheDarkniteFalls](https://github.com/TheDarkniteFalls) |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `0.2.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f14a993`](https://github.com/ARPAHLS/skillware/commit/f14a993) | fix(issue_resolver): replace wide emoji regex for CodeQL py/overly-large-range (#146) | 29 May 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`eea3fdd`](https://github.com/ARPAHLS/skillware/commit/eea3fdd) | feat(issue_resolver): universal workflow v0.2, examples, and release 0.3.3 (#144) | 29 May 2026 | `0.2.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`fd9f65d`](https://github.com/ARPAHLS/skillware/commit/fd9f65d) | Add dev_tools/issue_resolver skill. (#85) | 22 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/mental_coach.md
+++ b/docs/skills/mental_coach.md
@@ -3,6 +3,9 @@
 **Domain:** `wellness`
 **Skill ID:** `wellness/mental_coach`
 **Issuer:** [@mrmasa88](https://github.com/mrmasa88) (AO) · **Contact:** masa88keith@gmail.com
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[wellness_mental_coach]"`. See [Install extras](../usage/install_extras.md).
 
@@ -169,3 +172,15 @@ Always include `disclaimers_required` in the user-facing reply.
 - English-first v0.1; non-English input routes to CAUTION with resources.
 - Public KB only; no private corpus in the published package.
 - Crisis gate uses conservative keyword signals; over-escalation is intentional.
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`wellness/mental_coach`](https://github.com/ARPAHLS/skillware/tree/main/skills/wellness/mental_coach)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`6cbe140`](https://github.com/ARPAHLS/skillware/commit/6cbe140) | Add wellness/mental_coach skill resolving #148 (#174) | 22 Jun 2026 | `0.1.0` | [@mrmasa88](https://github.com/mrmasa88) |
+<!-- skill-history:end -->

--- a/docs/skills/mica_module.md
+++ b/docs/skills/mica_module.md
@@ -2,6 +2,9 @@
 
 **ID**: `compliance/mica_module`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 20 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[compliance_mica_module]"`. See [Install extras](../usage/install_extras.md).
 
@@ -198,6 +201,31 @@ The skill returns a strictly formatted JSON context block that Parent Agents inc
 ```
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`compliance/mica_module`](https://github.com/ARPAHLS/skillware/tree/main/skills/compliance/mica_module)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`812ec7e`](https://github.com/ARPAHLS/skillware/commit/812ec7e) | Add card ui_schema validation guard and fix drift (#199) (#260) | 20 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`7ddedb2`](https://github.com/ARPAHLS/skillware/commit/7ddedb2) | feat: migrate from google-generativeai to google-genai SDK (#97) | 23 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`39487f8`](https://github.com/ARPAHLS/skillware/commit/39487f8) | Add generic API keys guide for skills requiring external calls. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`85480b0`](https://github.com/ARPAHLS/skillware/commit/85480b0) | chore: resolve flake8 linting violations across MiCA module and examples | 11 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`9cd18b0`](https://github.com/ARPAHLS/skillware/commit/9cd18b0) | feat(compliance): implement high-performance MiCA module (close #35) | 11 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/novelty_extractor.md
+++ b/docs/skills/novelty_extractor.md
@@ -3,6 +3,9 @@
 **Domain:** `data_engineering`
 **Skill ID:** `data_engineering/novelty_extractor`
 **Issuer:** [@rizzoMartin](https://github.com/rizzoMartin)
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[data_engineering_novelty_extractor]"`. See [Install extras](../usage/install_extras.md).
 
@@ -219,3 +222,17 @@ On error:
   text. Results on other languages may vary.
 - **Threshold sensitivity**: Results depend on the chosen `novelty_threshold`.
   A value between 0.80 and 0.90 works well for most corpora.
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`data_engineering/novelty_extractor`](https://github.com/ARPAHLS/skillware/tree/main/skills/data_engineering/novelty_extractor)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`b994606`](https://github.com/ARPAHLS/skillware/commit/b994606) | fix(novelty_extractor): mock embeddings in bundle tests for offline CI | 13 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`5030981`](https://github.com/ARPAHLS/skillware/commit/5030981) | Feat/issue 24 novelty extractor (#116) | 25 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+<!-- skill-history:end -->

--- a/docs/skills/pdf_form_filler.md
+++ b/docs/skills/pdf_form_filler.md
@@ -2,6 +2,9 @@
 
 **ID**: `office/pdf_form_filler`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[office_pdf_form_filler]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -194,6 +197,34 @@ The skill returns a JSON object with the result of the operation.
 *   **LLM Dependency**: Requires an active internet connection and valid API key for the semantic mapping step.
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`office/pdf_form_filler`](https://github.com/ARPAHLS/skillware/tree/main/skills/office/pdf_form_filler)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `0.1.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`91bef48`](https://github.com/ARPAHLS/skillware/commit/91bef48) | docs: document manifest ID alignment and provider tool names (#201) | 1 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`673e227`](https://github.com/ARPAHLS/skillware/commit/673e227) | fix: align pdf_form_filler and evm_tx_handler manifest names with registry paths | 1 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e465dc4`](https://github.com/ARPAHLS/skillware/commit/e465dc4) | Fix skill path resolution and PyPI skill packaging. (#79) | 18 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`39487f8`](https://github.com/ARPAHLS/skillware/commit/39487f8) | Add generic API keys guide for skills requiring external calls. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`b6b8180`](https://github.com/ARPAHLS/skillware/commit/b6b8180) | feat: Make Skillware pip-installable and add release workflow (closes #7) | 15 Feb 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`3838724`](https://github.com/ARPAHLS/skillware/commit/3838724) | feat: Add automated testing and strict linting (closes #8) | 15 Feb 2026 | `—` | [@rosspeili](https://github.com/rosspeili) |
+| [`34e966c`](https://github.com/ARPAHLS/skillware/commit/34e966c) | feat(skills): add pdf_form_filler skill (Fixes #4) | 15 Feb 2026 | `—` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/pii_masker.md
+++ b/docs/skills/pii_masker.md
@@ -2,6 +2,9 @@
 
 **ID**: `compliance/pii_masker`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 20 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[compliance_pii_masker]"`. See [Install extras](../usage/install_extras.md).
 **Category**: Compliance
@@ -199,6 +202,29 @@ client = OpenAI(
 ```
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`compliance/pii_masker`](https://github.com/ARPAHLS/skillware/tree/main/skills/compliance/pii_masker)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`812ec7e`](https://github.com/ARPAHLS/skillware/commit/812ec7e) | Add card ui_schema validation guard and fix drift (#199) (#260) | 20 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`14807be`](https://github.com/ARPAHLS/skillware/commit/14807be) | style: format codebase with Black (#153) | 3 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`8b598bc`](https://github.com/ARPAHLS/skillware/commit/8b598bc) | feat(compliance): add pii_masker skill using micro-f1-mask | 9 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/prompt_injection_firewall.md
+++ b/docs/skills/prompt_injection_firewall.md
@@ -3,6 +3,9 @@
 **Domain:** `security`
 **Skill ID:** `security/prompt_injection_firewall`
 **Issuer:** [@mrmasa88](https://github.com/mrmasa88) (AO) · **Contact:** masa88keith@gmail.com
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 31 Jul 2026
+<!-- skill-doc-meta:end -->
 **Recommended install:** `pip install "skillware[security_prompt_injection_firewall]"`. See [Install extras](../usage/install_extras.md).
 
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -202,6 +205,16 @@ pytest skills/security/prompt_injection_firewall/test_skill.py
 ```
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`security/prompt_injection_firewall`](https://github.com/ARPAHLS/skillware/tree/main/skills/security/prompt_injection_firewall)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`1071c08`](https://github.com/ARPAHLS/skillware/commit/1071c08) | Add security/prompt_injection_firewall skill (#267) | 31 Jul 2026 | `0.1.0` | [@mrmasa88](https://github.com/mrmasa88) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/prompt_rewriter.md
+++ b/docs/skills/prompt_rewriter.md
@@ -3,6 +3,9 @@
 **Domain:** `optimization`
 **Skill ID:** `optimization/prompt_rewriter`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[optimization_prompt_rewriter]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -156,6 +159,31 @@ pytest tests/skills/optimization/test_prompt_rewriter.py
 ```
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`optimization/prompt_rewriter`](https://github.com/ARPAHLS/skillware/tree/main/skills/optimization/prompt_rewriter)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`14807be`](https://github.com/ARPAHLS/skillware/commit/14807be) | style: format codebase with Black (#153) | 3 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`5ea39b2`](https://github.com/ARPAHLS/skillware/commit/5ea39b2) | chore: Fix linting errors for CI | 23 Mar 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`84b7113`](https://github.com/ARPAHLS/skillware/commit/84b7113) | docs: remove redundant skill README and emphasize docs/skills/ documentation | 21 Mar 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`12a3f8f`](https://github.com/ARPAHLS/skillware/commit/12a3f8f) | feat: align prompt rewriter with skillware standards and fix lints | 21 Mar 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`c434341`](https://github.com/ARPAHLS/skillware/commit/c434341) | feat: add prompt rewriter skill and optimization category | 21 Mar 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/synthetic_generator.md
+++ b/docs/skills/synthetic_generator.md
@@ -3,6 +3,9 @@
 **Domain:** `data_engineering`
 **Skill ID:** `data_engineering/synthetic_generator`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[data_engineering_synthetic_generator]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -193,6 +196,32 @@ The skill constructs a response validating the pipeline and containing the raw s
 *   **Heuristic Entropy**: The `zlib` entropy score evaluates lexical byte-variance, not semantic variance. It serves as a guardrail against robotic boilerplate repetition but is not mathematically bulletproof.
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`data_engineering/synthetic_generator`](https://github.com/ARPAHLS/skillware/tree/main/skills/data_engineering/synthetic_generator)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`14807be`](https://github.com/ARPAHLS/skillware/commit/14807be) | style: format codebase with Black (#153) | 3 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`7ddedb2`](https://github.com/ARPAHLS/skillware/commit/7ddedb2) | feat: migrate from google-generativeai to google-genai SDK (#97) | 23 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e465dc4`](https://github.com/ARPAHLS/skillware/commit/e465dc4) | Fix skill path resolution and PyPI skill packaging. (#79) | 18 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`39487f8`](https://github.com/ARPAHLS/skillware/commit/39487f8) | Add generic API keys guide for skills requiring external calls. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`3ca49b6`](https://github.com/ARPAHLS/skillware/commit/3ca49b6) | chore: fix flake8 linting errors and bump version to 0.2.2 | 3 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`8f8a963`](https://github.com/ARPAHLS/skillware/commit/8f8a963) | feat: implement high-entropy synthetic data generator skill (Issue #22) | 3 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/token_limiter.md
+++ b/docs/skills/token_limiter.md
@@ -3,6 +3,9 @@
 **Domain:** `monitoring`
 **Skill ID:** `monitoring/token_limiter`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `1.0.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[monitoring_token_limiter]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -264,6 +267,19 @@ print(json.dumps(result, indent=2))
 - Turn cache is in-memory per skill instance; restart the process to clear all cache.
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`monitoring/token_limiter`](https://github.com/ARPAHLS/skillware/tree/main/skills/monitoring/token_limiter)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `1.0.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f959510`](https://github.com/ARPAHLS/skillware/commit/f959510) | feat(monitoring): add token_limiter skill for agent loop budgets (#207) | 30 Jun 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/tos_evaluator.md
+++ b/docs/skills/tos_evaluator.md
@@ -3,6 +3,9 @@
 **Domain:** `compliance`
 **Skill ID:** `compliance/tos_evaluator`
 **Issuer:** [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `0.1.0` — 16 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[compliance_tos_evaluator]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -211,6 +214,31 @@ pytest skills/compliance/tos_evaluator/test_skill.py
 ```
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`compliance/tos_evaluator`](https://github.com/ARPAHLS/skillware/tree/main/skills/compliance/tos_evaluator)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`14807be`](https://github.com/ARPAHLS/skillware/commit/14807be) | style: format codebase with Black (#153) | 3 Jun 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `0.1.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `0.1.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`7ddedb2`](https://github.com/ARPAHLS/skillware/commit/7ddedb2) | feat: migrate from google-generativeai to google-genai SDK (#97) | 23 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `0.1.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`d87b4ce`](https://github.com/ARPAHLS/skillware/commit/d87b4ce) | Add DeepSeek tool adapter and usage guide. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e931e5f`](https://github.com/ARPAHLS/skillware/commit/e931e5f) | Add OpenAI usage guide and reference example. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`39487f8`](https://github.com/ARPAHLS/skillware/commit/39487f8) | Add generic API keys guide for skills requiring external calls. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `0.1.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`50d088d`](https://github.com/ARPAHLS/skillware/commit/50d088d) | feat: add tos evaluator skill | 28 Apr 2026 | `0.1.0` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/uk_companies_house_handler.md
+++ b/docs/skills/uk_companies_house_handler.md
@@ -2,6 +2,9 @@
 
 **ID**: `finance/uk_companies_house_handler`
 **Issuer**: [@Areen-09](https://github.com/Areen-09) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `1.2.0` — 24 Aug 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[finance_uk_companies_house_handler]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -391,6 +394,21 @@ Prompt mode via `SkillLoader.to_ollama_prompt(bundle)`; match `"tool": "finance/
 - **Not legal advice**: Company information is provided as-is. This is not legal, accounting, or regulatory advice.
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`finance/uk_companies_house_handler`](https://github.com/ARPAHLS/skillware/tree/main/skills/finance/uk_companies_house_handler)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`01cd620`](https://github.com/ARPAHLS/skillware/commit/01cd620) | feat(uk_companies_house_handler): upgrade to v2b with pipeline orchestration and composites (#220) (#308) | 24 Aug 2026 | `1.2.0` | [@Areen-09](https://github.com/Areen-09), [@rosspeili](https://github.com/rosspeili) |
+| [`84cd790`](https://github.com/ARPAHLS/skillware/commit/84cd790) | feat: complete uk companies house handler v2a (#220) (#255) | 22 Jul 2026 | `1.1.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `1.0.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`8251e89`](https://github.com/ARPAHLS/skillware/commit/8251e89) | feat: add UK Companies House handler skill (#172) (#218) | 8 Jul 2026 | `1.0.0` | [@Areen-09](https://github.com/Areen-09) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/docs/skills/wallet_screening.md
+++ b/docs/skills/wallet_screening.md
@@ -2,6 +2,9 @@
 
 **ID**: `finance/wallet_screening`
 **Issuer**: [@rosspeili](https://github.com/rosspeili) ([@ARPAHLS](https://github.com/ARPAHLS))
+<!-- skill-doc-meta:begin -->
+**Version**: `1.0.1` — 23 Jul 2026
+<!-- skill-doc-meta:end -->
 
 **Recommended install:** `pip install "skillware[finance_wallet_screening]"`. See [Install extras](../usage/install_extras.md).
 [Skill Library](README.md) · [Testing](../TESTING.md)
@@ -244,6 +247,39 @@ The skill returns a rich forensic report. Agents act on this data. `metadata.war
 - **Not legal advice**: Risk flags are derived from open-source sanctions data and pattern heuristics. A clean result does not constitute legal clearance.
 
 ---
+
+<!-- skill-history:begin -->
+## Skill history
+
+Commits that touched this skill bundle or its catalog page ([`finance/wallet_screening`](https://github.com/ARPAHLS/skillware/tree/main/skills/finance/wallet_screening)).
+
+| Commit | Description | Date | Version | Contributors |
+| :--- | :--- | :--- | :--- | :--- |
+| [`0b308d3`](https://github.com/ARPAHLS/skillware/commit/0b308d3) | feat(wallet_screening): paginate Etherscan txlist and surface warnings (#214) (#215) | 23 Jul 2026 | `1.0.1` | [@Hendobox](https://github.com/Hendobox) |
+| [`bca8181`](https://github.com/ARPAHLS/skillware/commit/bca8181) | Add category and per-skill pip extras with manifest sync (#236). (#256) | 16 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f301088`](https://github.com/ARPAHLS/skillware/commit/f301088) | Implement manifest param validation and standardize outputs key. (#253) | 12 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`4814478`](https://github.com/ARPAHLS/skillware/commit/4814478) | Fix: to_gemini_tool to return types.Tool object. Fixes #223 (#229) | 10 Jul 2026 | `1.0.0` | [@Areen-09](https://github.com/Areen-09) |
+| [`0d550d0`](https://github.com/ARPAHLS/skillware/commit/0d550d0) | docs: sweep vision, bundle class usage, and README Mermaid | 8 Jul 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`a941a92`](https://github.com/ARPAHLS/skillware/commit/a941a92) | docs(wallet_screening): align examples and docs with finance/wallet_s… (#175) | 20 Jun 2026 | `1.0.0` | [@Akanksha-H](https://github.com/Akanksha-H) |
+| [`280ff40`](https://github.com/ARPAHLS/skillware/commit/280ff40) | fix(wallet_screening): address #165 review — bundle test, CHANGELOG, manifest name | 15 Jun 2026 | `1.0.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`904e18b`](https://github.com/ARPAHLS/skillware/commit/904e18b) | fix(wallet_screening): load manifest.yaml in skill.manifest property | 13 Jun 2026 | `1.0.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`0f81d1f`](https://github.com/ARPAHLS/skillware/commit/0f81d1f) | Backfill bundle tests for six registry skills missing test_skill.py. | 10 Jun 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`2c7c2b9`](https://github.com/ARPAHLS/skillware/commit/2c7c2b9) | feat(wallet_screening): unify TRM/scam tx risk index for analysis (#140) | 29 May 2026 | `1.0.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`5b68b78`](https://github.com/ARPAHLS/skillware/commit/5b68b78) | Feat/issue 93 cli visual redesign (#129) | 26 May 2026 | `1.0.0` | [@rizzoMartin](https://github.com/rizzoMartin) |
+| [`9f17292`](https://github.com/ARPAHLS/skillware/commit/9f17292) | feat(wallet_screening): FTM publicKey matching and ETH sanctions index (#128) | 26 May 2026 | `1.0.0` | [@Hendobox](https://github.com/Hendobox) |
+| [`52cce29`](https://github.com/ARPAHLS/skillware/commit/52cce29) | docs: clarify runnable examples across skill pages (#121) | 24 May 2026 | `1.0.0` | [@narutamaaurum](https://github.com/narutamaaurum) |
+| [`a3a7ac8`](https://github.com/ARPAHLS/skillware/commit/a3a7ac8) | docs: update Gemini snippets to google-genai (#92) | 23 May 2026 | `1.0.0` | [@kunal-9090](https://github.com/kunal-9090) |
+| [`cca7334`](https://github.com/ARPAHLS/skillware/commit/cca7334) | docs: skill docs revamp — remove emojis, add breadcrumbs, fix index, add missing sections (closes #52) (#82) | 21 May 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e465dc4`](https://github.com/ARPAHLS/skillware/commit/e465dc4) | Fix skill path resolution and PyPI skill packaging. (#79) | 18 May 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`5b18e21`](https://github.com/ARPAHLS/skillware/commit/5b18e21) | Document per-skill usage examples across providers. | 17 May 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`39487f8`](https://github.com/ARPAHLS/skillware/commit/39487f8) | Add generic API keys guide for skills requiring external calls. | 17 May 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`f800f41`](https://github.com/ARPAHLS/skillware/commit/f800f41) | Add skill issuer attribution across registry and docs. | 17 May 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`e658e7e`](https://github.com/ARPAHLS/skillware/commit/e658e7e) | docs: update enterprise disclaimer heading and scope to ARPA catalog skills only | 16 May 2026 | `1.0.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`891f5cc`](https://github.com/ARPAHLS/skillware/commit/891f5cc) | docs: add standard enterprise disclaimer to all skill documentation pages (#59) | 16 May 2026 | `1.0.0` | [@shaansatsangi](https://github.com/shaansatsangi) |
+| [`3838724`](https://github.com/ARPAHLS/skillware/commit/3838724) | feat: Add automated testing and strict linting (closes #8) | 15 Feb 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`6b2e357`](https://github.com/ARPAHLS/skillware/commit/6b2e357) | Refactor: Move skills and templates to root to decouple content from framework | 23 Jan 2026 | `1.0.0` | [@rosspeili](https://github.com/rosspeili) |
+| [`cc327c8`](https://github.com/ARPAHLS/skillware/commit/cc327c8) | Initial commit: Skillware Framework v1.0 | 20 Jan 2026 | `—` | [@rosspeili](https://github.com/rosspeili) |
+<!-- skill-history:end -->
 
 ## Enterprise disclaimer
 

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -11,8 +11,8 @@ Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from 
 5. **`instructions.md`**: Tell the agent when and how to use the tool.
 6. **`card.json`**: Mirror `issuer` from the manifest; customize UI fields.
 7. **`test_skill.py`**: Bundle test (required; enforced by `tests/test_skill_issuer.py`); offline, mock external services, including HTTP clients, LLM APIs, embedding/model loaders, and any first-run model downloads; run `pytest skills/<category>/<skill_name>/test_skill.py` or `skillware test <category>/<skill_name>`. See [TESTING.md](../../docs/TESTING.md).
-8. **`docs/skills/<skill_name>.md`**: Catalog page with **ID**, **Issuer**, **Recommended install** (`pip install "skillware[<category>_<skill>]"`), and **Usage Examples** (all providers; see `docs/usage/skill_usage_template.md`).
-9. **`docs/skills/README.md`**: Add a row to the skill library table.
+8. **`docs/skills/<skill_name>.md`**: Catalog page with **ID**, **Issuer**, **Version**, **Recommended install** (`pip install "skillware[<category>_<skill>]"`), **Usage Examples** (all providers; see `docs/usage/skill_usage_template.md`), and **Skill history** (linked GitHub contributors).
+9. **`docs/skills/README.md`**: Add a row (Skill, ID, **Version**, Issuer, Description).
 
 Do not commit template placeholders (`Your Name`, `you@example.com`, `YOUR ORG`, etc.) under `skills/`—only real issuer details belong in the registry.
 

--- a/tests/test_registry_docs.py
+++ b/tests/test_registry_docs.py
@@ -220,3 +220,38 @@ def test_catalog_pages_have_skill_specific_recommended_install(
     assert not missing, "Missing skill-specific recommended install:\n" + "\n".join(
         f"  - {item}" for item in missing
     )
+
+
+def test_catalog_pages_have_version_and_history_blocks(
+    manifested_skills: set[str],
+):
+    """Every catalog page exposes synced version metadata and skill history."""
+    docs_root = REPO_ROOT / "docs" / "skills"
+    missing = []
+
+    for skill_id in sorted(manifested_skills):
+        page = docs_root / f"{Path(skill_id).name}.md"
+        content = page.read_text(encoding="utf-8")
+        checks = [
+            ("<!-- skill-doc-meta:begin -->", "version metadata begin marker"),
+            ("**Version**:", "version header"),
+            ("<!-- skill-doc-meta:end -->", "version metadata end marker"),
+            ("<!-- skill-history:begin -->", "skill history begin marker"),
+            ("## Skill history", "skill history heading"),
+            ("<!-- skill-history:end -->", "skill history end marker"),
+        ]
+        for needle, label in checks:
+            if needle not in content:
+                missing.append(f"{page.name}: missing {label}")
+
+    assert not missing, "Missing skill version/history blocks:\n" + "\n".join(
+        f"  - {item}" for item in missing
+    )
+
+
+def test_skill_library_index_has_version_column():
+    """Skill library tables include a Version column with manifest values."""
+    readme = (REPO_ROOT / "docs" / "skills" / "README.md").read_text(encoding="utf-8")
+    assert "| Skill | ID | Version | Issuer | Description |" in readme
+    assert "| :--- | :--- | :--- | :--- | :--- |" in readme
+    assert "`1.2.0` (24 Aug 2026)" in readme  # spot-check latest merged skill


### PR DESCRIPTION
Adds **Version** metadata and **Skill history** tables to every skill catalog page, plus a **Version** column in the skill library index. History rows link commit SHAs and list contributors as GitHub usernames (`[@user](https://github.com/user)`), not display names.

Also updates contributor guidance (`CONTRIBUTING.md`, `ai_native_workflow.md`, `templates/python_skill/README.md`) and adds registry doc tests so version/history blocks stay present.

### Type of Change

- [ ] **New Skill**
- [ ] **Skill Upgrade**
- [ ] **Bug Fix**
- [x] **Documentation**
- [ ] **Framework Feature**
- [ ] **CLI**
- [ ] **Examples**
- [ ] **Packaging**
- [ ] **RFC / meta**

## Checklist (all PRs)

- [ ] Linked GitHub issue (`Fixes #…` or `Refs #…`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset)
- [x] `pytest skills/` and `pytest tests/` pass locally when relevant
- [x] `CHANGELOG.md` updated under `[Unreleased]` when user-visible behavior changes
- [x] `examples/README.md` updated if this PR adds, renames, or removes a runnable script *(N/A)*
- [x] Ran `pytest tests/test_registry_docs.py` when skills, examples index, or agent-loops matrix changed