### PR TITLE
feat(cli): add theme subcommand and align help topics with context/ch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ## [Unreleased]
 
+### Added
+
+- **CLI:** `skillware theme [pastel|ocean|mono]` subcommand — set or interactively choose the global presentation theme; `--help` topic index now includes Context, Chains, and Theme alongside existing groups.
+
+### Changed
+
+- **CLI:** Brief `skillware --help` topic list aligned with Context, Chains, and Theme command groups (matching `docs/usage/cli.md`).
+
 ## [0.5.4] - 2026-09-03
 
 ### Added

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -37,6 +37,9 @@ After installation, the `skillware` command is available directly:
     skillware list
     skillware doctor
     skillware config show
+    skillware context show
+    skillware chain list
+    skillware theme ocean
     skillware mail addressbook show
     skillware test
     skillware examples
@@ -118,7 +121,7 @@ Available commands:
 | `3` / `test` | Run bundle tests (`test_skill.py`) for one or all skills | Available |
 | `4` / `paths` | Paths submenu — view roots, edit project/external paths, shadowing, flat-layout diagnose | Available |
 | `5` / `doctor` | Check manifest deps and skill.py import readiness | Available |
-| `6` / `help` | Grouped help (Skills, Examples, Paths, Config, Mail, General) with doc links | Available |
+| `6` / `help` | Grouped help (Skills, Examples, Paths, Config, Context, Chains, Theme, Mail, General) with doc links | Available |
 | `7` / `mail` | Mail submenu — address book and signature setup for `office/gmail_handler` | Available |
 | `8` / `theme` | Choose `pastel`, `ocean`, or `mono` and save it to global config | Available |
 
@@ -132,22 +135,26 @@ Available commands:
 | `2` / `examples` | indexed runnable scripts |
 | `3` / `paths` | resolution and paths submenu |
 | `4` / `config` | merged YAML settings |
-| `5` / `mail` | address book and signature setup |
-| `6` / `general` | menu, `--help`, `--version` |
-| `7` / `install` | pip install skillware |
-| `8` / `docs` | link to this CLI guide |
-| `9` / `interactive` | numbered splash menu |
+| `5` / `context` | `context show` — registry brief (SkillContext) |
+| `6` / `chains` | `chain list`, `show`, `validate`, `run`, `dry-run` |
+| `7` / `theme` | `theme` — CLI color theme picker or direct set |
+| `8` / `mail` | address book and signature setup |
+| `9` / `general` | menu, `--help`, `--version` |
+| `10` / `install` | pip install skillware |
+| `11` / `docs` | link to this CLI guide |
+| `12` / `interactive` | numbered splash menu |
 
-Brief `--help` groups (same topics, less detail):
+Brief `--help` topic index matches the table above. Each topic expands to the command groups below when you choose **`6` / `help`** in the interactive menu:
 
 | Group | Topics |
 | :--- | :--- |
 | **Skills** | `list`, `test`, `doctor` |
 | **Examples** | `examples` |
 | **Paths** | `paths`, interactive paths submenu |
-| **Config** | `config show`, interactive theme picker |
+| **Config** | `config show` |
 | **Context** | `context show` — registry brief (SkillContext) |
 | **Chains** | `chain list`, `chain show`, `chain validate`, `chain run`, `chain dry-run` |
+| **Theme** | `theme`, interactive menu `8`, direct `theme <name>` |
 | **Mail** | `mail`, interactive mail submenu |
 | **General** | interactive menu, `--help`, `--version` |
 
@@ -335,9 +342,13 @@ mail:
 When no config file exists, resolution stays **legacy**: `SKILLWARE_SKILL_PATH` → `./skills/` walk → bundled. When config exists, `resolution.order` applies (default: project → external → bundled). The **bundled** registry from `pip install skillware` is always included and cannot be disabled. **Pip-only installs with no local `skills/` folder still resolve bundled registry skills** — only roots that exist on disk are searched; an empty project tier does not block bundled.
 
 `skillware config show` reports the effective `presentation.theme`. To change
-the global theme without editing YAML, run `skillware`, choose **`8` / `theme`**,
-then select a built-in theme by number or name. The picker writes only
-`presentation.theme` in the global config and preserves unrelated settings.
+the global theme without editing YAML, use any of:
+
+- `skillware theme ocean` — set directly
+- `skillware theme` — interactive picker (non-menu)
+- `skillware` → **`8` / `theme`** — same picker from the splash menu
+
+The picker writes only `presentation.theme` in the global config and preserves unrelated settings.
 
 A project `.skillware.yaml` value overrides the global selection while the CLI
 runs inside that project. The picker still saves the global preference and
@@ -480,6 +491,15 @@ the same condition `SkillLoader` requires to load a skill successfully.
 
 ## Color themes
 
+### skillware theme
+
+Choose or set the CLI presentation theme (`pastel`, `ocean`, `mono`):
+
+    skillware theme
+    skillware theme ocean
+
+Without a theme name, `skillware theme` opens the same interactive picker as splash menu **`8` / `theme`**. With a name, it saves globally immediately and prints a notice when project config overrides the effective theme in the current directory.
+
 The selected theme is applied to tables, headings, categories, skill IDs,
 menus, links, statuses, errors, and the splash gradient.
 
@@ -490,6 +510,19 @@ menus, links, statuses, errors, and the splash gradient.
 | `mono` | Grayscale presentation | `#F0F0F0` → `#A0A0A0` → `#606060` |
 
 Choose a theme interactively:
+
+```text
+skillware theme
+theme> ocean
+```
+
+Or set directly:
+
+```text
+skillware theme ocean
+```
+
+From the splash menu:
 
 ```text
 skillware

--- a/skillware/cli.py
+++ b/skillware/cli.py
@@ -98,6 +98,9 @@ _DOCS_CLI_LIST = f"{_DOCS_CLI}#skillware-list"
 _DOCS_CLI_EXAMPLES = f"{_DOCS_CLI}#skillware-examples"
 _DOCS_CLI_PATHS = f"{_DOCS_CLI}#skillware-paths"
 _DOCS_CLI_CONFIG = f"{_DOCS_CLI}#skillware-config"
+_DOCS_CLI_CONTEXT = f"{_DOCS_CLI}#skillware-context"
+_DOCS_CLI_CHAIN = f"{_DOCS_CLI}#skillware-chain"
+_DOCS_CLI_THEME = f"{_DOCS_CLI}#color-themes"
 _DOCS_CLI_MAIL = f"{_DOCS_CLI}#skillware-mail"
 
 HELP_GROUPS: List[Tuple[str, List[Tuple[str, str]], str]] = [
@@ -140,9 +143,41 @@ HELP_GROUPS: List[Tuple[str, List[Tuple[str, str]], str]] = [
         "Config",
         [
             ("skillware config show", "merged global + project YAML (read-only)"),
-            ("skillware (menu 8 / theme)", "choose and save the global CLI theme"),
         ],
         _DOCS_CLI_CONFIG,
+    ),
+    (
+        "Context",
+        [
+            ("skillware context show", "registry brief (SkillContext)"),
+            ("skillware context show --skill <id>", "single-skill context"),
+            ("skillware context show --mode tools_only", "tool schemas only"),
+            ("skillware context show --export <path>", "write context markdown"),
+        ],
+        _DOCS_CLI_CONTEXT,
+    ),
+    (
+        "Chains",
+        [
+            ("skillware chain list", "list configured chains"),
+            ("skillware chain show <name>", "show chain definition"),
+            ("skillware chain validate [name]", "validate chain definitions"),
+            ("skillware chain run <name> --var key=value", "execute a named chain"),
+            (
+                "skillware chain dry-run <name> --var key=value",
+                "resolve without execute",
+            ),
+        ],
+        _DOCS_CLI_CHAIN,
+    ),
+    (
+        "Theme",
+        [
+            ("skillware theme", "interactive theme picker"),
+            ("skillware theme <pastel|ocean|mono>", "set global CLI theme"),
+            ("skillware (menu 8 / theme)", "same picker from splash menu"),
+        ],
+        _DOCS_CLI_THEME,
     ),
     (
         "Mail",
@@ -196,11 +231,14 @@ _HELP_MENU: List[Tuple[str, str, str, Union[int, str]]] = [
     ("2", "examples", "indexed runnable scripts", 1),
     ("3", "paths", "resolution and path editor", 2),
     ("4", "config", "merged YAML settings", 3),
-    ("5", "mail", "address book and signature setup", 4),
-    ("6", "general", "menu, help, version", 5),
-    ("7", "install", "pip install skillware", "install"),
-    ("8", "docs", "full CLI guide online", "docs"),
-    ("9", "interactive", "numbered splash menu", "interactive"),
+    ("5", "context", "registry brief (SkillContext)", 4),
+    ("6", "chains", "list, validate, run named chains", 5),
+    ("7", "theme", "CLI color theme picker", 6),
+    ("8", "mail", "address book and signature setup", 7),
+    ("9", "general", "menu, help, version", 8),
+    ("10", "install", "pip install skillware", "install"),
+    ("11", "docs", "full CLI guide online", "docs"),
+    ("12", "interactive", "numbered splash menu", "interactive"),
 ]
 
 _CLI_USAGE_EXAMPLES: Tuple[str, ...] = (
@@ -210,6 +248,9 @@ _CLI_USAGE_EXAMPLES: Tuple[str, ...] = (
     "skillware test finance/wallet_screening",
     "skillware paths",
     "skillware config show",
+    "skillware context show",
+    "skillware chain list",
+    "skillware theme ocean",
     "skillware mail addressbook show",
     "skillware doctor --category compliance",
 )
@@ -1396,7 +1437,48 @@ def cmd_chain_run(
     return 0 if result.status != "failed" else 1
 
 
-def cmd_theme_picker(console=None, input_fn=None) -> Optional[str]:
+def _save_global_theme_selection(selected: str, console) -> None:
+    """Persist a theme name globally and print effective vs saved notices."""
+    target = save_global_presentation_theme(selected)
+    _apply_active_theme()
+    effective = load_merged_config().presentation.theme
+    console.print(f"  Saved global theme '{selected}' to {target}", style=ID_STYLE)
+    if effective != selected:
+        console.print(
+            f"  Project config keeps '{effective}' active in this directory.",
+            style="dim",
+        )
+
+
+def cmd_theme(
+    theme_name: Optional[str] = None,
+    console=None,
+    input_fn=None,
+) -> int:
+    """Set or interactively choose the global CLI presentation theme."""
+    _apply_active_theme()
+    if console is None:
+        console = Console()
+
+    if theme_name is not None:
+        selected = theme_name.lower()
+        if selected not in THEMES:
+            console.print(f"  Unknown theme: '{theme_name}'", style=ERROR_DIM_STYLE)
+            console.print(
+                f"  Choose from: {', '.join(sorted(THEMES))}",
+                style="dim",
+            )
+            return 1
+        _save_global_theme_selection(selected, console)
+        return 0
+
+    cmd_theme_picker(console=console, input_fn=input_fn, show_back=False)
+    return 0
+
+
+def cmd_theme_picker(
+    console=None, input_fn=None, *, show_back: bool = True
+) -> Optional[str]:
     """Select and persist a global CLI theme. Returns _NAV_EXIT when requested."""
     if console is None:
         console = Console()
@@ -1415,7 +1497,7 @@ def cmd_theme_picker(console=None, input_fn=None) -> Optional[str]:
                 f"    [{key}] {name:<8}— {description}",
                 style=MENU_STYLE,
             )
-        _print_nav_footer(console, show_back=True)
+        _print_nav_footer(console, show_back=show_back)
 
         raw = _read_line("  theme> ", input_fn)
         choice, nav = _parse_nav(raw)
@@ -1432,15 +1514,7 @@ def cmd_theme_picker(console=None, input_fn=None) -> Optional[str]:
             console.print()
             continue
 
-        target = save_global_presentation_theme(selected)
-        _apply_active_theme()
-        effective = load_merged_config().presentation.theme
-        console.print(f"  Saved global theme '{selected}' to {target}", style=ID_STYLE)
-        if effective != selected:
-            console.print(
-                f"  Project config keeps '{effective}' active in this directory.",
-                style="dim",
-            )
+        _save_global_theme_selection(selected, console)
         return None
 
 
@@ -1803,7 +1877,7 @@ def cmd_interactive(console=None, parser=None) -> None:
                 console.print("  Bye.", style="dim")
                 return
         elif command == "theme":
-            theme_nav = cmd_theme_picker(console=console)
+            theme_nav = cmd_theme_picker(console=console, show_back=True)
             if theme_nav == _NAV_EXIT:
                 console.print("  Bye.", style="dim")
                 return
@@ -1945,6 +2019,18 @@ def main() -> None:
     config_subparsers.add_parser(
         "show",
         help="Print merged global and project YAML settings.",
+    )
+
+    theme_parser = subparsers.add_parser(
+        "theme",
+        help="Choose or set the CLI color theme.",
+    )
+    theme_parser.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        choices=sorted(THEMES.keys()),
+        help="Theme name (pastel, ocean, mono). Omit for interactive picker.",
     )
 
     mail_parser = subparsers.add_parser(
@@ -2200,6 +2286,8 @@ def main() -> None:
             raise SystemExit(cmd_config_show())
         config_parser.print_help()
         raise SystemExit(2)
+    elif args.command == "theme":
+        raise SystemExit(cmd_theme(theme_name=getattr(args, "name", None)))
     elif args.command == "mail":
         if args.mail_area is None:
             raise SystemExit(cmd_mail())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from skillware.cli import (
     cmd_paths_submenu,
     cmd_doctor,
     cmd_theme_picker,
+    cmd_theme,
 )
 
 import importlib.util
@@ -876,9 +877,14 @@ def test_cmd_help_includes_grouped_sections():
     assert "skills" in output
     assert "paths" in output
     assert "config" in output
+    assert "context" in output
+    assert "chains" in output
+    assert "theme" in output
     assert "CLI usage examples" in output
     assert "skillware config show" in output
-    assert "skillware list --category" not in output or "CLI usage examples" in output
+    assert "skillware context show" in output
+    assert "skillware chain list" in output
+    assert "skillware theme ocean" in output
 
 
 def test_cmd_help_includes_paths_command():
@@ -1163,3 +1169,66 @@ def test_interactive_mail_dispatches(monkeypatch):
 
     output = buf.getvalue()
     assert "mail>" in output.lower() or "Address book" in output
+
+
+def test_cmd_theme_sets_name_directly(isolated_theme_environment):
+    import io
+    import yaml
+    from rich.console import Console
+
+    _repo, config_dir = isolated_theme_environment
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    rc = cmd_theme("ocean", console=console)
+    assert rc == 0
+
+    saved = yaml.safe_load((config_dir / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["presentation"]["theme"] == "ocean"
+    assert "Saved global theme 'ocean'" in buf.getvalue()
+
+
+def test_cmd_theme_rejects_unknown_name(isolated_theme_environment):
+    import io
+    from rich.console import Console
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    rc = cmd_theme("unknown", console=console)
+    assert rc == 1
+    assert "Unknown theme" in buf.getvalue()
+
+
+def test_main_theme_subcommand(monkeypatch, isolated_theme_environment):
+    import sys
+    import yaml
+    from skillware.cli import main
+
+    _repo, config_dir = isolated_theme_environment
+    argv = sys.argv
+    sys.argv = ["skillware", "theme", "mono"]
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+    finally:
+        sys.argv = argv
+
+    saved = yaml.safe_load((config_dir / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["presentation"]["theme"] == "mono"
+
+
+def test_main_theme_interactive_subcommand(monkeypatch, isolated_theme_environment):
+    import sys
+    from skillware.cli import main
+
+    monkeypatch.setattr("builtins.input", lambda _: "2")
+    argv = sys.argv
+    sys.argv = ["skillware", "theme"]
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+    finally:
+        sys.argv = argv


### PR DESCRIPTION
## Summary

Improves CLI discoverability for features added in 0.5.4:

- **`skillware theme [pastel|ocean|mono]`** — set the global presentation theme directly, or run `skillware theme` for the interactive picker (same as splash menu `8`).
- **`skillware --help`** — brief topic index now includes **Context**, **Chains**, and **Theme**, aligned with `HELP_GROUPS` and `docs/usage/cli.md`.

Closes the gap where `context` / `chain` subcommands existed but were easy to miss from `--help`, and where theme was menu-only.

## Type of Change

- [x] **CLI** — `skillware/cli.py`, `docs/usage/cli.md`
- [x] **Documentation** — CLI reference updates

## Checklist

- [x] Scope is CLI/docs/tests only — no unrelated refactors
- [x] `black` / `flake8` clean on touched files
- [x] `pytest tests/test_cli.py` — 74 passed; full suite 369 passed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Linked issue — _optional small UX follow-up; no blocking issue_

## Test plan

- [x] `skillware --help` — topics 5–7 show `context`, `chains`, `theme`
- [x] `skillware theme ocean` — saves globally; project override notice when applicable
- [x] `skillware theme` — interactive picker works standalone
- [x] Splash menu `8` / `theme` — unchanged behavior
- [x] `skillware context show` / `skillware chain list` — still work as before