### PR TITLE
fix(examples): derive tool dispatch names from manifest (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 - **CLI:** User-configurable `pastel`, `ocean`, and `mono` presentation themes; interactive menu selection persists globally, project config can override it, and unknown values fall back to `pastel` (#248).
 - **CLI:** The mail submenu and direct mail commands now follow the active presentation theme (#248).
 
+### Fixed
+
+- **Examples:** Derive agent-loop tool dispatch names from the loaded manifest in `claude_tos_evaluator.py`, `ollama_tos_evaluator.py`, and `ollama_novelty_extractor.py` (#178).
+
 ## [0.5.3] - 2026-09-01
 
 ### Added

--- a/examples/claude_tos_evaluator.py
+++ b/examples/claude_tos_evaluator.py
@@ -9,7 +9,8 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
-print(f"Loaded Skill: {bundle['manifest']['name']}")
+TOOL_NAME = bundle["manifest"]["name"]
+print(f"Loaded Skill: {TOOL_NAME}")
 
 TOSEvaluatorSkill = bundle["module"].TOSEvaluatorSkill
 tos_skill = TOSEvaluatorSkill()
@@ -39,7 +40,7 @@ if message.stop_reason == "tool_use":
     print(f"Claude requested tool: {tool_name}")
     print(f"Input: {tool_input}")
 
-    if tool_name == "compliance/tos_evaluator":
+    if tool_name == TOOL_NAME:
         result = tos_skill.execute(tool_input)
         print(json.dumps(result, indent=2))
 

--- a/examples/ollama_novelty_extractor.py
+++ b/examples/ollama_novelty_extractor.py
@@ -7,6 +7,7 @@ from skillware.core.env import load_env_file
 load_env_file()
 
 bundle = SkillLoader.load_skill("data_engineering/novelty_extractor")
+TOOL_NAME = bundle["manifest"]["name"]
 NoveltyExtractor = bundle["module"].NoveltyExtractor
 skill = NoveltyExtractor()
 
@@ -17,7 +18,7 @@ system_prompt = f"""You are an intelligent agent equipped with a local dataset n
 To use a skill, output exactly one JSON code block:
 ```json
 {{
-  "tool": "the_tool_name",
+  "tool": "{TOOL_NAME}",
   "arguments": {{
     "param_name": "value"
   }}
@@ -54,7 +55,7 @@ if tool_match:
     fn_name = tool_call.get("tool")
     fn_args = tool_call.get("arguments", {})
 
-    if fn_name == "data_engineering/novelty_extractor":
+    if fn_name == TOOL_NAME:
         result = skill.execute(fn_args)
         print(json.dumps(result, indent=2))
         messages.append({"role": "assistant", "content": message_content})

--- a/examples/ollama_tos_evaluator.py
+++ b/examples/ollama_tos_evaluator.py
@@ -9,6 +9,7 @@ from skillware.core.loader import SkillLoader
 load_env_file()
 
 bundle = SkillLoader.load_skill("compliance/tos_evaluator")
+TOOL_NAME = bundle["manifest"]["name"]
 TOSEvaluatorSkill = bundle["module"].TOSEvaluatorSkill
 tos_skill = TOSEvaluatorSkill()
 
@@ -19,7 +20,7 @@ system_prompt = f"""You are an intelligent agent equipped with a local website p
 To use a skill, output exactly one JSON code block:
 ```json
 {{
-  "tool": "the_tool_name",
+  "tool": "{TOOL_NAME}",
   "arguments": {{
     "param_name": "value"
   }}
@@ -53,7 +54,7 @@ if tool_match:
     fn_name = tool_call.get("tool")
     fn_args = tool_call.get("arguments", {})
 
-    if fn_name == "compliance/tos_evaluator":
+    if fn_name == TOOL_NAME:
         result = tos_skill.execute(fn_args)
         print(json.dumps(result, indent=2))
         messages.append({"role": "assistant", "content": message_content})


### PR DESCRIPTION
## Summary

Fixes #178

Replace hardcoded skill IDs in agent-loop examples with manifest-derived `TOOL_NAME` values so dispatch stays aligned with the loaded bundle if manifest names change.

**Changes:**
- `examples/claude_tos_evaluator.py` — `TOOL_NAME = bundle["manifest"]["name"]`; dispatch via `tool_name == TOOL_NAME`
- `examples/ollama_tos_evaluator.py` — same pattern; Ollama JSON template uses `{TOOL_NAME}` instead of `"the_tool_name"`
- `examples/ollama_novelty_extractor.py` — same Ollama pattern
- `CHANGELOG.md` — `[Unreleased]` Fixed entry

`examples/gemini_tos_evaluator.py` was already correct on main (sanitized manifest name). No loader, skill, or index changes.

### Type of Change

- [ ] New Skill
- [ ] Skill Upgrade
- [ ] Bug Fix
- [x] Documentation
- [ ] Framework Feature
- [ ] CLI
- [x] Examples
- [ ] Packaging
- [ ] RFC / meta

## Checklist (all PRs)

- [x] Linked GitHub issue (`Fixes #178`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `black --check` / `flake8` on touched files (examples-only diff)
- [x] `pytest tests/test_registry_docs.py` and `tests/test_examples_smoke.py` — 19 passed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `examples/README.md` unchanged (no scripts added/renamed/removed)
- [x] `pytest tests/test_registry_docs.py` run (no catalog/agent-loops matrix change)

## New or updated skill

N/A — examples-only PR.

## Related Issues

Fixes #178