### PR TITLE
fix(tests): isolate test suite from global skillware config (#302)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,15 @@ def mock_skill_loader():
     """Mocks the SkillLoader to return a dummy skill bundle."""
     # This might not be needed if we import the class directly, but good to have.
     return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def isolate_skillware_config(tmp_path_factory, monkeypatch):
+    """Isolate tests from any real global config.yaml on the developer's machine."""
+    from skillware.core.config import GLOBAL_CONFIG_DIR_ENV, clear_config_cache
+
+    isolated_dir = tmp_path_factory.mktemp("isolated_skillware_config")
+    monkeypatch.setenv(GLOBAL_CONFIG_DIR_ENV, str(isolated_dir))
+    clear_config_cache()
+    yield
+    clear_config_cache()


### PR DESCRIPTION
## Description
Fixes #302.

### Root Cause
When an operator initializes or configures Skillware locally (e.g., running `skillware mail signature init`), a global `config.yaml` is written to the user's config directory. When this file exists, `get_skill_roots()` switches to configured mode (`project` -> `external` -> `bundled`), causing tests that verify legacy resolution order (`test_get_skill_roots_order_env_project_bundled` and `test_resolve_skill_prefers_env_over_cwd`) to fail on developer machines.

### Solution
- Added an `autouse=True` fixture `isolate_skillware_config` in `tests/conftest.py` that points `SKILLWARE_CONFIG_DIR` (`GLOBAL_CONFIG_DIR_ENV`) to an isolated temporary directory for every test and clears the configuration cache before and after test execution.
- Tests that explicitly mock or test custom config layers can continue to set `GLOBAL_CONFIG_DIR_ENV` or provide their own config files without conflict.

### Verification
- Verified with simulated global `config.yaml`: both `test_get_skill_roots_order_env_project_bundled` and `test_resolve_skill_prefers_env_over_cwd` pass.
- Ran full test suite: 245 passed.
- Lint check: `flake8 tests/conftest.py` passed cleanly.