### PR TITLE
Rosspeili/fix 326 readme narrative refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 ### Changed
 
 - **Docs (`README.md`, `docs/introduction.md`):** Refresh opening narrative, tighten Quick Start, shorten Gemini hero example (`monitoring/token_limiter`), rectangular How it works Mermaid, simplify introduction diagrams, remove legacy Body/Mind/Conscience aliases, and align Presentation (`card.json`) with registry bundle standard (#326).
+- **Security:** Bump support windows — `>= 0.5.3` patched, `0.4.6–0.5.2` silent (no security fixes), `< 0.4.6` unsupported with CLI advisory (`SECURITY.md`, `version_policy.py`).
 - **Docs:** Document `issuer.org` design-ownership policy; align ARPA-driven registry skills (`prompt_injection_firewall`, `bg_remover`, `novelty_extractor`) and catalog Issuer lines (#295).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
-- **Docs:** Adopt **Skill anatomy** (Contract, Effect, Directive, Assurance, Corpus, Reference, Presentation, Interface) across introduction, README Mission, CONTRIBUTING, provider guides, catalog pages, and contributor templates (#319).
+- **Docs (`README.md`, `docs/introduction.md`):** Refresh opening narrative, tighten Quick Start, shorten Gemini hero example (`monitoring/token_limiter`), rectangular How it works Mermaid, simplify introduction diagrams, remove legacy Body/Mind/Conscience aliases, and align Presentation (`card.json`) with registry bundle standard (#326).
 - **Docs:** Document `issuer.org` design-ownership policy; align ARPA-driven registry skills (`prompt_injection_firewall`, `bg_remover`, `novelty_extractor`) and catalog Issuer lines (#295).
 
 ### Fixed
 
-- **Docs (`README.md`):** Fix How it works Mermaid — use stadium node `([Any Host])` for the third block (rectangle `[Any Host]` breaks rendering; same pattern as pre-#319 `([Logical Systems])`).
+- **Docs (`README.md`, `docs/introduction.md`):** How it works Mermaid — rectangular `AnyHost["Any Host"]` node aligned with Registry and Loader blocks (#326).
 - **Tests:** Isolate `pytest tests/` from the operator's global `config.yaml` via autouse `SKILLWARE_CONFIG_DIR` in `tests/conftest.py`; add configured-mode discovery and loader coverage alongside legacy-order tests (#302).
 
 ## [0.5.2] - 2026-08-27

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ Checklists below use **file names**; each file implements a **role**. The [READM
 | **Effect** | `skill.py` (+ effect modules in the same folder) | Yes |
 | **Directive** | `instructions.md` | Yes |
 | **Assurance** | `test_skill.py` | Yes (registry) |
-| **Presentation** | `card.json` | Optional |
+| **Presentation** | `card.json` | Recommended |
 | **Corpus** | `kb/`, `data/`, bundled knowledge files | Optional |
 | **Reference** | `schemas/`, maps, in-bundle spec fixtures | Optional |
 | **Interface** | `skillware/core/loader.py` adapters | Framework (not in bundle) |
@@ -302,7 +302,7 @@ The primary guide for the host LLM. Skill instructions should be a concise, appe
 
 ### 4. `card.json` (Presentation)
 
-- Optional but recommended for user-facing agents and catalog UIs.
+- Recommended for every registry skill; all bundled skills under `skills/` ship one.
 - Describes UI presentation (`name`, `description`, `icon`, `ui_schema`, and similar).
 - When present, include an `issuer` object that matches `manifest.yaml` (`name` and `email` at minimum; copy `github` and `org` when used).
 - For output cards (`ui_schema.type` = `card`), each `ui_schema.fields[].key` must be a dot path into the JSON returned by `execute()` (for example `metadata.wallet_address`, `preview.you_pay`). Update `card.json` in the same PR when you change the output shape.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@
 
 ---
 
-**Skillware** is an open-source framework and registry for modular, actionable Agent capabilities. It treats **Skills** as installable content, decoupling capability from intelligence. Just as `apt-get` installs software and `pip` installs libraries, `skillware` installs *know-how* for AI agents.
+**Skillware** is an open-source framework and registry for modular, actionable Agent capabilities. It installs know-how for AI agents — modular **Skills** (code, contract, and host guidance) that decouple capability from the model. Don't prompt your agents — equip them.
 
 > "I know Kung Fu." - Neo
 
 ## Mission
 
-The AI ecosystem is fragmented. Developers often re-invent tool definitions, system prompts, and safety rules for every project. **Skillware** supplies a standard to package capabilities into self-contained, installable units that work across **Gemini**, **Claude**, **Ollama**, **GPT**, and **Llama**. For the full story and roadmap, see our **[Vision](docs/vision.md)**.
+Every new agent stack tends to reinvent tool schemas, system prompts, and safety rules. **Skillware** packages each capability as a self-contained bundle and adapts it to **Gemini**, **Claude**, **OpenAI**, **Ollama**, and other OpenAI-compatible hosts. For the full story and roadmap, see **[Vision](docs/vision.md)**.
 
 A **Skill** in this framework provides everything an Agent needs to master a domain:
 
@@ -47,7 +47,7 @@ A **Skill** in this framework provides everything an Agent needs to master a dom
 4. **Assurance**: Offline tests that Effect honors Contract before a skill joins the registry.
 5. **Interface**: Standardized tool schemas for any LLM or agent runtime.
 
-Optional **Corpus**, **Reference**, and **Presentation** assets extend bundles when needed. Full reference: [Introduction — Skill anatomy](docs/introduction.md#skill-anatomy).
+Optional **Corpus** and **Reference** assets extend bundles when needed. Every bundled registry skill also ships **Presentation** (`card.json`) for catalog and UI metadata. Full reference: [Introduction — Skill anatomy](docs/introduction.md#skill-anatomy).
 
 ### Skill library
 
@@ -58,10 +58,10 @@ Browse capabilities by category in the [Skill library](docs/skills/README.md) or
 ```mermaid
 flowchart LR
     Registry[Registry] -->|Load| Loader[Loader]
-    Loader -->|Adapt| AnyHost([Any Host])
+    Loader -->|Adapt| AnyHost["Any Host"]
 ```
 
-Install the registry once. Skillware loads a bundle, adapts it to your host's tool format, and your app runs the agent loop (Gemini, Claude, Ollama, custom scripts, …). For details on how the loader turns the manifest into a tool, see the [Introduction](docs/introduction.md).
+Install the registry once. Skillware loads a bundle, adapts it to your host's tool format, and your app runs the agent loop (Gemini, Claude, Ollama, custom scripts, …). See the [Introduction](docs/introduction.md) for loader details and [Agent loops](docs/usage/agent_loops.md) for the execution pattern.
 
 ## Architecture
 
@@ -79,7 +79,7 @@ Skillware/
 │           ├── manifest.yaml   # Contract: schema, constitution, issuer
 │           ├── skill.py        # Effect: deterministic execution
 │           ├── instructions.md # Directive: host guidance
-│           ├── card.json       # Presentation (optional)
+│           ├── card.json       # Presentation: catalog / UI metadata
 │           └── test_skill.py   # Assurance (required for registry skills)
 ├── skillware/                  # Core Framework Package
 │   ├── cli.py                  # Command-line interface
@@ -125,20 +125,9 @@ skillware list
 skillware paths
 ```
 
-This prints a table of all locally available skills and confirms the install
-and path resolution are working. `skillware paths` shows the **live** root order
-the loader uses (legacy without config: external → project → bundled; with
-`.skillware.yaml` or global config: project → external → bundled by default),
-tier labels, and shadowing. **Bundled registry skills from `pip install skillware`
-are always available** — an empty or missing local `skills/` folder does not
-disable them. Running `skillware` with no arguments opens the interactive menu.
-As optional checks you can also run `skillware test` to execute bundle tests,
-and `skillware examples` to browse the runnable example index (fetched from
-GitHub when no local `examples/README.md` is present).
+You should see a table of bundled registry skills and a paths summary confirming install and discovery. **Bundled skills from `pip install skillware` are always available** — an empty local `skills/` folder does not disable them.
 
-If `skillware` is not recognized, Python's `Scripts` directory may not be on
-your PATH — use `python -m skillware list` as a fallback. See
-[CLI Reference](docs/usage/cli.md#running-the-cli) for details.
+For path tiers, shadowing, config files, and the interactive menu, see [CLI — paths & tiers](docs/usage/cli.md#skillware-paths), [CLI — config](docs/usage/cli.md#skillware-config), and [Finding skills on disk](docs/usage/README.md#finding-skills-on-disk). If `skillware` is not on your PATH, use `python -m skillware list` ([CLI Reference](docs/usage/cli.md#running-the-cli)).
 
 ### 3. Configuration
 
@@ -164,66 +153,38 @@ Edit `.env` with agent keys (for example Gemini) and any keys your skills need. 
 
 ### 4. Usage Example (Gemini)
 
-This example requires the Google SDK optional extra: `pip install "skillware[gemini]"` (local dev: `pip install -e ".[gemini]"`). See the [Gemini usage guide](docs/usage/gemini.md) for setup details.
+Requires `pip install "skillware[gemini]"` (dev: `pip install -e ".[gemini]"`) and `GOOGLE_API_KEY`. The skill itself is offline — no skill API keys. For setup details see [Gemini usage guide](docs/usage/gemini.md). Multi-turn loops: [Agent loops](docs/usage/agent_loops.md).
 
 ```python
-import os
 import google.genai as genai
 from google.genai import types
 from skillware.core.loader import SkillLoader
-from skillware.core.env import load_env_file
 
-# Load Environment
-load_env_file()
+bundle = SkillLoader.load_skill("monitoring/token_limiter")
+skill = bundle["class"]()
+tool = SkillLoader.to_gemini_tool(bundle)
 
-# 1. Load the Skill from the Registry
-# The loader reads the code, manifest, and instructions automatically
-skill_bundle = SkillLoader.load_skill("finance/wallet_screening")
-skill = skill_bundle["class"](
-    config={"ETHERSCAN_API_KEY": os.environ.get("ETHERSCAN_API_KEY")}
-)
-# Or: skill = skill_bundle["module"].WalletScreeningSkill(config={...})
-
-# 2. Client & Tool Setup
 client = genai.Client()
-tool = SkillLoader.to_gemini_tool(skill_bundle)       # The "Adapter"
-system_instruction = skill_bundle['instructions']     # Directive
-
-# 3. Agent Loop
 response = client.models.generate_content(
     model="gemini-2.5-flash",
-    contents="Screen wallet 0xd8dA... for risks.",
+    contents=(
+        "Check token budget for task_id demo_run: "
+        "current_token_count 95000, max_allowed_tokens 100000."
+    ),
     config=types.GenerateContentConfig(
         tools=[tool],
-        system_instruction=system_instruction,
+        system_instruction=bundle["instructions"],
     ),
 )
 
 for part in response.candidates[0].content.parts:
     if part.function_call:
-        result = skill.execute(dict(part.function_call.args))
-        follow_up = client.models.generate_content(
-            model="gemini-2.5-flash",
-            contents=[
-                "Use this tool result to answer the original request.",
-                {
-                    "function_response": {
-                        "name": part.function_call.name,
-                        "response": {"result": result},
-                    }
-                },
-            ],
-            config=types.GenerateContentConfig(
-                tools=[tool],
-                system_instruction=system_instruction,
-            ),
-        )
-        print(follow_up.text)
+        print(skill.execute(dict(part.function_call.args)))
     else:
         print(part.text)
 ```
 
-For other providers and shared integration patterns, see the [usage guides index](docs/usage/README.md), [agent loops](docs/usage/agent_loops.md), [Gemini](docs/usage/gemini.md), [Claude](docs/usage/claude.md), [OpenAI](docs/usage/openai.md), [OpenAI-compatible hosts](docs/usage/openai_compatible.md), [DeepSeek](docs/usage/deepseek.md), [Ollama](docs/usage/ollama.md), [API keys for skills](docs/usage/api_keys.md), and the [skill usage template](docs/usage/skill_usage_template.md) for contributors.
+For other providers and integration patterns, see the [usage guides](docs/usage/README.md).
 
 ## Documentation
 
@@ -236,11 +197,7 @@ For other providers and shared integration patterns, see the [usage guides index
 
 ## Contributing
 
-We are building the "App Store" for Agents. Skills are the main contribution, but documentation, tests, and framework fixes are welcome too. Human operators and supervised agents follow the same standards: scoped PRs, deterministic behavior, and verified tests.
-
-Start with [Contributing](CONTRIBUTING.md) (types, skill standard, PR process), [Agent Native Workflow](docs/contributing/ai_native_workflow.md) (for autonomous and semi-autonomous agents), [Testing](docs/TESTING.md) (Black, Flake8, framework and skill pytest, pre-PR checklist), and [Changelog](CHANGELOG.md) (user-facing entries under `[Unreleased]`).
-
-Also read the [Agent Code of Conduct](CODE_OF_CONDUCT.md). Open PRs with the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) and complete only the sections that apply.
+Skills, docs, tests, and framework fixes are welcome. Start with [Contributing](CONTRIBUTING.md), [Agent Native Workflow](docs/contributing/ai_native_workflow.md), and [Testing](docs/TESTING.md). See the [Agent Code of Conduct](CODE_OF_CONDUCT.md). Open PRs with the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Comparison
 
@@ -258,7 +215,7 @@ Skillware differs from the Model Context Protocol (MCP), and Agent Skills (SKILL
 <a href="https://pypistats.org/packages/skillware"><img src="https://img.shields.io/badge/Stats-PyPiStats-ffdac1?style=flat-square" alt="PyPI Stats dashboard"></a>
 <a href="https://pepy.tech/projects/skillware"><img src="https://img.shields.io/pepy/dt/skillware?style=flat-square&label=DLs%20%E2%86%93%20total&color=bbf7d0" alt="Total downloads (PePy)"></a>
 
-PyPI download counts show how often `skillware` is installed from the package index. Numbers come from public third-party aggregators, and they include CI and mirror traffic, so they measure **install activity**, not unique users. Totals may differ slightly between services because each source uses its own window and methodology. Use the stats dashboards in the above badges for charts, version breakdowns, and longer history.
+PyPI download counts measure **install activity** from public aggregators (including CI and mirrors), not unique users. Use the badge links above for charts and version breakdowns.
 
 ## Citing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Use a current Skillware release to receive security fixes. We patch vulnerabilit
 
 | Installed version | Security support | CLI advisory |
 | :--- | :--- | :--- |
-| **>= 0.4.7** | Supported. Security reports accepted and patched here. | Silent |
-| **0.3.5 – 0.4.6** | No security fixes. Upgrade recommended. | Silent |
-| **< 0.3.5** (e.g. 0.3.4, 0.2.9) | Unsupported. | One dim stderr message at CLI startup (in releases that ship this check) |
+| **>= 0.5.3** | Supported. Security reports accepted and patched here. | Silent |
+| **0.4.6 – 0.5.2** | No security fixes. Upgrade recommended. | Silent |
+| **< 0.4.6** (e.g. 0.4.5, 0.3.4) | Unsupported. | One dim stderr message at CLI startup (in releases that ship this check) |
 
 Thresholds are defined in `skillware/version_policy.py` (`MIN_SECURITY_SUPPORTED`, `MIN_UNSUPPORTED`) and bumped by maintainers when support windows change.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,12 +1,10 @@
 # Deep Dive: The Skillware Philosophy
 
-**Skillware** is an Operating System for Agentic Capabilities. It was born from the realization that current agent frameworks (LangChain, AutoGPT) couple *intelligence* (the model) too tightly with *capability* (the tool).
-
-If you want your agent to "know" how to analyze a balance sheet, you shouldn't have to prompt-engineer a specific model or write a custom tool definition for that specific model's API. You should be able to **install** that capability.
+**Skillware** is an Operating System for Agentic Capabilities. It decouples *intelligence* (the model) from *capability* (the tool): you **install** know-how instead of redefining it for every host.
 
 ## Skill anatomy
 
-Every registry skill is a folder of **roles** implemented by fixed filenames in v0. The [README Mission](../README.md#mission) summarizes the core roles; optional assets and the full reference are below. Filenames stay unchanged.
+Every registry skill is a folder of **roles** implemented by fixed filenames. The [README Mission](../README.md#mission) summarizes the core roles; the full reference is below. Filenames stay unchanged.
 
 ### Grouping
 
@@ -17,15 +15,15 @@ CAPABILITY (what the host unlocks)
 └── Directive     instructions.md
 
 REGISTRY (required to merge)
-└── Assurance      test_skill.py
+├── Assurance     test_skill.py
+└── Presentation  card.json
 
 OPTIONAL ASSETS
-├── Corpus         kb/, data/, bundled knowledge files
-├── Reference      schemas/, maps, in-bundle spec fixtures
-└── Presentation   card.json
+├── Corpus        kb/, data/, bundled knowledge files
+└── Reference     schemas/, maps, in-bundle spec fixtures
 
 FRAMEWORK (outside the bundle folder)
-└── Interface      SkillLoader model adapters (to_gemini_tool, …)
+└── Interface     SkillLoader model adapters (to_gemini_tool, …)
 ```
 
 ### Role reference
@@ -36,9 +34,9 @@ FRAMEWORK (outside the bundle folder)
 | **Effect** | `skill.py` | What runs deterministically when invoked? (`BaseSkill.execute()`) |
 | **Directive** | `instructions.md` | How should the host use this capability? When, how to read outputs, limits |
 | **Assurance** | `test_skill.py` | Does Effect honor Contract? (offline bundle tests; CI / `skillware test`) |
+| **Presentation** | `card.json` | Catalog and UI card metadata; issuer must match Contract when present |
 | **Corpus** | `kb/`, `data/`, … | Static knowledge Effect reads (not fetched at runtime) |
 | **Reference** | `schemas/`, maps | Machine-readable adjuncts to Contract (validators, terminology) |
-| **Presentation** | `card.json` | Optional catalog / UI card metadata |
 | **Interface** | `skillware/core/loader.py` | Adapters that expose Contract to a host API |
 
 **Effect modules** — co-located Python imported by `skill.py` (for example `workflow.py`, `budget.py`). Part of Effect implementation, not separate bundle roles.
@@ -47,13 +45,13 @@ FRAMEWORK (outside the bundle folder)
 
 **Constitution vs directive** — hard limits and registry identity live in **Contract** (`manifest.yaml`). Operational playbook for the host lives in **Directive** (`instructions.md`). Both constrain behavior; different consumers.
 
-Legacy narrative aliases (**Body** = Effect, **Mind** = Directive, **Conscience** = Contract) may appear in older prose; prefer the role names above in new docs. Planned for removal in a later cleanup pass.
+**Presentation** — `card.json` is part of the standard registry bundle (every skill under `skills/` ships one). CI validates issuer parity and UI schema keys when a card is present; see [CONTRIBUTING](../CONTRIBUTING.md#4-cardjson-presentation).
 
 ---
 
 ## The Architecture: How It Works
 
-Skillware relies on a strict, modular layout. Instead of hardcoding tools into your primary application, you maintain a structured registry of capabilities grouped by domain folders under `skills/` (see [Skill categories](../CONTRIBUTING.md#skill-categories) when contributing):
+Skillware relies on a strict, modular layout. Capabilities live under `skills/` grouped by domain (see [Skill categories](../CONTRIBUTING.md#skill-categories)):
 
 ```text
 Skillware/
@@ -61,12 +59,12 @@ Skillware/
 │   └── category/                   # Domain boundary (e.g., 'finance')
 │       └── skill_name/             # A self-contained capability bundle
 │           ├── manifest.yaml       # Contract
-│           ├── skill.py              # Effect (entry)
-│           ├── instructions.md       # Directive
-│           ├── card.json             # Presentation (optional)
-│           ├── test_skill.py         # Assurance
-│           ├── kb/ or data/          # Corpus (optional)
-│           └── schemas/              # Reference (optional)
+│           ├── skill.py            # Effect (entry)
+│           ├── instructions.md     # Directive
+│           ├── card.json           # Presentation
+│           ├── test_skill.py       # Assurance
+│           ├── kb/ or data/        # Corpus (optional)
+│           └── schemas/            # Reference (optional)
 └── skillware/
     └── core/
         ├── base_skill.py           # Effect interface (`BaseSkill`)
@@ -75,36 +73,14 @@ Skillware/
 ```
 
 ```mermaid
-flowchart TD
-    subgraph Bundle["Skill Bundle Folder"]
-        Manifest[manifest.yaml]
-        Instructions[instructions.md]
-        SkillPy[skill.py]
-    end
-
-    Loader[SkillLoader] -->|Loads| Bundle
-    Loader --> Adapters
-
-    subgraph Adapters["Interface — model adapters"]
-        direction LR
-        API[API models]
-        Local[Local models]
-    end
-
-    Host[Host App] -.->|Directly calls execute| SkillPy
-
-    style Host stroke-width:2px,stroke-dasharray: 5 5
+flowchart LR
+    Registry[Registry] -->|Load| Loader[SkillLoader]
+    Loader -->|Adapt| Host["Any Host"]
 ```
 
-A skill is a folder on disk. The loader turns the manifest into whatever tool schema your runtime expects. For the high-level picture, see [How it works](../README.md#how-it-works); for the code loop that hooks these adapters up, see [Agent Loops](usage/agent_loops.md).
+A skill is a folder on disk. The loader reads Contract and Directive, exposes **Interface** adapters, and your host runs the loop. See [How it works](../README.md#how-it-works) and [Agent Loops](usage/agent_loops.md).
 
-When you run `SkillLoader.load_skill("category/skill_name")`, a complex orchestration happens behind the scenes:
-
-### Step 1: Discovery & Loading
-The loader resolves `category/skill_name` to a skill directory by checking, in order: an existing path on disk, then configured skill roots (legacy without YAML: `SKILLWARE_SKILL_PATH` → cwd `skills/` walk → bundled; with `.skillware.yaml` or global config: `resolution.order`, default project → external → bundled, bundled always on). Missing local `skills/` directories are skipped — bundled registry skills remain available after `pip install skillware`. Run `skillware paths` and `skillware config show` for a live view. Each bundle is a directory containing `manifest.yaml` and `skill.py`.
-*   It dynamically imports the `skill.py` module and auto-discovers the single `BaseSkill` subclass as `bundle["class"]` (no hardcoded class names required).
-*   It parses the `manifest.yaml` (including `issuer` for attribution, separate from tool-calling fields). Registry skills set `name` to the full ID (`category/skill_name`), which Claude uses as the tool name; Gemini, OpenAI, and DeepSeek receive a sanitized variant (slashes → underscores). For registry-layout paths (`<skill_root>/<category>/<skill_name>/`), the loader warns when `name` does not match the folder path; flat private layouts (`<skill_root>/<skill_name>/`) skip this check. Loaded bundles expose `registry_id` when validation applies.
-*   It reads `instructions.md` and, when present, optional `card.json`.
+When you run `SkillLoader.load_skill("category/skill_name")`:
 
 ```mermaid
 flowchart LR
@@ -113,37 +89,40 @@ flowchart LR
     PACK --> ADAPT[adapt]
 ```
 
-For how skills are resolved on disk, the provenance tiers, and what to check before loading skills you did not write, see [Skill trust model & operator security](security/skill-trust-model.md).
+### Step 1: Discovery & Loading
+
+The loader resolves `category/skill_name` against configured skill roots (run `skillware paths` and `skillware config show` for the live order). Bundled registry skills remain available after `pip install skillware` even without a local `skills/` tree.
+
+- Dynamically imports `skill.py` and discovers the single `BaseSkill` subclass as `bundle["class"]`.
+- Parses `manifest.yaml` (including `issuer` for attribution).
+- Reads `instructions.md` and `card.json`.
+
+For provenance tiers and operator security, see [Skill trust model](security/skill-trust-model.md).
 
 ### Step 2: Adaptation (Interface)
-Every model (Gemini, Claude, GPT) expects a different tool-schema shape.
-*   **Gemini** wants `FunctionDeclaration` with Protobuf types (UPPERCASE).
-*   **Claude** wants `tool` definitions with JSON Schema input (lowercase).
-*   **OpenAI** wants a `tools` list.
 
-The `SkillLoader` acts as the **Interface** layer.
-*   `SkillLoader.to_gemini_tool(skill)` -> Transmutes the manifest into Gemini's format.
-*   `SkillLoader.to_claude_tool(skill)` -> Transmutes the manifest into Claude's format.
-*   `SkillLoader.to_openai_tool(skill)` -> Transmutes the manifest into OpenAI's tool format.
-*   `SkillLoader.to_deepseek_tool(skill)` -> Transmutes the manifest into DeepSeek's tool format.
-*   `SkillLoader.to_ollama_prompt(skill)` -> Textual tool description for Ollama prompt-based loops.
+Every model expects a different tool-schema shape. The **Interface** layer transmutes Contract into host formats:
+
+- `SkillLoader.to_gemini_tool(skill)` — Gemini `FunctionDeclaration`
+- `SkillLoader.to_claude_tool(skill)` — Claude tools + JSON Schema
+- `SkillLoader.to_openai_tool(skill)` — OpenAI Chat Completions tools
+- `SkillLoader.to_deepseek_tool(skill)` — DeepSeek-compatible tools
+- `SkillLoader.to_ollama_prompt(skill)` — textual tool block for Ollama loops
 
 ### Step 3: Directive injection
-Pass the skill's **`instructions.md`** (**Directive**) into the host system prompt (or equivalent). The model learns this skill's contract and limits—registry ID, when to invoke, how to interpret outputs—not a replacement host persona.
 
-This injection ensures the model isn't just *able* to call the tool, but is *guided* on using it correctly for the task.
+Pass **`instructions.md`** (**Directive**) into the host system prompt. The model learns when to invoke the skill, how to read outputs, and operational limits — not a replacement host persona.
 
 ---
 
 ## The Execution Loop
 
-1.  **User Query**: "Is wallet 0x123 safe?"
-2.  **Host reads Directive**: The LLM reads the injected `instructions.md` and realizes it should use the `finance/wallet_screening` tool.
-3.  **Tool Call**: The LLM outputs a structured tool call (e.g., JSON or Protobuf) via **Interface** adapters.
-4.  **Framework Execution**: Your script may validate tool arguments with `skill.validate_params(...)` before `execute()` (optional; recommended in agent loops). Direct integrations can call `skill.execute({"address": "0x123"})` without validation, as in many examples under `examples/`.
-5.  **Effect runs**: `skill.py` executes. It fetches Etherscan data, checks local JSON sanctions lists, and returns structured results.
-6.  **Structured Output**: `execute()` returns a JSON-serializable object.
-7.  **Synthesis**: The LLM receives the JSON. Guided again by **Directive**, it translates the data into a human-readable report.
+1.  **User Query**: "Should this agent loop stop — we're at 95k tokens?"
+2.  **Host reads Directive**: The model sees injected `instructions.md` and selects `monitoring/token_limiter`.
+3.  **Tool Call**: The model emits a structured tool call via **Interface** adapters.
+4.  **Framework Execution**: Your script may call `skill.validate_params(...)` before `execute()` (recommended in production loops).
+5.  **Effect runs**: `skill.py` evaluates the budget and returns structured JSON.
+6.  **Synthesis**: The model receives the result and explains the next step to the user.
 
 ## Model Agnosticism
 

--- a/skillware/version_policy.py
+++ b/skillware/version_policy.py
@@ -10,9 +10,9 @@ from typing import Optional
 from packaging.version import Version
 
 PACKAGE_NAME = "skillware"
-MIN_SECURITY_SUPPORTED = Version("0.4.7")
-MIN_UNSUPPORTED = Version("0.3.5")
-UPGRADE_TARGET = "0.4.7"
+MIN_SECURITY_SUPPORTED = Version("0.5.3")
+MIN_UNSUPPORTED = Version("0.4.6")
+UPGRADE_TARGET = "0.5.3"
 
 
 def is_version_check_disabled() -> bool:
@@ -34,7 +34,7 @@ def get_installed_version() -> Optional[Version]:
 
 
 def should_emit_unsupported_advisory(installed: Version) -> bool:
-    """True only for installs below MIN_UNSUPPORTED (e.g. 0.3.4 and earlier)."""
+    """True only for installs below MIN_UNSUPPORTED (e.g. 0.4.5 and earlier)."""
     return installed < MIN_UNSUPPORTED
 
 

--- a/templates/python_skill/README.md
+++ b/templates/python_skill/README.md
@@ -2,7 +2,7 @@
 
 Starter bundle under `skills/<category>/<skill_name>/`. Copy this template from `templates/python_skill/`, then replace every placeholder before opening a PR.
 
-Roles: [Skill anatomy](../../docs/introduction.md#skill-anatomy) — **Contract** (`manifest.yaml`), **Effect** (`skill.py`), **Directive** (`instructions.md`), **Assurance** (`test_skill.py`), optional **Presentation** (`card.json`).
+Roles: [Skill anatomy](../../docs/introduction.md#skill-anatomy) — **Contract** (`manifest.yaml`), **Effect** (`skill.py`), **Directive** (`instructions.md`), **Assurance** (`test_skill.py`), **Presentation** (`card.json`).
 
 ## Before you submit
 

--- a/tests/test_version_policy.py
+++ b/tests/test_version_policy.py
@@ -28,13 +28,13 @@ def test_get_installed_version_dev_returns_none(monkeypatch):
 
 
 def test_should_emit_only_below_min_unsupported():
+    assert version_policy.should_emit_unsupported_advisory(Version("0.4.5")) is True
     assert version_policy.should_emit_unsupported_advisory(Version("0.3.4")) is True
     assert version_policy.should_emit_unsupported_advisory(Version("0.2.9")) is True
-    assert version_policy.should_emit_unsupported_advisory(Version("0.2.5")) is True
-    assert version_policy.should_emit_unsupported_advisory(Version("0.3.5")) is False
-    assert version_policy.should_emit_unsupported_advisory(Version("0.4.0")) is False
     assert version_policy.should_emit_unsupported_advisory(Version("0.4.6")) is False
-    assert version_policy.should_emit_unsupported_advisory(Version("0.4.7")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.5.0")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.5.2")) is False
+    assert version_policy.should_emit_unsupported_advisory(Version("0.5.3")) is False
 
 
 def test_emit_advisory_silent_for_current_release(monkeypatch, capsys):
@@ -51,14 +51,14 @@ def test_emit_advisory_silent_for_security_supported_floor(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.4.7",
+        lambda _name: "0.5.3",
     )
     version_policy.emit_upgrade_advisory()
     assert capsys.readouterr().err == ""
 
 
 def test_emit_advisory_silent_for_outdated_but_supported_band(monkeypatch, capsys):
-    for version in ("0.3.5", "0.4.0", "0.4.6"):
+    for version in ("0.4.6", "0.5.0", "0.5.2"):
         monkeypatch.setattr(
             version_policy.metadata,
             "version",
@@ -72,13 +72,13 @@ def test_emit_advisory_warns_for_unsupported(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.3.4",
+        lambda _name: "0.4.5",
     )
     version_policy.emit_upgrade_advisory()
     err = capsys.readouterr().err
-    assert "0.3.4" in err
+    assert "0.4.5" in err
     assert "unsupported" in err.lower()
-    assert ">=0.4.7" in err
+    assert ">=0.5.3" in err
 
 
 def test_emit_advisory_respects_opt_out(monkeypatch, capsys):
@@ -86,7 +86,7 @@ def test_emit_advisory_respects_opt_out(monkeypatch, capsys):
     monkeypatch.setattr(
         version_policy.metadata,
         "version",
-        lambda _name: "0.3.4",
+        lambda _name: "0.4.5",
     )
     version_policy.emit_upgrade_advisory()
     assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Description

Refresh README and introduction narrative for scannability and site voice, align Presentation (`card.json`) docs with registry practice, and bump security support windows to **0.5.3** as the patched baseline.

Fixes #326

| Acceptance criterion | Where |
| :--- | :--- |
| Opening hook ≤2 sentences + tagline | `README.md` |
| Mission ≤3 sentences; non-redundant providers | `README.md` |
| Quick Start §2 ≤120 words + doc links | `README.md` |
| Gemini hero ≤25 lines (`token_limiter`) | `README.md` |
| Rectangular How it works Mermaid | `README.md`, `docs/introduction.md` |
| Simpler introduction diagrams | `docs/introduction.md` |
| Remove Body/Mind/Conscience legacy note | `docs/introduction.md` |
| `card.json` not marked optional in user-facing docs | `README.md`, `docs/introduction.md`, `CONTRIBUTING.md`, `templates/python_skill/README.md` |

Also: security support — `>= 0.5.3` patched, `0.4.6–0.5.2` silent, `< 0.4.6` unsupported (`SECURITY.md`, `skillware/version_policy.py`).

### Type of Change

- [ ] **New Skill**
- [ ] **Skill Upgrade**
- [ ] **Bug Fix**
- [x] **Documentation**
- [ ] **Framework Feature**
- [ ] **CLI**
- [ ] **Examples**
- [ ] **Packaging**
- [x] **RFC / meta** — security support windows

## Checklist (all PRs)

- [x] Linked GitHub issue (`Fixes #326`)
- [x] Scope matches the issue — no unrelated refactors
- [ ] `python -m black --check .` and `flake8` pass locally (or CI-equivalent subset)
- [x] `pytest tests/test_version_policy.py` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `examples/README.md` updated (N/A)
- [ ] `pytest tests/test_registry_docs.py` (N/A)

## New or updated skill

N/A — docs and security policy only.

## Constitution and safety (skills only)

N/A

## Related Issues

Fixes #326