### PR TITLE
feat(validation): add frontmatter schema validator and standalone test suite

### DIFF
--- a/skillware/version_policy.py
+++ b/skillware/version_policy.py
@@ -45,6 +45,19 @@ def format_unsupported_message(installed: Version) -> str:
     )
 
 
+def validate_frontmatter_dict(data: dict) -> tuple[bool, str]:
+    """Validate skill instructions frontmatter dictionary."""
+    if not isinstance(data, dict):
+        return False, "Frontmatter must be a key-value mapping"
+    name = data.get("name")
+    if not name or not isinstance(name, str) or not name.strip():
+        return False, "Missing or empty 'name' field"
+    desc = data.get("description")
+    if not desc or not isinstance(desc, str) or not desc.strip():
+        return False, "Missing or empty 'description' field"
+    return True, ""
+
+
 def emit_upgrade_advisory() -> None:
     """Print one dim stderr advisory for unsupported CLI installs; otherwise silent."""
     if is_version_check_disabled():

--- a/tests/test_version_and_manifest.py
+++ b/tests/test_version_and_manifest.py
@@ -33,4 +33,3 @@ class TestVersionAndManifest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_version_and_manifest.py
+++ b/tests/test_version_and_manifest.py
@@ -20,7 +20,9 @@ class TestVersionAndManifest(unittest.TestCase):
         self.assertIn("Upgrade to >=", msg)
 
     def test_validate_frontmatter_dict(self):
-        valid, err = validate_frontmatter_dict({"name": "test-skill", "description": "A test skill"})
+        valid, err = validate_frontmatter_dict(
+            {"name": "test-skill", "description": "A test skill"}
+        )
         self.assertTrue(valid)
         self.assertEqual(err, "")
 
@@ -29,5 +31,6 @@ class TestVersionAndManifest(unittest.TestCase):
         self.assertIn("name", err)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_version_and_manifest.py
+++ b/tests/test_version_and_manifest.py
@@ -1,0 +1,33 @@
+import unittest
+from packaging.version import Version
+from skillware.version_policy import (
+    should_emit_unsupported_advisory,
+    format_unsupported_message,
+    validate_frontmatter_dict,
+    MIN_UNSUPPORTED,
+)
+
+
+class TestVersionAndManifest(unittest.TestCase):
+    def test_should_emit_unsupported_advisory(self):
+        self.assertTrue(should_emit_unsupported_advisory(Version("0.3.0")))
+        self.assertFalse(should_emit_unsupported_advisory(MIN_UNSUPPORTED))
+        self.assertFalse(should_emit_unsupported_advisory(Version("0.4.7")))
+
+    def test_format_unsupported_message(self):
+        msg = format_unsupported_message(Version("0.3.0"))
+        self.assertIn("0.3.0", msg)
+        self.assertIn("Upgrade to >=", msg)
+
+    def test_validate_frontmatter_dict(self):
+        valid, err = validate_frontmatter_dict({"name": "test-skill", "description": "A test skill"})
+        self.assertTrue(valid)
+        self.assertEqual(err, "")
+
+        invalid, err = validate_frontmatter_dict({"name": "", "description": "desc"})
+        self.assertFalse(invalid)
+        self.assertIn("name", err)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary
- Added alidate_frontmatter_dict in skillware/version_policy.py to validate required metadata fields (
ame, description).
- Added standalone unit test suite in 	ests/test_version_and_manifest.py.

Closes #320, closes #321, closes #322.