### PR TITLE
fix: isolate discovery tests from merged global config (isolate pytest from config.yaml)

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -39,6 +39,10 @@ def test_get_skill_roots_order_env_project_bundled(tmp_path, monkeypatch):
     project_root.mkdir(parents=True)
     monkeypatch.chdir(tmp_path / "project")
     monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, str(env_root))
+    # Isolate from any operator-level global config.yaml so the legacy
+    # skill-root order (env -> cwd project -> bundled) is asserted
+    # deterministically, regardless of the developer's machine state.
+    monkeypatch.setenv("SKILLWARE_CONFIG_DIR", str(tmp_path / "no-global-config"))
 
     roots = get_skill_roots()
     tiers = [root.tier for root in roots]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -394,6 +394,10 @@ def test_resolve_skill_prefers_env_over_cwd(tmp_path, monkeypatch):
 
     monkeypatch.setenv(SKILLWARE_SKILL_PATH_ENV, str(env_root))
     monkeypatch.chdir(tmp_path)
+    # Isolate from any operator-level global config.yaml so the legacy
+    # env-over-cwd resolution is asserted deterministically, regardless of
+    # the developer's machine state (see #302).
+    monkeypatch.setenv("SKILLWARE_CONFIG_DIR", str(tmp_path / "no-global-config"))
     bundle = SkillLoader.load_skill("shared_id")
     assert bundle["manifest"]["name"] == "from_env"
 


### PR DESCRIPTION
## Summary

Fixes the two framework tests that fail with **458 pass / 2 fail** after an operator runs `skillware mail signature init` (which writes a user-level `config.yaml`). Since #246, when global config exists, discovery uses the configured resolution order (project → external → bundled), which contradicts the legacy-mode assertions in:

- `tests/test_discovery.py::test_get_skill_roots_order_env_project_bundled`
- `tests/test_loader.py::test_resolve_skill_prefers_env_over_cwd`

## Fix

Both tests now set `SKILLWARE_CONFIG_DIR` to an empty temp directory via `monkeypatch`, isolating the test run from any operator-level global `config.yaml`. The legacy-order assertions then hold deterministically regardless of the developer's machine state. CI stays green on clean homes; local runs after `mail signature init` are now green too.

## Changes

- `tests/test_discovery.py`: added `monkeypatch.setenv("SKILLWARE_CONFIG_DIR", ...)` isolation
- `tests/test_loader.py`: same isolation

## Acceptance criteria

- [x] `python -m pytest tests/test_discovery.py::test_get_skill_roots_order_env_project_bundled tests/test_loader.py::test_resolve_skill_prefers_env_over_cwd -q` passes even with a global `config.yaml` present
- [x] Test isolation only; no runtime behavior change