### PR TITLE
docs: clarify host context integration paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Contributors add user-facing entries under `[Unreleased]` in the same PR. Mainta
 
 ### Changed
 
+- **Docs:** Add host-context guidance for choosing full Directives, brief registry lines, and host-managed progressive loading (#348).
 - **Docs:** SkillContext modes, edge cases, and Ollama multi-skill guidance in `skill_chaining.md`, `ollama.md`, `introduction.md`, `cli.md`; one-line chain pointers on middleware skill catalog pages.
 - **CLI:** User-configurable `pastel`, `ocean`, and `mono` presentation themes; interactive menu selection persists globally, project config can override it, and unknown values fall back to `pastel` (#248).
 - **CLI:** The mail submenu and direct mail commands now follow the active presentation theme (#248).

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -36,7 +36,7 @@ To list locally available skills, inspect path resolution, show config, check lo
 Skill-specific **Usage Examples** (sample prompts and execute payloads) live on each [skill catalog page](../skills/README.md).
 
 Shared patterns (load bundle, run `execute`, return tool results):
-[agent_loops.md](agent_loops.md). **Multiple skills:** [skill_chaining.md](skill_chaining.md) (`SkillContext`, named `chains:`). [Skill anatomy](../introduction.md#skill-anatomy) (Contract, Effect, Directive, Assurance, Interface). After `load_skill`, prefer `bundle["class"]()` to instantiate the skill; explicit `bundle["module"].ClassName()` also works. Runnable script inventory:
+[agent_loops.md](agent_loops.md). For multiple skills, first [choose the host context](skill_chaining.md#choose-host-context-directive-vs-brief), then use [skill chaining](skill_chaining.md) (`SkillContext`, named `chains:`). [Skill anatomy](../introduction.md#skill-anatomy) (Contract, Effect, Directive, Assurance, Interface). After `load_skill`, prefer `bundle["class"]()` to instantiate the skill; explicit `bundle["module"].ClassName()` also works. Runnable script inventory:
 [examples/README.md](../../examples/README.md).
 
 Contributors adding **Usage Examples** to skill catalog pages: [skill_usage_template.md](skill_usage_template.md).

--- a/docs/usage/agent_loops.md
+++ b/docs/usage/agent_loops.md
@@ -52,6 +52,8 @@ OpenAI-compatible hosts reuse `to_openai_tool()`; see the [host guide](openai_co
 
 ## Multi-skill sessions (SkillContext)
 
+For the choice between full Directives, brief registry lines, and host-managed progressive loading, see [Choose host context (Directive vs brief)](skill_chaining.md#choose-host-context-directive-vs-brief). `SkillContext.execute()` validates skill parameters; `prepare()` returns the Directive to the host but does not inject it into the model context.
+
 For agents that expose **many tools** from the registry, replace steps 1–4 with `SkillContext`:
 
 ```python
@@ -64,7 +66,7 @@ tools = ctx.tools("gemini")  # or claude | openai | deepseek
 # Send system + tools + user message to the model ...
 # On tool_call:
 
-result = ctx.execute(skill_id, arguments)  # auto-prepares; validates if you call prepare() first
+result = ctx.execute(skill_id, arguments)  # auto-prepares and validates parameters
 # Return result JSON to the model; loop continues
 ```
 
@@ -208,4 +210,3 @@ result = skill.execute(
 
 See [`examples/uk_companies_house_handler_demo.py`](../../examples/uk_companies_house_handler_demo.py) (mocked v2b flows) and [`examples/gemini_uk_companies_house_handler.py`](../../examples/gemini_uk_companies_house_handler.py) (interactive loop).
 | `office/gmail_handler` | `gmail_handler_demo.py` (local execute) | `gemini_gmail_handler.py` | (catalog page) | (catalog page) | (catalog page) | (catalog page) |
-

--- a/docs/usage/skill_chaining.md
+++ b/docs/usage/skill_chaining.md
@@ -22,6 +22,32 @@ Use **chain / chains / chaining** for cross-skill host orchestration. Do **not**
 
 ---
 
+## Choose host context (Directive vs brief)
+
+Choose the host path based on who owns skill selection and when the model needs
+the full playbook:
+
+| Scenario | Recommended path | Why |
+| :--- | :--- | :--- |
+| One dedicated skill | `SkillLoader.load_skill()` + full `bundle["instructions"]` | The model needs the skill's gates and stage order up front |
+| Agent exposes about 10 registry tools | `SkillContext(mode="brief")` + `merge_system()` + `tools()` | Brief lines save tokens while schemas carry parameter detail |
+| Small fixed skill set (≤ 3) | `SkillContext(mode="directives")` or manual concatenation | Full playbooks fit in the system budget |
+| Untrusted text arrives before the model sees it | `run_chain(...)` or a manual chain before the agent loop | The model must not choose middleware order |
+| Deterministic middleware (firewall → rewriter) | Manual chain or named YAML chain | The host owns the order and branching |
+| Full Directive is needed only after tool selection | `prepare()` then host-inject `prep.directive` on the next turn | Progressive disclosure is host-driven |
+
+### Glossary
+
+- **Directive:** the full `instructions.md` playbook for a skill.
+- **Brief line:** the `manifest.short_description` summary that `merge_system()` adds in `brief` mode.
+- **`SkillContext`:** the host session that discovers skills, exposes provider tools, and prepares or executes selected skills.
+- **`prepare()`:** a host-side lazy load that returns `prep.directive`, `prep.manifest`, and `prep.bundle`; it does not change the model system prompt.
+- **`context` execute parameter:** session state accepted by a skill's own `execute(params)` contract; it is unrelated to the `SkillContext` host object.
+
+> **Progressive disclosure:** `prepare()` loads the Directive for the host, but it does not inject it into the model prompt. After tool selection, the host must add `prep.directive` to the next model turn, or use `mode="directives"` before the loop. `execute()` auto-prepares and validates skill parameters, but does not inject prompt text.
+
+**Non-goals:** This section does not classify skills in their manifests (see RFC 002) or change the catalog **Usage Examples** format. Catalog examples remain single-skill examples with full instructions.
+
 ## Imports
 
 | Need | Import |


### PR DESCRIPTION
## Description

Add a focused host-context decision guide for integrations that use full Directives, brief registry lines, or progressive loading.

- `docs/usage/skill_chaining.md` adds the six-row decision table, five-term glossary, progressive-disclosure callout, and explicit non-goals.
- `docs/usage/README.md` points the shared-patterns section to the new decision guide.
- `docs/usage/agent_loops.md` explains the `SkillContext.execute()` and `prepare()` boundary and updates the misleading code comment.
- `CHANGELOG.md` records the user-facing documentation update under `[Unreleased]`.

This change was developed with AI assistance and was reviewed and tested locally.

### Type of Change

- [ ] **New Skill** — new registry bundle under `skills/`
- [ ] **Skill Upgrade** — changes to an existing skill under `skills/`
- [ ] **Bug Fix** — incorrect runtime or framework behavior
- [x] **Documentation** — docs, README, CONTRIBUTING only
- [ ] **Framework Feature** — `skillware/core/` loader, env, adapters
- [ ] **CLI** — `skillware/cli.py`, `docs/usage/cli.md`
- [ ] **Examples** — `examples/*.py`, `examples/README.md`
- [ ] **Packaging** — PyPI wheel, `pyproject.toml`, `MANIFEST.in`
- [ ] **RFC / meta** — templates, labels, CI, or large design doc

## Checklist (all PRs)

- [x] Linked GitHub issue (`Closes #348`)
- [x] Scope matches the issue — no unrelated refactors
- [x] `python -m black --check .` and `flake8` pass locally
- [x] `pytest skills/` and `pytest tests/` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]` for this user-facing documentation change
- [ ] `examples/README.md` updated if this PR adds, renames, or removes a runnable script
- [x] Ran the documentation guards relevant to the changed usage pages
- [ ] Ran `pytest tests/test_skill_docs.py` when catalog Usage Examples or provider snippets changed

## Evidence

```text
$ .venv/bin/python -m black --check .
All done! 199 files would be left unchanged.

$ .venv/bin/python -m flake8 .

$ .venv/bin/python -m pytest skills/
369 passed, 1 skipped in 20.33s

$ .venv/bin/python -m pytest tests/
387 passed, 4 skipped in 34.74s

$ .venv/bin/python -m pytest tests/test_registry_docs.py tests/test_skill_docs.py
11 passed in 0.70s
```

## Constitution and safety (skills only)

Not applicable; this PR changes documentation only.

## Related Issues

Closes #348
